### PR TITLE
feat: implement PersistentMemoryStore with ChatMemoryStore

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/PersistentMemoryStore.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/PersistentMemoryStore.java
@@ -1,0 +1,36 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+@ApplicationScoped
+public class PersistentMemoryStore implements ChatMemoryStore {
+
+  @Override
+  @Transactional
+  public List<ChatMessage> getMessages(Object memoryId) {
+    return ChatMessageEntity.findByMemoryIdOrdered(memoryId.toString())
+        .stream()
+        .map(ChatMessageEntity::toChatMessage)
+        .toList();
+  }
+
+  @Override
+  @Transactional
+  public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+    String id = memoryId.toString();
+    ChatMessageEntity.deleteByMemoryId(id);
+    for (ChatMessage message : messages) {
+      ChatMessageEntity.fromChatMessage(id, message).persist();
+    }
+  }
+
+  @Override
+  @Transactional
+  public void deleteMessages(Object memoryId) {
+    ChatMessageEntity.deleteByMemoryId(memoryId.toString());
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/PersistentMemoryStoreTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/PersistentMemoryStoreTest.java
@@ -1,0 +1,84 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class PersistentMemoryStoreTest {
+
+  @Inject
+  PersistentMemoryStore store;
+
+  @Test
+  @Transactional
+  void getMessages_returnsEmptyForNewSession() {
+    var messages = store.getMessages("nonexistent-session");
+
+    assertTrue(messages.isEmpty());
+  }
+
+  @Test
+  @Transactional
+  void updateMessages_persistsAndRetrievesMessages() {
+    String sessionId = "test-session-1";
+    store.updateMessages(sessionId, List.of(
+        new UserMessage("hello"),
+        AiMessage.from("hi there")
+    ));
+
+    List<ChatMessage> retrieved = store.getMessages(sessionId);
+
+    assertEquals(2, retrieved.size());
+    assertEquals(UserMessage.class, retrieved.get(0).getClass());
+    assertEquals(AiMessage.class, retrieved.get(1).getClass());
+  }
+
+  @Test
+  @Transactional
+  void updateMessages_replacesExistingMessages() {
+    String sessionId = "test-session-2";
+    store.updateMessages(sessionId, List.of(
+        new UserMessage("first"),
+        AiMessage.from("first response")
+    ));
+    store.updateMessages(sessionId, List.of(
+        new UserMessage("second"),
+        AiMessage.from("second response")
+    ));
+
+    List<ChatMessage> retrieved = store.getMessages(sessionId);
+
+    assertEquals(2, retrieved.size());
+    assertEquals("second", ((UserMessage) retrieved.get(0)).singleText());
+  }
+
+  @Test
+  @Transactional
+  void deleteMessages_removesSession() {
+    String sessionId = "test-session-3";
+    store.updateMessages(sessionId, List.of(new UserMessage("to be deleted")));
+
+    store.deleteMessages(sessionId);
+
+    assertTrue(store.getMessages(sessionId).isEmpty());
+  }
+
+  @Test
+  @Transactional
+  void multipleSessions_areIsolated() {
+    store.updateMessages("session-a", List.of(new UserMessage("a")));
+    store.updateMessages("session-b", List.of(new UserMessage("b"), AiMessage.from("b response")));
+
+    assertEquals(1, store.getMessages("session-a").size());
+    assertEquals(2, store.getMessages("session-b").size());
+  }
+}


### PR DESCRIPTION
Closes #23

## Summary

- Implement `PersistentMemoryStore` as `@ApplicationScoped` CDI bean implementing `ChatMemoryStore`
- Auto-discovered by Quarkus LangChain4j — replaces default in-memory store
- `getMessages(memoryId)` — retrieves all messages for a session ordered by `createdAt`
- `updateMessages(memoryId, messages)` — replaces all messages for a session (delete + insert)
- `deleteMessages(memoryId)` — removes all messages for a session
- Window size = 20 messages (default `quarkus.langchain4j.chat-memory.memory-window.max-messages=20`)
- 5 tests: empty session, persist+retrieve, replace, delete, session isolation