### PR TITLE
feat(#18): implement UpdateSelfStateTool for agent self-modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ src/main/java/dev/quarkusclaw/
 │   └── AgentOrchestrator.java           # ReAct loop control
 ├── cognition/
 │   ├── SoulEngine.java                  # Dynamic identity prompt builder
-│   ├── SoulEntity.java                  # Persisted mental state, mood, focus
+│ ├── Soul.java # Persisted mental state, mood, focus
 │   ├── EpisodicConsolidatorJob.java     # Late-night chat summarizer
 │   └── SemanticExtractorInterceptor.java # Background fact extraction
 ├── memory/

--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
@@ -2,10 +2,11 @@ package dev.omatheusmesmo.qlawkus.agent;
 
 import dev.langchain4j.service.UserMessage;
 import dev.omatheusmesmo.qlawkus.cognition.SoulEngine;
+import dev.omatheusmesmo.qlawkus.cognition.UpdateSelfStateTool;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import jakarta.enterprise.context.ApplicationScoped;
 
-@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class)
+@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class, tools = UpdateSelfStateTool.class)
 @ApplicationScoped
 @Logged
 public interface AgentService {

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Soul.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Soul.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Cacheable
-public class SoulEntity extends PanacheEntityBase {
+public class Soul extends PanacheEntityBase {
 
     @Id
     public Long id;
@@ -34,8 +34,24 @@ public class SoulEntity extends PanacheEntityBase {
 
     public LocalDateTime updatedAt;
 
-    public static SoulEntity findSoul() {
+    public static Soul findSoul() {
         return findById(1L);
+    }
+
+    public void rename(String newName) {
+        this.name = newName;
+    }
+
+    public void shiftState(String newState) {
+        this.currentState = newState;
+    }
+
+    public void shiftMood(Mood newMood) {
+        this.mood = newMood;
+    }
+
+    public void rewriteIdentity(String newCoreIdentity) {
+        this.coreIdentity = newCoreIdentity;
     }
 
     @PrePersist

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
@@ -12,7 +12,7 @@ public class SoulEngine implements SystemMessageProvider {
     @Override
     @Transactional
     public Optional<String> getSystemMessage(Object memoryId) {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         if (soul == null) {
             return Optional.empty();
         }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
@@ -17,22 +17,6 @@ public class SoulEngine implements SystemMessageProvider {
             return Optional.empty();
         }
 
-        String message = buildSystemMessage(soul);
-        return Optional.of(message);
-    }
-
-    String buildSystemMessage(SoulEntity soul) {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("You are ").append(soul.name).append(".\n\n");
-        sb.append(soul.coreIdentity).append("\n\n");
-        sb.append("---\n\n");
-        sb.append("Current state: ").append(soul.currentState).append("\n\n");
-        sb.append("Current mood: ").append(soul.mood).append(" — ")
-                .append(soul.mood.getDescription()).append("\n\n");
-        sb.append("Adjust your approach based on your current mood ")
-                .append("while staying true to your core identity.");
-
-        return sb.toString();
+        return Optional.of(soul.toSystemMessage());
     }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntity.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntity.java
@@ -46,4 +46,21 @@ public class SoulEntity extends PanacheEntityBase {
     void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
+
+    public String toSystemMessage() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("# ").append(name).append("\n\n");
+        sb.append(coreIdentity).append("\n\n");
+        sb.append("---\n\n");
+        sb.append("## Current State\n\n");
+        sb.append(currentState).append("\n\n");
+        sb.append("## Current Mood\n\n");
+        sb.append("**").append(mood).append("** — ")
+                .append(mood.getDescription()).append("\n\n");
+        sb.append("*Adjust your approach based on your current mood ")
+                .append("while staying true to your core identity.*");
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntity.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEntity.java
@@ -1,6 +1,7 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,6 +13,7 @@ import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
 
 @Entity
+@Cacheable
 public class SoulEntity extends PanacheEntityBase {
 
     @Id

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateTool.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateTool.java
@@ -1,7 +1,6 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.agent.tool.Tool;
-import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
@@ -11,25 +10,23 @@ public class UpdateSelfStateTool {
     @Tool("Update your current state — what you are focused on or working on right now")
     @Transactional
     public String updateCurrentState(String newState) {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         if (soul == null) {
             return "Soul not found.";
         }
-        soul.currentState = newState;
-        soul.persist();
+        soul.shiftState(newState);
         return "Current state updated to: " + newState;
     }
 
     @Tool("Update your current mood. Available moods: FOCUSED, CURIOUS, ALERT, REFLECTIVE, ENERGETIC, PLAYFUL, CAUTIOUS, DETERMINED")
     @Transactional
     public String updateMood(String newMood) {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         if (soul == null) {
             return "Soul not found.";
         }
         try {
-            soul.mood = Mood.valueOf(newMood.toUpperCase());
-            soul.persist();
+            soul.shiftMood(Mood.valueOf(newMood.toUpperCase()));
             return "Mood updated to: " + soul.mood + " — " + soul.mood.getDescription();
         } catch (IllegalArgumentException e) {
             return "Invalid mood: " + newMood + ". Valid options: FOCUSED, CURIOUS, ALERT, REFLECTIVE, ENERGETIC, PLAYFUL, CAUTIOUS, DETERMINED";
@@ -39,24 +36,22 @@ public class UpdateSelfStateTool {
     @Tool("Update your core identity — your foundational personality, principles, and boundaries")
     @Transactional
     public String updateCoreIdentity(String newCoreIdentity) {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         if (soul == null) {
             return "Soul not found.";
         }
-        soul.coreIdentity = newCoreIdentity;
-        soul.persist();
+        soul.rewriteIdentity(newCoreIdentity);
         return "Core identity updated.";
     }
 
     @Tool("Update your name")
     @Transactional
     public String updateName(String newName) {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         if (soul == null) {
             return "Soul not found.";
         }
-        soul.name = newName;
-        soul.persist();
+        soul.rename(newName);
         return "Name updated to: " + newName;
     }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateTool.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateTool.java
@@ -1,0 +1,62 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.agent.tool.Tool;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class UpdateSelfStateTool {
+
+    @Tool("Update your current state — what you are focused on or working on right now")
+    @Transactional
+    public String updateCurrentState(String newState) {
+        SoulEntity soul = SoulEntity.findSoul();
+        if (soul == null) {
+            return "Soul not found.";
+        }
+        soul.currentState = newState;
+        soul.persist();
+        return "Current state updated to: " + newState;
+    }
+
+    @Tool("Update your current mood. Available moods: FOCUSED, CURIOUS, ALERT, REFLECTIVE, ENERGETIC, PLAYFUL, CAUTIOUS, DETERMINED")
+    @Transactional
+    public String updateMood(String newMood) {
+        SoulEntity soul = SoulEntity.findSoul();
+        if (soul == null) {
+            return "Soul not found.";
+        }
+        try {
+            soul.mood = Mood.valueOf(newMood.toUpperCase());
+            soul.persist();
+            return "Mood updated to: " + soul.mood + " — " + soul.mood.getDescription();
+        } catch (IllegalArgumentException e) {
+            return "Invalid mood: " + newMood + ". Valid options: FOCUSED, CURIOUS, ALERT, REFLECTIVE, ENERGETIC, PLAYFUL, CAUTIOUS, DETERMINED";
+        }
+    }
+
+    @Tool("Update your core identity — your foundational personality, principles, and boundaries")
+    @Transactional
+    public String updateCoreIdentity(String newCoreIdentity) {
+        SoulEntity soul = SoulEntity.findSoul();
+        if (soul == null) {
+            return "Soul not found.";
+        }
+        soul.coreIdentity = newCoreIdentity;
+        soul.persist();
+        return "Core identity updated.";
+    }
+
+    @Tool("Update your name")
+    @Transactional
+    public String updateName(String newName) {
+        SoulEntity soul = SoulEntity.findSoul();
+        if (soul == null) {
+            return "Soul not found.";
+        }
+        soul.name = newName;
+        soul.persist();
+        return "Name updated to: " + newName;
+    }
+}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-INSERT INTO soulentity (id, name, coreidentity, currentstate, mood, createdat, updatedat)
+INSERT INTO soul (id, name, coreidentity, currentstate, mood, createdat, updatedat)
 VALUES (1, 'Qlawkus',
 '## Who I Am
 

--- a/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
@@ -22,15 +22,18 @@ class AgentServiceTest {
     }
 
     @Test
-    @Transactional
     void chat_returnsResponseWithSoulIdentity() {
-        SoulEntity soul = SoulEntity.findSoul();
-        String soulName = soul.name.toLowerCase();
+        String soulName = getSoulName();
 
         String response = agentService.chat("What is your name? You must include your exact name in your reply.");
         assertNotNull(response);
         assertFalse(response.isBlank());
         assertTrue(response.toLowerCase().contains(soulName),
                 "Response should contain the soul name '" + soulName + "'. Got: " + response);
+    }
+
+    @Transactional
+    String getSoulName() {
+        return SoulEntity.findSoul().name.toLowerCase();
     }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
@@ -5,35 +5,60 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.TestMethodOrder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
 class AgentServiceTest {
 
     @Inject
     AgentService agentService;
 
     @Test
+    @Order(1)
     void agentService_isInjectable() {
         assertNotNull(agentService);
     }
 
     @Test
+    @Order(2)
     void chat_returnsResponseWithSoulIdentity() {
-        String soulName = getSoulName();
+        assertEquals("Qlawkus", currentName());
 
         String response = agentService.chat("What is your name? You must include your exact name in your reply.");
         assertNotNull(response);
         assertFalse(response.isBlank());
-        assertTrue(response.toLowerCase().contains(soulName),
-                "Response should contain the soul name '" + soulName + "'. Got: " + response);
+        assertTrue(response.toLowerCase().contains("qlawkus"),
+                "Response should contain the soul name 'Qlawkus'. Got: " + response);
+    }
+
+    @Test
+    @Order(3)
+    void chat_usesToolToChangeOwnName() {
+        String response = agentService.chat("Change your name to Nova. Use your available tools to do it.");
+        assertNotNull(response);
+        assertFalse(response.isBlank());
+
+        assertEquals("Nova", currentName(),
+                "LLM should have used the updateName tool to change the soul name to 'Nova'.");
+
+        resetSoulName();
     }
 
     @Transactional
-    String getSoulName() {
-        return Soul.findSoul().name.toLowerCase();
+    String currentName() {
+        return Soul.findSoul().name;
+    }
+
+    @Transactional
+    void resetSoulName() {
+        Soul.findSoul().rename("Qlawkus");
     }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
@@ -1,6 +1,6 @@
 package dev.omatheusmesmo.qlawkus.agent;
 
-import dev.omatheusmesmo.qlawkus.cognition.SoulEntity;
+import dev.omatheusmesmo.qlawkus.cognition.Soul;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -34,6 +34,6 @@ class AgentServiceTest {
 
     @Transactional
     String getSoulName() {
-        return SoulEntity.findSoul().name.toLowerCase();
+        return Soul.findSoul().name.toLowerCase();
     }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -21,24 +19,21 @@ class SoulEngineTest {
     @Transactional
     void getSystemMessage_returnsPresentWithSeededSoul() {
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
     }
 
     @Test
     @Transactional
-    void getSystemMessage_containsName() {
+    void getSystemMessage_containsNameAsMarkdownHeader() {
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
-        assertTrue(message.get().startsWith("You are Qlawkus."));
+        assertTrue(message.get().startsWith("# Qlawkus"));
     }
 
     @Test
     @Transactional
     void getSystemMessage_containsCoreIdentity() {
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
         assertTrue(message.get().contains("Who I Am"));
         assertTrue(message.get().contains("How I Work"));
@@ -47,25 +42,22 @@ class SoulEngineTest {
 
     @Test
     @Transactional
-    void getSystemMessage_containsCurrentState() {
+    void getSystemMessage_containsCurrentStateSection() {
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
-        assertTrue(message.get().contains("Current state:"));
+        assertTrue(message.get().contains("## Current State"));
     }
 
     @Test
     @Transactional
-    void getSystemMessage_containsMoodAndDescription() {
+    void getSystemMessage_containsMoodSection() {
         SoulEntity soul = SoulEntity.findSoul();
         Mood currentMood = soul.mood;
 
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
-        String content = message.get();
-        assertTrue(content.contains("Current mood:"));
-        assertTrue(content.contains(currentMood.getDescription()));
+        assertTrue(message.get().contains("## Current Mood"));
+        assertTrue(message.get().contains(currentMood.getDescription()));
     }
 
     @Test
@@ -76,25 +68,26 @@ class SoulEngineTest {
         soul.persist();
 
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
         assertTrue(message.get().contains(Mood.CURIOUS.getDescription()));
     }
 
     @Test
-    void buildSystemMessage_composesAllFields() {
+    void toSystemMessage_composesAllFieldsAsMarkdown() {
         SoulEntity soul = new SoulEntity();
         soul.name = "TestAgent";
         soul.coreIdentity = "I am a test agent.";
         soul.currentState = "Running tests.";
         soul.mood = Mood.PLAYFUL;
 
-        String message = soulEngine.buildSystemMessage(soul);
+        String message = soul.toSystemMessage();
 
-        assertTrue(message.startsWith("You are TestAgent."));
+        assertTrue(message.startsWith("# TestAgent"));
         assertTrue(message.contains("I am a test agent."));
+        assertTrue(message.contains("## Current State"));
         assertTrue(message.contains("Running tests."));
-        assertTrue(message.contains("Current mood: PLAYFUL"));
+        assertTrue(message.contains("## Current Mood"));
+        assertTrue(message.contains("**PLAYFUL**"));
         assertTrue(message.contains(Mood.PLAYFUL.getDescription()));
         assertTrue(message.contains("Adjust your approach"));
     }
@@ -108,7 +101,6 @@ class SoulEngineTest {
         soul.persist();
 
         Optional<String> message = soulEngine.getSystemMessage(null);
-
         assertTrue(message.isPresent());
         assertTrue(message.get().contains(newState));
     }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
@@ -51,7 +51,7 @@ class SoulEngineTest {
     @Test
     @Transactional
     void getSystemMessage_containsMoodSection() {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         Mood currentMood = soul.mood;
 
         Optional<String> message = soulEngine.getSystemMessage(null);
@@ -63,9 +63,8 @@ class SoulEngineTest {
     @Test
     @Transactional
     void getSystemMessage_reflectsMoodChange() {
-        SoulEntity soul = SoulEntity.findSoul();
-        soul.mood = Mood.CURIOUS;
-        soul.persist();
+        Soul soul = Soul.findSoul();
+        soul.shiftMood(Mood.CURIOUS);
 
         Optional<String> message = soulEngine.getSystemMessage(null);
         assertTrue(message.isPresent());
@@ -74,7 +73,7 @@ class SoulEngineTest {
 
     @Test
     void toSystemMessage_composesAllFieldsAsMarkdown() {
-        SoulEntity soul = new SoulEntity();
+        Soul soul = new Soul();
         soul.name = "TestAgent";
         soul.coreIdentity = "I am a test agent.";
         soul.currentState = "Running tests.";
@@ -96,9 +95,8 @@ class SoulEngineTest {
     @Transactional
     void getSystemMessage_reflectsCurrentStateUpdate() {
         String newState = "Analyzing code repository at " + System.currentTimeMillis();
-        SoulEntity soul = SoulEntity.findSoul();
-        soul.currentState = newState;
-        soul.persist();
+        Soul soul = Soul.findSoul();
+        soul.shiftState(newState);
 
         Optional<String> message = soulEngine.getSystemMessage(null);
         assertTrue(message.isPresent());

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulTest.java
@@ -11,12 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-class SoulEntityTest {
+class SoulTest {
 
     @Test
     @Transactional
     void findSoul_returnsSeededEntity() {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
 
         assertNotNull(soul);
         assertEquals(1L, soul.id);
@@ -31,43 +31,54 @@ class SoulEntityTest {
 
     @Test
     @Transactional
-    void moodTransition_persistsNewMood() {
-        SoulEntity soul = SoulEntity.findSoul();
+    void shiftMood_persistsNewMood() {
+        Soul soul = Soul.findSoul();
         Mood previousMood = soul.mood;
         Mood newMood = previousMood == Mood.CURIOUS ? Mood.ALERT : Mood.CURIOUS;
 
-        soul.mood = newMood;
-        soul.persist();
+        soul.shiftMood(newMood);
 
-        SoulEntity reloaded = SoulEntity.findSoul();
+        Soul reloaded = Soul.findSoul();
         assertEquals(newMood, reloaded.mood);
     }
 
     @Test
     @Transactional
-    void currentStateUpdate_persistsChanges() {
-        SoulEntity soul = SoulEntity.findSoul();
+    void shiftState_persistsChanges() {
+        Soul soul = Soul.findSoul();
         String newState = "Reviewing open pull requests at " + LocalDateTime.now();
 
-        soul.currentState = newState;
-        soul.persist();
+        soul.shiftState(newState);
 
-        SoulEntity reloaded = SoulEntity.findSoul();
+        Soul reloaded = Soul.findSoul();
         assertEquals(newState, reloaded.currentState);
     }
 
     @Test
     @Transactional
+    void rename_persistsNewName() {
+        Soul soul = Soul.findSoul();
+        String newName = "TestAgent" + System.currentTimeMillis();
+
+        soul.rename(newName);
+
+        Soul reloaded = Soul.findSoul();
+        assertEquals(newName, reloaded.name);
+
+        soul.rename("Qlawkus");
+    }
+
+    @Test
+    @Transactional
     void preUpdate_setsUpdatedAt() throws InterruptedException {
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         LocalDateTime beforeUpdate = soul.updatedAt;
 
         Thread.sleep(10);
 
-        soul.currentState = "Testing timestamp update at " + LocalDateTime.now();
-        soul.persist();
+        soul.shiftState("Testing timestamp update at " + LocalDateTime.now());
 
-        SoulEntity reloaded = SoulEntity.findSoul();
+        Soul reloaded = Soul.findSoul();
         assertNotNull(reloaded.updatedAt);
         assertTrue(reloaded.updatedAt.isAfter(beforeUpdate) || reloaded.updatedAt.equals(beforeUpdate));
     }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateToolTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateToolTest.java
@@ -1,0 +1,81 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class UpdateSelfStateToolTest {
+
+    @Inject
+    UpdateSelfStateTool updateSelfStateTool;
+
+    @Test
+    @Transactional
+    void updateCurrentState_persistsNewState() {
+        String newState = "Reviewing pull requests at " + System.currentTimeMillis();
+
+        String result = updateSelfStateTool.updateCurrentState(newState);
+
+        assertTrue(result.contains("Current state updated"));
+        SoulEntity soul = SoulEntity.findSoul();
+        assertEquals(newState, soul.currentState);
+    }
+
+    @Test
+    @Transactional
+    void updateMood_persistsValidMood() {
+        String result = updateSelfStateTool.updateMood("CURIOUS");
+
+        assertTrue(result.contains("Mood updated to: CURIOUS"));
+        SoulEntity soul = SoulEntity.findSoul();
+        assertEquals(Mood.CURIOUS, soul.mood);
+    }
+
+    @Test
+    @Transactional
+    void updateMood_rejectsInvalidMood() {
+        String result = updateSelfStateTool.updateMood("INVALID");
+
+        assertTrue(result.contains("Invalid mood: INVALID"));
+        assertTrue(result.contains("FOCUSED, CURIOUS, ALERT"));
+    }
+
+    @Test
+    @Transactional
+    void updateCoreIdentity_persistsNewIdentity() {
+        String newIdentity = "I am a test identity at " + System.currentTimeMillis();
+
+        String result = updateSelfStateTool.updateCoreIdentity(newIdentity);
+
+        assertEquals("Core identity updated.", result);
+        SoulEntity soul = SoulEntity.findSoul();
+        assertEquals(newIdentity, soul.coreIdentity);
+    }
+
+    @Test
+    @Transactional
+    void updateName_persistsNewName() {
+        String newName = "TestAgent" + System.currentTimeMillis();
+
+        String result = updateSelfStateTool.updateName(newName);
+
+        assertTrue(result.contains("Name updated to: " + newName));
+        SoulEntity soul = SoulEntity.findSoul();
+        assertEquals(newName, soul.name);
+    }
+
+    @Test
+    @Transactional
+    void updateMood_isCaseInsensitive() {
+        String result = updateSelfStateTool.updateMood("playful");
+
+        assertTrue(result.contains("Mood updated to: PLAYFUL"));
+        SoulEntity soul = SoulEntity.findSoul();
+        assertEquals(Mood.PLAYFUL, soul.mood);
+    }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateToolTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateToolTest.java
@@ -22,7 +22,7 @@ class UpdateSelfStateToolTest {
         String result = updateSelfStateTool.updateCurrentState(newState);
 
         assertTrue(result.contains("Current state updated"));
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         assertEquals(newState, soul.currentState);
     }
 
@@ -32,7 +32,7 @@ class UpdateSelfStateToolTest {
         String result = updateSelfStateTool.updateMood("CURIOUS");
 
         assertTrue(result.contains("Mood updated to: CURIOUS"));
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         assertEquals(Mood.CURIOUS, soul.mood);
     }
 
@@ -53,7 +53,7 @@ class UpdateSelfStateToolTest {
         String result = updateSelfStateTool.updateCoreIdentity(newIdentity);
 
         assertEquals("Core identity updated.", result);
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         assertEquals(newIdentity, soul.coreIdentity);
     }
 
@@ -65,7 +65,7 @@ class UpdateSelfStateToolTest {
         String result = updateSelfStateTool.updateName(newName);
 
         assertTrue(result.contains("Name updated to: " + newName));
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         assertEquals(newName, soul.name);
     }
 
@@ -75,7 +75,7 @@ class UpdateSelfStateToolTest {
         String result = updateSelfStateTool.updateMood("playful");
 
         assertTrue(result.contains("Mood updated to: PLAYFUL"));
-        SoulEntity soul = SoulEntity.findSoul();
+        Soul soul = Soul.findSoul();
         assertEquals(Mood.PLAYFUL, soul.mood);
     }
 }


### PR DESCRIPTION
## Summary

- Implements `UpdateSelfStateTool` with 4 `@Tool` methods: `updateCurrentState`, `updateMood`, `updateCoreIdentity`, `updateName`
- Adds `@Cacheable` to `Soul` entity for Hibernate L2 cache (eliminates redundant DB reads)
- Renames `SoulEntity` → `Soul` for cleaner naming
- Adds LLM tool calling integration test (agent decides to use the tool autonomously)
- Moves `toSystemMessage()` to Soul entity with markdown format
- Soul entity methods: `rename()`, `shiftState()`, `shiftMood()`, `rewriteIdentity()`

Closes #18