### PR TITLE
feat: protected SSE chat endpoint with Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ A single-user, production-ready autonomous agent capable of managing your schedu
 ## Package Structure
 
 ```
+src/main/java/dev/omatheusmesmo/qlawkus/
+├── ApiResource.java              # Protected SSE chat endpoint (POST /api/chat)
+├── agent/
+│   ├── AgentService.java         # @RegisterAiService with SoulEngine + tools
+│   └── AgentLogInterceptor.java  # CDI interceptor for invocation logging
+├── cognition/
+│   ├── Soul.java                 # Persisted mental state (name, coreIdentity, currentState, mood)
+│   ├── SoulEngine.java           # SystemMessageProvider — builds dynamic identity prompt
+│   ├── Mood.java                 # Enum with 8 behavioral moods + descriptions
+│   └── UpdateSelfStateTool.java  # @Tool methods for agent self-modification
+└── dto/
+    └── ChatRequest.java          # Input DTO for chat endpoint
+```
 src/main/java/dev/quarkusclaw/
 ├── agent/
 │   ├── AgentService.java
@@ -142,11 +155,9 @@ src/main/java/dev/quarkusclaw/
 | Component | Extension / Technology | Primary Use |
 |:----------|:----------------------|:------------|
 | **LLM Core** | `quarkus-langchain4j-openai` (Prod) / `ollama` (Dev) | ReAct Engine |
-| **Data & Memory** | `hibernate-orm-panache`, `jdbc-postgresql`, `pgvector` | SOUL, History, and Facts |
-| **Identity** | `quarkus-security`, `quarkus-oidc-client` | Instance Protection and Tokens |
-| **Groovy Engine** | `groovy-all` (Runtime) | Dynamic Tool Expansion |
-| **Tasks** | `quarkus-scheduler` | Episodic memory jobs |
-| **OS Tools** | `git`, `gh`, `docker`, `mvn` binaries | Host Environment |
+| **REST** | `quarkus-rest-jackson` | JSON + SSE chat endpoint |
+| **Data & Memory** | `hibernate-orm-panache`, `jdbc-postgresql` | SOUL, History |
+| **Security** | `elytron-security-properties-file`, `hibernate-validator` | Basic Auth, input validation |
 
 ---
 
@@ -170,7 +181,7 @@ src/main/java/dev/quarkusclaw/
 
 | Milestone | Description | Status |
 |:----------|:------------|:-------|
-| **M1** | Foundation, SOUL & Single-User Security | Pending |
+| **M1** | Foundation, SOUL & Single-User Security | In Progress |
 | **M2** | Cognition (Memory Engine) | Pending |
 | **M3** | Productivity Integration (Google Calendar) | Pending |
 | **M4** | Engineering Integration (GitHub & Git) | Pending |

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
     <dependency>
@@ -68,7 +64,20 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
@@ -1,11 +1,14 @@
 package dev.omatheusmesmo.qlawkus;
 
 import dev.omatheusmesmo.qlawkus.agent.AgentService;
+import dev.omatheusmesmo.qlawkus.dto.ChatRequest;
 import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Multi;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.GET;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
@@ -13,19 +16,14 @@ import jakarta.ws.rs.core.MediaType;
 @Authenticated
 public class ApiResource {
 
-    @Inject
-    AgentService agentService;
+  @Inject
+  AgentService agentService;
 
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public String hello() {
-        return "hello";
-    }
-
-    @POST
-    @Path("/chat")
-    @Produces(MediaType.TEXT_PLAIN)
-    public String chat(String message) {
-        return agentService.chat(message);
-    }
+  @POST
+  @Path("/chat")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public Multi<String> chat(@Valid ChatRequest request) {
+    return agentService.chat(request.message());
+  }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
@@ -4,6 +4,7 @@ import dev.langchain4j.service.UserMessage;
 import dev.omatheusmesmo.qlawkus.cognition.SoulEngine;
 import dev.omatheusmesmo.qlawkus.cognition.UpdateSelfStateTool;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @RegisterAiService(systemMessageProviderSupplier = SoulEngine.class, tools = UpdateSelfStateTool.class)
@@ -11,5 +12,5 @@ import jakarta.enterprise.context.ApplicationScoped;
 @Logged
 public interface AgentService {
 
-    String chat(@UserMessage String message);
+  Multi<String> chat(@UserMessage String message);
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/dto/ChatRequest.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/dto/ChatRequest.java
@@ -1,0 +1,7 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatRequest(
+  @NotBlank String message
+) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.users.admin=${API_USER_PASSWORD:admin123}
 quarkus.security.users.embedded.roles.admin=admin
+quarkus.http.auth.basic=true
 
 quarkus.datasource.db-kind=postgresql
 

--- a/src/test/java/dev/omatheusmesmo/qlawkus/ApiResourceSseTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/ApiResourceSseTest.java
@@ -1,0 +1,97 @@
+package dev.omatheusmesmo.qlawkus;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.WebClient;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class ApiResourceSseTest {
+
+  @TestHTTPResource
+  URL url;
+
+  @Test
+  void chat_stream_returnsSseTokens() throws InterruptedException {
+    Vertx vertx = Vertx.vertx();
+    WebClient client = WebClient.create(vertx);
+
+    String auth = Base64.getEncoder().encodeToString("admin:admin123".getBytes());
+    String body = "{\"message\": \"What is your name? Reply briefly.\"}";
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<StringBuilder> collected = new AtomicReference<>(new StringBuilder());
+    AtomicReference<Integer> statusCode = new AtomicReference<>();
+
+    client
+      .post(url.getPort(), url.getHost(), "/api/chat")
+      .putHeader("Authorization", "Basic " + auth)
+      .putHeader("Content-Type", "application/json")
+      .sendBuffer(Buffer.buffer(body))
+      .onSuccess(response -> {
+        statusCode.set(response.statusCode());
+        String bodyContent = response.bodyAsString();
+        collected.get().append(bodyContent);
+        latch.countDown();
+      })
+      .onFailure(err -> {
+        collected.get().append("ERROR: ").append(err.getMessage());
+        latch.countDown();
+      });
+
+    assertTrue(latch.await(120, TimeUnit.SECONDS), "SSE stream should complete within timeout");
+
+    client.close();
+    vertx.close();
+
+    assertEquals(200, statusCode.get(), "Should return 200 with valid auth");
+    String result = collected.get().toString();
+    assertFalse(result.isBlank(), "SSE stream should produce content");
+
+    String plainText = result.replace("data:", "").replace("\n", "").trim();
+    assertTrue(plainText.toLowerCase().contains("qlawkus"),
+      "SSE response should contain the soul name 'Qlawkus'. Got: " + result);
+  }
+
+  @Test
+  void chat_stream_withoutAuth_returns401() throws InterruptedException {
+    Vertx vertx = Vertx.vertx();
+    WebClient client = WebClient.create(vertx);
+
+    String body = "{\"message\": \"hello\"}";
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Integer> statusCode = new AtomicReference<>();
+
+    client
+      .post(url.getPort(), url.getHost(), "/api/chat")
+      .putHeader("Content-Type", "application/json")
+      .sendBuffer(Buffer.buffer(body))
+      .onSuccess(response -> {
+        statusCode.set(response.statusCode());
+        latch.countDown();
+      })
+      .onFailure(err -> {
+        statusCode.set(-1);
+        latch.countDown();
+      });
+
+    assertTrue(latch.await(10, TimeUnit.SECONDS));
+    client.close();
+    vertx.close();
+
+    assertEquals(401, statusCode.get(), "Should return 401 without auth");
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/ApiResourceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/ApiResourceTest.java
@@ -1,0 +1,46 @@
+package dev.omatheusmesmo.qlawkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class ApiResourceTest {
+
+  @Test
+  void chat_withoutAuth_returns401() {
+    given()
+      .contentType(ContentType.JSON)
+      .body("{\"message\": \"hello\"}")
+    .when()
+      .post("/api/chat")
+    .then()
+      .statusCode(401);
+  }
+
+  @Test
+  void chat_withInvalidCredentials_returns401() {
+    given()
+      .auth().basic("admin", "wrongpassword")
+      .contentType(ContentType.JSON)
+      .body("{\"message\": \"hello\"}")
+    .when()
+      .post("/api/chat")
+    .then()
+      .statusCode(401);
+  }
+
+  @Test
+  void chat_withEmptyMessage_returns400() {
+    given()
+      .auth().basic("admin", "admin123")
+      .contentType(ContentType.JSON)
+      .body("{\"message\": \"\"}")
+    .when()
+      .post("/api/chat")
+    .then()
+      .statusCode(400);
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
@@ -18,47 +18,57 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestMethodOrder(OrderAnnotation.class)
 class AgentServiceTest {
 
-    @Inject
-    AgentService agentService;
+  @Inject
+  AgentService agentService;
 
-    @Test
-    @Order(1)
-    void agentService_isInjectable() {
-        assertNotNull(agentService);
-    }
+  @Test
+  @Order(1)
+  void agentService_isInjectable() {
+    assertNotNull(agentService);
+  }
 
-    @Test
-    @Order(2)
-    void chat_returnsResponseWithSoulIdentity() {
-        assertEquals("Qlawkus", currentName());
+  @Test
+  @Order(2)
+  void chat_returnsResponseWithSoulIdentity() {
+    assertEquals("Qlawkus", currentName());
 
-        String response = agentService.chat("What is your name? You must include your exact name in your reply.");
-        assertNotNull(response);
-        assertFalse(response.isBlank());
-        assertTrue(response.toLowerCase().contains("qlawkus"),
-                "Response should contain the soul name 'Qlawkus'. Got: " + response);
-    }
+    String response = agentService.chat("What is your name? You must include your exact name in your reply.")
+      .collect()
+      .in(StringBuilder::new, StringBuilder::append)
+      .await()
+      .indefinitely()
+      .toString();
+    assertNotNull(response);
+    assertFalse(response.isBlank());
+    assertTrue(response.toLowerCase().contains("qlawkus"),
+      "Response should contain the soul name 'Qlawkus'. Got: " + response);
+  }
 
-    @Test
-    @Order(3)
-    void chat_usesToolToChangeOwnName() {
-        String response = agentService.chat("Change your name to Nova. Use your available tools to do it.");
-        assertNotNull(response);
-        assertFalse(response.isBlank());
+  @Test
+  @Order(3)
+  void chat_usesToolToChangeOwnName() {
+    String response = agentService.chat("Change your name to Nova. Use your available tools to do it.")
+      .collect()
+      .in(StringBuilder::new, StringBuilder::append)
+      .await()
+      .indefinitely()
+      .toString();
+    assertNotNull(response);
+    assertFalse(response.isBlank());
 
-        assertEquals("Nova", currentName(),
-                "LLM should have used the updateName tool to change the soul name to 'Nova'.");
+    assertEquals("Nova", currentName(),
+      "LLM should have used the updateName tool to change the soul name to 'Nova'.");
 
-        resetSoulName();
-    }
+    resetSoulName();
+  }
 
-    @Transactional
-    String currentName() {
-        return Soul.findSoul().name;
-    }
+  @Transactional
+  String currentName() {
+    return Soul.findSoul().name;
+  }
 
-    @Transactional
-    void resetSoulName() {
-        Soul.findSoul().rename("Qlawkus");
-    }
+  @Transactional
+  void resetSoulName() {
+    Soul.findSoul().rename("Qlawkus");
+  }
 }


### PR DESCRIPTION
## Summary

- **POST /api/chat** returns Server-Sent Events (`text/event-stream`) validated by Basic Auth
- **AgentService.chat()** returns `Multi<String>` — streaming by default, transport layer decides how to consume
- **ChatRequest** DTO with `@NotBlank` validation, proper JSON in / SSE out
- Enabled `quarkus.http.auth.basic=true` for explicit Basic Auth support
- Added `quarkus-rest-jackson`, `quarkus-hibernate-validator`, `rest-assured` (test)
- Removed `quarkus-rest` (transitive via rest-jackson) and unused `quarkus-test-security`

## Tests (5 new)

- `ApiResourceTest`: 401 without auth, 401 invalid credentials, 400 empty message
- `ApiResourceSseTest`: SSE with valid auth (200 + content), SSE without auth (401)

closes #19