### PR TITLE
feat: create ChatMessageEntity for working memory persistence

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatMessageEntity.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatMessageEntity.java
@@ -1,0 +1,63 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.data.message.ChatMessageType;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+public class ChatMessageEntity extends PanacheEntityBase {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  public Long id;
+
+  @Column(nullable = false)
+  public String memoryId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 24)
+  public ChatMessageType type;
+
+  @Column(columnDefinition = "TEXT", nullable = false)
+  public String content;
+
+  @Column(nullable = false)
+  public LocalDateTime createdAt;
+
+  public static List<ChatMessageEntity> findByMemoryIdOrdered(String memoryId) {
+    return list("memoryId = ?1 order by createdAt", memoryId);
+  }
+
+  public static long deleteByMemoryId(String memoryId) {
+    return delete("memoryId = ?1", memoryId);
+  }
+
+  @PrePersist
+  void persistCreatedAt() {
+    createdAt = LocalDateTime.now();
+  }
+
+  public static ChatMessageEntity fromChatMessage(String memoryId, ChatMessage message) {
+    ChatMessageEntity entity = new ChatMessageEntity();
+    entity.memoryId = memoryId;
+    entity.type = message.type();
+    entity.content = ChatMessageSerializer.messageToJson(message);
+    return entity;
+  }
+
+  public ChatMessage toChatMessage() {
+    return ChatMessageDeserializer.messageFromJson(content);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,7 @@ quarkus.security.users.embedded.roles.admin=admin
 quarkus.http.auth.basic=true
 
 quarkus.datasource.db-kind=postgresql
+quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 
 quarkus.langchain4j.pgvector.table=embeddings
 quarkus.langchain4j.pgvector.dimension=${EMBEDDING_DIMENSION:768}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-INSERT INTO soul (id, name, coreidentity, currentstate, mood, createdat, updatedat)
+INSERT INTO soul (id, name, core_identity, current_state, mood, created_at, updated_at)
 VALUES (1, 'Qlawkus',
 '## Who I Am
 

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/ChatMessageEntityTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/ChatMessageEntityTest.java
@@ -1,0 +1,84 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+class ChatMessageEntityTest {
+
+  @Test
+  @Transactional
+  void fromChatMessage_serializesUserMessage() {
+    ChatMessageEntity entity = ChatMessageEntity.fromChatMessage("test-session", new UserMessage("hello"));
+
+    assertEquals("test-session", entity.memoryId);
+    assertEquals(ChatMessageType.USER, entity.type);
+    assertNotNull(entity.content);
+  }
+
+  @Test
+  @Transactional
+  void fromChatMessage_serializesAiMessage() {
+    ChatMessageEntity entity = ChatMessageEntity.fromChatMessage("test-session", AiMessage.from("hi there"));
+
+    assertEquals(ChatMessageType.AI, entity.type);
+  }
+
+  @Test
+  @Transactional
+  void toChatMessage_roundtripUserMessage() {
+    ChatMessageEntity entity = ChatMessageEntity.fromChatMessage("test-session", new UserMessage("hello"));
+    entity.persist();
+
+    ChatMessageEntity persisted = ChatMessageEntity.findById(entity.id);
+    UserMessage deserialized = (UserMessage) persisted.toChatMessage();
+
+    assertEquals("hello", deserialized.singleText());
+  }
+
+  @Test
+  @Transactional
+  void toChatMessage_roundtripAiMessage() {
+    ChatMessageEntity entity = ChatMessageEntity.fromChatMessage("test-session", AiMessage.from("response"));
+    entity.persist();
+
+    ChatMessageEntity persisted = ChatMessageEntity.findById(entity.id);
+    AiMessage deserialized = (AiMessage) persisted.toChatMessage();
+
+    assertEquals("response", deserialized.text());
+  }
+
+  @Test
+  @Transactional
+  void findByMemoryIdOrdered_returnsInOrder() {
+    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("first")).persist();
+    ChatMessageEntity.fromChatMessage("session-1", AiMessage.from("second")).persist();
+    ChatMessageEntity.fromChatMessage("session-2", new UserMessage("other")).persist();
+
+    var messages = ChatMessageEntity.findByMemoryIdOrdered("session-1");
+
+    assertEquals(2, messages.size());
+    assertEquals(ChatMessageType.USER, messages.get(0).type);
+    assertEquals(ChatMessageType.AI, messages.get(1).type);
+  }
+
+  @Test
+  @Transactional
+  void deleteByMemoryId_removesOnlyTargetSession() {
+    ChatMessageEntity.fromChatMessage("session-a", new UserMessage("a")).persist();
+    ChatMessageEntity.fromChatMessage("session-b", new UserMessage("b")).persist();
+
+    ChatMessageEntity.deleteByMemoryId("session-a");
+
+    assertEquals(0, ChatMessageEntity.findByMemoryIdOrdered("session-a").size());
+    assertEquals(1, ChatMessageEntity.findByMemoryIdOrdered("session-b").size());
+  }
+}


### PR DESCRIPTION
Closes #22

## Summary

- Create `ChatMessageEntity` JPA entity for persisting chat messages in PostgreSQL
- Each row stores one message with: `memoryId`, `type` (enum matching LangChain4j's ChatMessageType), `content` (JSON-serialized via `ChatMessageSerializer`), and `createdAt`
- Static helpers: `fromChatMessage()` / `toChatMessage()` for serialization roundtrip
- Query methods: `findByMemoryIdOrdered()` and `deleteByMemoryId()`
- 6 tests covering: serialization, deserialization roundtrip (User + AI), ordered retrieval, session-scoped deletion

## Design decisions

- One row per message (not one row per session) — enables windowed eviction in `PersistentMemoryStore` (#23) and future per-message queries
- JSON serialization via LangChain4j's built-in `ChatMessageSerializer`/`ChatMessageDeserializer` — preserves tool execution results and metadata
- `ChatMessageType` enum mirrors LangChain4j's enum for type-safe filtering