### PR TITLE
feat: define AgentService using SoulEngine with log interceptors and chat endpoint

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
@@ -1,7 +1,10 @@
 package dev.omatheusmesmo.qlawkus;
 
+import dev.omatheusmesmo.qlawkus.agent.AgentService;
 import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
@@ -10,9 +13,19 @@ import jakarta.ws.rs.core.MediaType;
 @Authenticated
 public class ApiResource {
 
+    @Inject
+    AgentService agentService;
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
         return "hello";
+    }
+
+    @POST
+    @Path("/chat")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String chat(String message) {
+        return agentService.chat(message);
     }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentLogInterceptor.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentLogInterceptor.java
@@ -1,0 +1,50 @@
+package dev.omatheusmesmo.qlawkus.agent;
+
+import io.quarkus.logging.Log;
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@Inherited
+@InterceptorBinding
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@interface Logged {
+}
+
+@Logged
+@Interceptor
+@Priority(Interceptor.Priority.APPLICATION)
+class AgentLogInterceptor {
+
+    @AroundInvoke
+    Object logInvocation(InvocationContext context) throws Exception {
+        String method = context.getMethod().getName();
+        Object[] params = context.getParameters();
+
+        Log.infof("AgentService invocation: %s with %d parameters", method, params.length);
+
+        long start = System.currentTimeMillis();
+        try {
+            Object result = context.proceed();
+            long elapsed = System.currentTimeMillis() - start;
+            Log.infof("AgentService completed: %s in %dms", method, elapsed);
+            return result;
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
+            Log.errorf("AgentService failed: %s in %dms — %s", method, elapsed, e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
@@ -1,0 +1,14 @@
+package dev.omatheusmesmo.qlawkus.agent;
+
+import dev.langchain4j.service.UserMessage;
+import dev.omatheusmesmo.qlawkus.cognition.SoulEngine;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class)
+@ApplicationScoped
+@Logged
+public interface AgentService {
+
+    String chat(@UserMessage String message);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,8 +11,13 @@ quarkus.datasource.db-kind=postgresql
 %dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 %dev.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
 %dev.quarkus.langchain4j.ollama.chat-model.temperature=0
+%dev.quarkus.langchain4j.ollama.timeout=120s
 
 %test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%test.quarkus.langchain4j.chat-model.provider=ollama
+%test.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
+%test.quarkus.langchain4j.ollama.chat-model.temperature=0
+%test.quarkus.langchain4j.ollama.timeout=120s
 
 %prod.quarkus.datasource.jdbc.url=${QUARKUS_DATASOURCE_JDBC_URL}
 %prod.quarkus.datasource.username=${QUARKUS_DATASOURCE_USERNAME}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
@@ -1,0 +1,36 @@
+package dev.omatheusmesmo.qlawkus.agent;
+
+import dev.omatheusmesmo.qlawkus.cognition.SoulEntity;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class AgentServiceTest {
+
+    @Inject
+    AgentService agentService;
+
+    @Test
+    void agentService_isInjectable() {
+        assertNotNull(agentService);
+    }
+
+    @Test
+    @Transactional
+    void chat_returnsResponseWithSoulIdentity() {
+        SoulEntity soul = SoulEntity.findSoul();
+        String soulName = soul.name.toLowerCase();
+
+        String response = agentService.chat("What is your name? You must include your exact name in your reply.");
+        assertNotNull(response);
+        assertFalse(response.isBlank());
+        assertTrue(response.toLowerCase().contains(soulName),
+                "Response should contain the soul name '" + soulName + "'. Got: " + response);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AgentService` interface with `@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class)` connecting the dynamic soul identity to the LLM
- Add `@Logged` interceptor binding and `AgentLogInterceptor` CDI interceptor logging AgentService invocations (method, parameter count, elapsed time, errors)
- Add `POST /api/chat` endpoint on `ApiResource` delegating to AgentService
- Configure `%test` and `%dev` Ollama provider, model (`qwen3:1.7b`), and timeout (`120s`) in application.properties
- Integration test verifies AgentService is injectable and that LLM response contains the soul name from the database (not hardcoded)

closes #17