### PR TITLE
feat: configure LLM keys for Ollama %dev and OpenAI %prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,10 @@ QUARKUS_DATASOURCE_PASSWORD=quarkus
 
 # API authentication
 API_USER_PASSWORD=admin123
+
+# LLM configuration
+# Dev: Ollama (local) - defaults to qwen3:1.7b
+OLLAMA_MODEL=qwen3:1.7b
+# Prod: OpenAI
+OPENAI_API_KEY=sk-your-api-key-here
+OPENAI_MODEL=gpt-4o-mini

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,9 +9,15 @@ quarkus.security.users.embedded.roles.admin=admin
 quarkus.datasource.db-kind=postgresql
 
 %dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%dev.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
+%dev.quarkus.langchain4j.ollama.chat-model.temperature=0
+
 %test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 %prod.quarkus.datasource.jdbc.url=${QUARKUS_DATASOURCE_JDBC_URL}
 %prod.quarkus.datasource.username=${QUARKUS_DATASOURCE_USERNAME}
 %prod.quarkus.datasource.password=${QUARKUS_DATASOURCE_PASSWORD}
 %prod.quarkus.hibernate-orm.schema-management.strategy=none
+%prod.quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+%prod.quarkus.langchain4j.openai.chat-model.model-name=${OPENAI_MODEL:gpt-4o-mini}
+%prod.quarkus.langchain4j.openai.chat-model.temperature=0


### PR DESCRIPTION
## Summary

- Ollama in dev with configurable model (default: `qwen3:1.7b`)
- OpenAI in prod with API key and model via env variables
- Temperature set to 0 for deterministic responses
- Update `.env.example` with LLM configuration

## Configuration

| Profile | LLM | Config |
|---------|-----|--------|
| `%dev` | Ollama (local) | `OLLAMA_MODEL` env var (default: `qwen3:1.7b`) |
| `%prod` | OpenAI | `OPENAI_API_KEY` + `OPENAI_MODEL` env vars |

## Test plan

- [x] Dev mode starts successfully with Ollama detected on port 11434
- [x] API endpoint responds with authentication

closes #14