### PR TITLE
feat: spin up PostgreSQL with pgvector via Dev Services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ API_USER_PASSWORD=admin123
 # LLM configuration
 # Dev: Ollama (local) - defaults to qwen3:1.7b
 OLLAMA_MODEL=qwen3:1.7b
+OLLAMA_EMBEDDING_MODEL=nomic-embed-text
+EMBEDDING_DIMENSION=768
 # Prod: OpenAI
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_MODEL=gpt-4o-mini

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>quarkus-langchain4j-openai</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkiverse.langchain4j</groupId>
+      <artifactId>quarkus-langchain4j-pgvector</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,16 +9,27 @@ quarkus.http.auth.basic=true
 
 quarkus.datasource.db-kind=postgresql
 
+quarkus.langchain4j.pgvector.table=embeddings
+quarkus.langchain4j.pgvector.dimension=${EMBEDDING_DIMENSION:768}
+quarkus.langchain4j.pgvector.metadata.storage-mode=combined-jsonb
+
 %dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%dev.quarkus.langchain4j.chat-model.provider=ollama
+%dev.quarkus.langchain4j.embedding-model.provider=ollama
 %dev.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
 %dev.quarkus.langchain4j.ollama.chat-model.temperature=0
+%dev.quarkus.langchain4j.ollama.embedding-model.model-name=${OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
 %dev.quarkus.langchain4j.ollama.timeout=120s
+%dev.quarkus.langchain4j.pgvector.drop-table-first=true
 
 %test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 %test.quarkus.langchain4j.chat-model.provider=ollama
+%test.quarkus.langchain4j.embedding-model.provider=ollama
 %test.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
 %test.quarkus.langchain4j.ollama.chat-model.temperature=0
+%test.quarkus.langchain4j.ollama.embedding-model.model-name=${OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
 %test.quarkus.langchain4j.ollama.timeout=120s
+%test.quarkus.langchain4j.pgvector.drop-table-first=true
 
 %prod.quarkus.datasource.jdbc.url=${QUARKUS_DATASOURCE_JDBC_URL}
 %prod.quarkus.datasource.username=${QUARKUS_DATASOURCE_USERNAME}
@@ -27,3 +38,4 @@ quarkus.datasource.db-kind=postgresql
 %prod.quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %prod.quarkus.langchain4j.openai.chat-model.model-name=${OPENAI_MODEL:gpt-4o-mini}
 %prod.quarkus.langchain4j.openai.chat-model.temperature=0
+%prod.quarkus.langchain4j.pgvector.drop-table-first=false

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/PgVectorDevServicesTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/PgVectorDevServicesTest.java
@@ -1,0 +1,39 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+class PgVectorDevServicesTest {
+
+    @Inject
+    EmbeddingModel embeddingModel;
+
+    @Inject
+    EmbeddingStore<?> embeddingStore;
+
+    @Test
+    void embeddingModel_isInjected() {
+        assertNotNull(embeddingModel);
+    }
+
+    @Test
+    void embeddingStore_isInjected() {
+        assertNotNull(embeddingStore);
+    }
+
+    @Test
+    void embeddingModel_generatesVector() {
+        Embedding embedding = embeddingModel.embed("hello").content();
+
+        assertNotNull(embedding);
+        assertNotNull(embedding.vector());
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary

- Add `quarkus-langchain4j-pgvector` extension for vector storage
- Configure `nomic-embed-text` (768d) as embedding model via Ollama Dev Services
- Dev Services now spins up `pgvector/pgvector:pg17` container automatically
- Add `%dev.quarkus.langchain4j.chat-model.provider=ollama` (was missing, only had `%test`)
- Embedding dimension and model configurable via `EMBEDDING_DIMENSION` and `OLLAMA_EMBEDDING_MODEL` env vars
- PgVector metadata uses `combined-jsonb` for dynamic fact metadata
- Update `.env.example` with new embedding variables

## Verified

- `mvn compile` — clean, no warnings
- Unit tests pass (Soul, SoulEngine, UpdateSelfStateTool, ApiResource)
- `quarkus:dev` — both containers start (`pgvector/pgvector:pg17` + `ollama/ollama:latest`), `langchain4j-pgvector` in installed features, app healthy