### PR TITLE
feat: LLM startup thought and JVM cold start validation

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentLogInterceptor.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentLogInterceptor.java
@@ -28,23 +28,23 @@ import jakarta.interceptor.InterceptorBinding;
 @Priority(Interceptor.Priority.APPLICATION)
 class AgentLogInterceptor {
 
-    @AroundInvoke
-    Object logInvocation(InvocationContext context) throws Exception {
-        String method = context.getMethod().getName();
-        Object[] params = context.getParameters();
+  @AroundInvoke
+  Object logInvocation(InvocationContext context) throws Exception {
+    String method = context.getMethod().getName();
+    Object[] params = context.getParameters();
 
-        Log.infof("AgentService invocation: %s with %d parameters", method, params.length);
+    Log.infof("Thought ▸ %s invoked", method);
 
-        long start = System.currentTimeMillis();
-        try {
-            Object result = context.proceed();
-            long elapsed = System.currentTimeMillis() - start;
-            Log.infof("AgentService completed: %s in %dms", method, elapsed);
-            return result;
-        } catch (Exception e) {
-            long elapsed = System.currentTimeMillis() - start;
-            Log.errorf("AgentService failed: %s in %dms — %s", method, elapsed, e.getMessage());
-            throw e;
-        }
+    long start = System.currentTimeMillis();
+    try {
+      Object result = context.proceed();
+      long elapsed = System.currentTimeMillis() - start;
+      Log.infof("Thought ▸ %s completed in %dms", method, elapsed);
+      return result;
+    } catch (Exception e) {
+      long elapsed = System.currentTimeMillis() - start;
+      Log.errorf("Thought ▸ %s failed in %dms — %s", method, elapsed, e.getMessage());
+      throw e;
     }
+  }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/StartupThoughtObserver.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/StartupThoughtObserver.java
@@ -1,0 +1,49 @@
+package dev.omatheusmesmo.qlawkus.agent;
+
+import dev.omatheusmesmo.qlawkus.cognition.Soul;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+class StartupThoughtObserver {
+
+  @Inject
+  AgentService agentService;
+
+  void onStartup(@Observes StartupEvent event) {
+    logSoulState();
+    generateStartupThought();
+  }
+
+  @Transactional
+  void logSoulState() {
+    Soul soul = Soul.findSoul();
+    if (soul != null) {
+      Log.infof("Soul initialized: %s [%s] — %s",
+        soul.name, soul.mood, soul.currentState);
+    } else {
+      Log.warn("No Soul found in database at startup");
+    }
+  }
+
+  void generateStartupThought() {
+    try {
+      String thought = agentService.chat(
+        "You just initialized. Briefly reflect on your current state in one sentence."
+      )
+        .collect()
+        .in(StringBuilder::new, StringBuilder::append)
+        .await()
+        .indefinitely()
+        .toString();
+
+      Log.infof("Thought ▸ Startup reflection: %s", thought.trim());
+    } catch (Exception e) {
+      Log.warnf("Could not generate startup thought: %s", e.getMessage());
+    }
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
@@ -9,14 +9,13 @@ import java.util.Optional;
 @ApplicationScoped
 public class SoulEngine implements SystemMessageProvider {
 
-    @Override
-    @Transactional
-    public Optional<String> getSystemMessage(Object memoryId) {
-        Soul soul = Soul.findSoul();
-        if (soul == null) {
-            return Optional.empty();
-        }
-
-        return Optional.of(soul.toSystemMessage());
+  @Override
+  @Transactional
+  public Optional<String> getSystemMessage(Object memoryId) {
+    Soul soul = Soul.findSoul();
+    if (soul == null) {
+      return Optional.empty();
     }
+    return Optional.of(soul.toSystemMessage());
+  }
 }


### PR DESCRIPTION
## Summary

- **StartupThoughtObserver** generates an actual LLM thought at boot — the agent reflects on its own state when it wakes up (log only, no state mutation)
- Graceful fallback if LLM is unavailable at startup
- AgentLogInterceptor log format updated with `Thought ▸` prefix
- SoulEngine simplified (startup logic extracted to observer, no circular dependency)
- **ColdStartTest** verifies Soul is seeded correctly at startup

closes #20