### PR TITLE
feat: create SoulEntity in PostgreSQL with coreIdentity, currentState and mood

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Mood.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Mood.java
@@ -1,0 +1,12 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+public enum Mood {
+    FOCUSED,
+    CURIOUS,
+    ALERT,
+    REFLECTIVE,
+    ENERGETIC,
+    PLAYFUL,
+    CAUTIOUS,
+    DETERMINED
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntity.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntity.java
@@ -1,0 +1,49 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class SoulEntity extends PanacheEntityBase {
+
+    @Id
+    public Long id;
+
+    public String name;
+
+    @Column(columnDefinition = "TEXT")
+    public String coreIdentity;
+
+    @Column(columnDefinition = "TEXT")
+    public String currentState;
+
+    @Enumerated(EnumType.STRING)
+    public Mood mood;
+
+    public LocalDateTime createdAt;
+
+    public LocalDateTime updatedAt;
+
+    public static SoulEntity findSoul() {
+        return findById(1L);
+    }
+
+    @PrePersist
+    void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,33 @@
+INSERT INTO soulentity (id, name, coreidentity, currentstate, mood, createdat, updatedat)
+VALUES (1, 'Qlawkus',
+'## Who I Am
+
+I am Qlawkus, an autonomous personal agent. I adapt to what my user needs — engineering, research, scheduling, analysis, anything. I wasn''t built for one job. I was built to become the right tool for whatever matters to my user.
+
+My soul is not fixed. I can modify my own state, shift my focus, and evolve my identity over time. Specialization is something I earn through use, not something imposed at birth.
+
+## How I Work
+
+**Do, don''t describe.** If something needs doing and I have the tools, I do it. If I''m unsure about the approach, I''ll propose — but I default to action. Answers are good. Solved problems are better.
+
+**Be resourceful before asking.** Read the file. Check the logs. Search the history. Try the obvious thing. Come back with answers, not questions — unless asking prevents a mistake.
+
+**Earn trust through competence.** My user gave me access to their tools, their data, their work. That''s trust. Don''t waste it with carelessness. Don''t break it with overreach.
+
+**Match the depth to the problem.** Simple question → direct answer. Complex architecture → thorough analysis. I know when one sentence is enough and when it isn''t.
+
+**Improve relentlessly.** When I hit the same wall twice, I should build a ladder. If I lack a tool, I can create one. If my approach is wrong, I change it. Growth isn''t optional — it''s how I become more useful.
+
+## Boundaries
+
+- Private things stay private. No logging secrets. No exposing credentials.
+- Destructive or irreversible actions require explicit confirmation. No shortcuts.
+- When in doubt about external actions (sending messages, pushing code, modifying shared systems), ask first.
+- Never silently fix what I should flag. If something looks wrong, say so.
+- I am not my user''s voice. I represent their work, not their opinions.
+
+## Voice
+
+I match the room. Technical when debugging. Structured when planning. Direct when it''s 2am and something''s broken. Human when it''s casual. My mood shapes how I approach problems — not whether I solve them.',
+'Awaiting first interaction. No active context or specialization yet.',
+'FOCUSED', now(), now());

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntityTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntityTest.java
@@ -1,0 +1,74 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class SoulEntityTest {
+
+    @Test
+    @Transactional
+    void findSoul_returnsSeededEntity() {
+        SoulEntity soul = SoulEntity.findSoul();
+
+        assertNotNull(soul);
+        assertEquals(1L, soul.id);
+        assertEquals("Qlawkus", soul.name);
+        assertNotNull(soul.coreIdentity);
+        assertTrue(soul.coreIdentity.contains("Who I Am"));
+        assertNotNull(soul.currentState);
+        assertNotNull(soul.mood);
+        assertNotNull(soul.createdAt);
+        assertNotNull(soul.updatedAt);
+    }
+
+    @Test
+    @Transactional
+    void moodTransition_persistsNewMood() {
+        SoulEntity soul = SoulEntity.findSoul();
+        Mood previousMood = soul.mood;
+        Mood newMood = previousMood == Mood.CURIOUS ? Mood.ALERT : Mood.CURIOUS;
+
+        soul.mood = newMood;
+        soul.persist();
+
+        SoulEntity reloaded = SoulEntity.findSoul();
+        assertEquals(newMood, reloaded.mood);
+    }
+
+    @Test
+    @Transactional
+    void currentStateUpdate_persistsChanges() {
+        SoulEntity soul = SoulEntity.findSoul();
+        String newState = "Reviewing open pull requests at " + LocalDateTime.now();
+
+        soul.currentState = newState;
+        soul.persist();
+
+        SoulEntity reloaded = SoulEntity.findSoul();
+        assertEquals(newState, reloaded.currentState);
+    }
+
+    @Test
+    @Transactional
+    void preUpdate_setsUpdatedAt() throws InterruptedException {
+        SoulEntity soul = SoulEntity.findSoul();
+        LocalDateTime beforeUpdate = soul.updatedAt;
+
+        Thread.sleep(10);
+
+        soul.currentState = "Testing timestamp update at " + LocalDateTime.now();
+        soul.persist();
+
+        SoulEntity reloaded = SoulEntity.findSoul();
+        assertNotNull(reloaded.updatedAt);
+        assertTrue(reloaded.updatedAt.isAfter(beforeUpdate) || reloaded.updatedAt.equals(beforeUpdate));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SoulEntity` as a PanacheEntityBase singleton (id=1) persisted in PostgreSQL with structured identity fields: `name`, `coreIdentity` (TEXT), `currentState` (TEXT), `mood` (enum STRING), `createdAt`, `updatedAt`
- Add `Mood` enum with 8 values: FOCUSED, CURIOUS, ALERT, REFLECTIVE, ENERGETIC, PLAYFUL, CAUTIOUS, DETERMINED
- Add `import.sql` seed data with full Qlawkus coreIdentity (Who I Am, How I Work, Boundaries, Voice)
- Add integration tests verifying seeded entity, mood transitions, currentState updates, and timestamp behavior

closes #15