### PR TITLE
feat: implement security properties file with API credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # These are only used in prod profile (%prod)
 # Dev and Test use Dev Services (automatic PostgreSQL container)
 
-QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://localhost:5432/quarkusclaw
+QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://localhost:5432/qlawkus
 QUARKUS_DATASOURCE_USERNAME=quarkus
 QUARKUS_DATASOURCE_PASSWORD=quarkus
+
+# API authentication
+API_USER_PASSWORD=admin123

--- a/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
@@ -1,0 +1,18 @@
+package dev.omatheusmesmo.qlawkus;
+
+import io.quarkus.security.Authenticated;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api")
+@Authenticated
+public class ApiResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,8 @@ quarkus.http.port=8080
 
 quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.admin=${API_USER_PASSWORD:admin123}
+quarkus.security.users.embedded.roles.admin=admin
 
 quarkus.datasource.db-kind=postgresql
 


### PR DESCRIPTION
## Summary

- Define admin user with password via `API_USER_PASSWORD` env variable
- Assign `admin` role to the user
- Add `@Authenticated` protected `/api` endpoint
- Update `.env.example` with `API_USER_PASSWORD`

## Test plan

- [x] Unauthenticated request returns 401
- [x] Authenticated request (Basic Auth) returns 200
- [x] Dev mode starts successfully

closes #13