### PR TITLE
feat: implement SemanticExtractorObserver for async fact extraction into pgvector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/ApiResource.java
@@ -1,9 +1,13 @@
 package dev.omatheusmesmo.qlawkus;
 
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import dev.omatheusmesmo.qlawkus.agent.AgentService;
+import dev.omatheusmesmo.qlawkus.cognition.ChatCompletedEvent;
 import dev.omatheusmesmo.qlawkus.dto.ChatRequest;
 import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Multi;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.POST;
@@ -11,19 +15,36 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
 
 @Path("/api")
 @Authenticated
 public class ApiResource {
 
+  static final String DEFAULT_MEMORY_ID = "default";
+
   @Inject
   AgentService agentService;
+
+  @Inject
+  ChatMemoryStore memoryStore;
+
+  @Inject
+  Event<ChatCompletedEvent> eventEmitter;
 
   @POST
   @Path("/chat")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.SERVER_SENT_EVENTS)
   public Multi<String> chat(@Valid ChatRequest request) {
-    return agentService.chat(request.message());
+    return agentService.chat(request.message())
+        .onCompletion().invoke(() -> {
+          try {
+            List<ChatMessage> messages = memoryStore.getMessages(DEFAULT_MEMORY_ID);
+            eventEmitter.fire(new ChatCompletedEvent(messages));
+          } catch (Exception e) {
+            // best effort — never block the response
+          }
+        });
   }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatCompletedEvent.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatCompletedEvent.java
@@ -1,0 +1,7 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.ChatMessage;
+import java.util.List;
+
+public record ChatCompletedEvent(List<ChatMessage> messages) {
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserver.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserver.java
@@ -1,0 +1,74 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.TransactionPhase;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class SemanticExtractorObserver {
+
+  @Inject
+  ChatModel chatModel;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  void onChatCompleted(@Observes(during = TransactionPhase.AFTER_COMPLETION) ChatCompletedEvent event) {
+    if (event.messages().isEmpty()) return;
+
+    Infrastructure.getDefaultWorkerPool()
+        .submit(() -> extractAndStore(event.messages()));
+  }
+
+  void extractAndStore(Iterable<ChatMessage> messages) {
+    try {
+      StringBuilder conversation = new StringBuilder();
+      for (ChatMessage m : messages) {
+        conversation.append(m.type().name()).append(": ").append(m).append("\n");
+      }
+
+      String extractionPrompt = """
+          Extract factual information and user preferences from this conversation.
+          Return each fact as a separate line prefixed with '- '. If no facts or preferences are present, return nothing.
+
+          Examples:
+          - User prefers dark theme in IDE
+          - User works with Java and Quarkus
+          - User's name is Matheus
+          - User dislikes var keyword in Java
+
+          Conversation:
+          %s""".formatted(conversation);
+
+      String response = chatModel.chat(extractionPrompt);
+      if (response == null || response.isBlank()) return;
+
+      for (String line : response.split("\n")) {
+        String fact = line.trim().replaceAll("^-\\s*", "");
+        if (fact.isEmpty()) continue;
+
+        Metadata metadata = new Metadata();
+        metadata.put("source", "semantic-extractor");
+        TextSegment segment = TextSegment.from(fact, metadata);
+        Embedding embedding = embeddingModel.embed(fact).content();
+        embeddingStore.add(embedding, segment);
+        Log.infof("Semantic fact extracted: %s", fact);
+      }
+    } catch (Exception e) {
+      Log.warnf(e, "Failed to extract semantic facts");
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.C
 quarkus.langchain4j.pgvector.table=embeddings
 quarkus.langchain4j.pgvector.dimension=${EMBEDDING_DIMENSION:768}
 quarkus.langchain4j.pgvector.metadata.storage-mode=combined-jsonb
+quarkus.langchain4j.pgvector.metadata.column-definitions=metadata JSONB NULL
 
 %dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 %dev.quarkus.langchain4j.chat-model.provider=ollama

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserverTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserverTest.java
@@ -1,0 +1,122 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class SemanticExtractorObserverTest {
+
+  @InjectMock
+  ChatModel chatModel;
+
+  @Inject
+  SemanticExtractorObserver observer;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  @Test
+  void extractAndStore_storesFactsInVectorStore() {
+    when(chatModel.chat(anyString())).thenReturn("- User prefers Vim over VS Code\n- User codes in Rust");
+
+    List<ChatMessage> messages = List.of(
+        new UserMessage("I love Vim, never switching to VS Code"),
+        AiMessage.from("Noted! Vim is a great editor.")
+    );
+
+    observer.extractAndStore(messages);
+
+    Embedding queryEmbedding = embeddingModel.embed("editor preference Vim VS Code").content();
+    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(10)
+            .minScore(0.5)
+            .build()
+    );
+
+    assertFactFound(results, "Vim");
+
+    Embedding rustQuery = embeddingModel.embed("programming language Rust").content();
+    EmbeddingSearchResult<TextSegment> rustResults = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(rustQuery)
+            .maxResults(10)
+            .minScore(0.5)
+            .build()
+    );
+
+    assertFactFound(rustResults, "Rust");
+  }
+
+  @Test
+  void extractAndStore_storesMetadataWithSource() {
+    when(chatModel.chat(anyString())).thenReturn("- User's name is Matheus");
+
+    List<ChatMessage> messages = List.of(
+        new UserMessage("My name is Matheus"),
+        AiMessage.from("Nice to meet you, Matheus!")
+    );
+
+    observer.extractAndStore(messages);
+
+    Embedding queryEmbedding = embeddingModel.embed("user name Matheus").content();
+    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(10)
+            .minScore(0.5)
+            .build()
+    );
+
+    boolean hasSource = results.matches().stream()
+        .anyMatch(m -> "semantic-extractor".equals(m.embedded().metadata().getString("source")));
+    assertTrue(hasSource, "Expected metadata source=semantic-extractor");
+  }
+
+  @Test
+  void extractAndStore_handlesEmptyResponse() {
+    when(chatModel.chat(anyString())).thenReturn("");
+
+    List<ChatMessage> messages = List.of(new UserMessage("hello"));
+    observer.extractAndStore(messages);
+  }
+
+  @Test
+  void extractAndStore_handlesException() {
+    when(chatModel.chat(anyString())).thenThrow(new RuntimeException("LLM unavailable"));
+
+    List<ChatMessage> messages = List.of(new UserMessage("hello"));
+    observer.extractAndStore(messages);
+  }
+
+  private void assertFactFound(EmbeddingSearchResult<TextSegment> results, String keyword) {
+    boolean found = results.matches().stream()
+        .map(EmbeddingMatch::embedded)
+        .map(TextSegment::text)
+        .anyMatch(text -> text.toLowerCase().contains(keyword.toLowerCase()));
+    assertTrue(found, "Expected to find fact containing '" + keyword + "' but found: " +
+        results.matches().stream().map(m -> m.embedded().text()).toList());
+  }
+}


### PR DESCRIPTION
Closes #24

## Summary

- `ChatCompletedEvent` — CDI event record fired after each chat completion
- `SemanticExtractorObserver` — observes `ChatCompletedEvent` (AFTER_COMPLETION), runs extraction asynchronously on worker thread
- Uses `ChatModel` to extract facts/preferences from conversation via prompt
- Stores extracted facts as embeddings in pgvector with `source=semantic-extractor` metadata
- `ApiResource` fires the event on stream completion via `onCompletion().invoke()`
- Added `metadata JSONB NULL` column definition (required by `combined-jsonb` storage mode)
- Added `mockito-core` test dependency
- 3 tests: fact extraction + embedding search, empty response, exception handling

## Architecture

```
User → ApiResource → AgentService (Multi<String>)
                          ↓ onCompletion
                   ChatCompletedEvent (CDI fire)
                          ↓ AFTER_COMPLETION
               SemanticExtractorObserver (async worker)
                    ↓ ChatModel.extract()
                    ↓ EmbeddingModel.embed()
                    ↓ EmbeddingStore.add()
```