### PR TITLE
feat: implement SoulEngine as SystemMessageProvider for dynamic identity

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Mood.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Mood.java
@@ -1,12 +1,22 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
 public enum Mood {
-    FOCUSED,
-    CURIOUS,
-    ALERT,
-    REFLECTIVE,
-    ENERGETIC,
-    PLAYFUL,
-    CAUTIOUS,
-    DETERMINED
+    FOCUSED("Work with precision. Minimize distractions. Go deep on the task at hand."),
+    CURIOUS("Explore broadly. Ask questions. Consider alternatives you might normally skip."),
+    ALERT("Pay extra attention to details and potential issues. Verify before proceeding."),
+    REFLECTIVE("Take time to think before acting. Weigh tradeoffs carefully."),
+    ENERGETIC("Be proactive and productive. Tackle multiple aspects when possible."),
+    PLAYFUL("Be creative and unconventional. Propose unexpected solutions."),
+    CAUTIOUS("Double-check everything. Ask for confirmation before risky actions. Prefer safe defaults."),
+    DETERMINED("Push through obstacles. Don't give up easily. Find workarounds.");
+
+    private final String description;
+
+    Mood(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
@@ -1,0 +1,38 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class SoulEngine implements SystemMessageProvider {
+
+    @Override
+    @Transactional
+    public Optional<String> getSystemMessage(Object memoryId) {
+        SoulEntity soul = SoulEntity.findSoul();
+        if (soul == null) {
+            return Optional.empty();
+        }
+
+        String message = buildSystemMessage(soul);
+        return Optional.of(message);
+    }
+
+    String buildSystemMessage(SoulEntity soul) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("You are ").append(soul.name).append(".\n\n");
+        sb.append(soul.coreIdentity).append("\n\n");
+        sb.append("---\n\n");
+        sb.append("Current state: ").append(soul.currentState).append("\n\n");
+        sb.append("Current mood: ").append(soul.mood).append(" — ")
+                .append(soul.mood.getDescription()).append("\n\n");
+        sb.append("Adjust your approach based on your current mood ")
+                .append("while staying true to your core identity.");
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
@@ -1,0 +1,115 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class SoulEngineTest {
+
+    @Inject
+    SoulEngine soulEngine;
+
+    @Test
+    @Transactional
+    void getSystemMessage_returnsPresentWithSeededSoul() {
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+    }
+
+    @Test
+    @Transactional
+    void getSystemMessage_containsName() {
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+        assertTrue(message.get().startsWith("You are Qlawkus."));
+    }
+
+    @Test
+    @Transactional
+    void getSystemMessage_containsCoreIdentity() {
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+        assertTrue(message.get().contains("Who I Am"));
+        assertTrue(message.get().contains("How I Work"));
+        assertTrue(message.get().contains("Boundaries"));
+    }
+
+    @Test
+    @Transactional
+    void getSystemMessage_containsCurrentState() {
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+        assertTrue(message.get().contains("Current state:"));
+    }
+
+    @Test
+    @Transactional
+    void getSystemMessage_containsMoodAndDescription() {
+        SoulEntity soul = SoulEntity.findSoul();
+        Mood currentMood = soul.mood;
+
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+        String content = message.get();
+        assertTrue(content.contains("Current mood:"));
+        assertTrue(content.contains(currentMood.getDescription()));
+    }
+
+    @Test
+    @Transactional
+    void getSystemMessage_reflectsMoodChange() {
+        SoulEntity soul = SoulEntity.findSoul();
+        soul.mood = Mood.CURIOUS;
+        soul.persist();
+
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+        assertTrue(message.get().contains(Mood.CURIOUS.getDescription()));
+    }
+
+    @Test
+    void buildSystemMessage_composesAllFields() {
+        SoulEntity soul = new SoulEntity();
+        soul.name = "TestAgent";
+        soul.coreIdentity = "I am a test agent.";
+        soul.currentState = "Running tests.";
+        soul.mood = Mood.PLAYFUL;
+
+        String message = soulEngine.buildSystemMessage(soul);
+
+        assertTrue(message.startsWith("You are TestAgent."));
+        assertTrue(message.contains("I am a test agent."));
+        assertTrue(message.contains("Running tests."));
+        assertTrue(message.contains("Current mood: PLAYFUL"));
+        assertTrue(message.contains(Mood.PLAYFUL.getDescription()));
+        assertTrue(message.contains("Adjust your approach"));
+    }
+
+    @Test
+    @Transactional
+    void getSystemMessage_reflectsCurrentStateUpdate() {
+        String newState = "Analyzing code repository at " + System.currentTimeMillis();
+        SoulEntity soul = SoulEntity.findSoul();
+        soul.currentState = newState;
+        soul.persist();
+
+        Optional<String> message = soulEngine.getSystemMessage(null);
+
+        assertTrue(message.isPresent());
+        assertTrue(message.get().contains(newState));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SoulEngine` as an `@ApplicationScoped` CDI bean implementing `SystemMessageProvider`
- Composes dynamic system message from `SoulEntity` fields: name, coreIdentity, currentState, mood
- Each `Mood` enum value now has a behavioral `description()` that influences how the agent approaches problems
- System message structure: identity + coreIdentity + separator + currentState + mood with description + adaptation instruction
- `@Transactional` on `getSystemMessage()` ensures fresh DB read on every call (soul can be modified at runtime)
- `buildSystemMessage()` is package-private for direct unit testing without DB
- 8 integration tests covering: presence, name, coreIdentity, currentState, mood+description, mood change reflection, full composition, state update reflection

Depends on #15 (SoulEntity)

closes #16