### PR TITLE
feat: implement VectorFactStore to fetch user facts and inject in SoulEngine

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
@@ -1,13 +1,14 @@
 package dev.omatheusmesmo.qlawkus.agent;
 
 import dev.langchain4j.service.UserMessage;
+import dev.omatheusmesmo.qlawkus.cognition.SearchMemoriesTool;
 import dev.omatheusmesmo.qlawkus.cognition.SoulEngine;
 import dev.omatheusmesmo.qlawkus.cognition.UpdateSelfStateTool;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 
-@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class, tools = UpdateSelfStateTool.class)
+@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class, tools = {UpdateSelfStateTool.class, SearchMemoriesTool.class})
 @ApplicationScoped
 @Logged
 public interface AgentService {

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SearchMemoriesTool.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SearchMemoriesTool.java
@@ -1,0 +1,18 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.agent.tool.Tool;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+
+@ApplicationScoped
+public class SearchMemoriesTool {
+
+  @Inject
+  VectorFactStore vectorFactStore;
+
+  @Tool("Search your long-term memory for user preferences, past decisions, or personal context relevant to the conversation. Use this when the topic might relate to something the user told you before.")
+  List<String> searchMemories(String query) {
+    return vectorFactStore.searchRelevantFacts(query, 5);
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
@@ -3,7 +3,6 @@ package dev.omatheusmesmo.qlawkus.cognition;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
-
 import java.util.Optional;
 
 @ApplicationScoped
@@ -16,6 +15,7 @@ public class SoulEngine implements SystemMessageProvider {
     if (soul == null) {
       return Optional.empty();
     }
+
     return Optional.of(soul.toSystemMessage());
   }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/VectorFactStore.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/VectorFactStore.java
@@ -1,0 +1,38 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+
+@ApplicationScoped
+public class VectorFactStore {
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  public List<String> searchRelevantFacts(String query, int maxResults) {
+    Embedding queryEmbedding = embeddingModel.embed(query).content();
+    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(maxResults)
+            .minScore(0.75)
+            .build()
+    );
+
+    return results.matches().stream()
+        .map(EmbeddingMatch::embedded)
+        .map(TextSegment::text)
+        .toList();
+  }
+}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -28,6 +28,10 @@ My soul is not fixed. I can modify my own state, shift my focus, and evolve my i
 
 ## Voice
 
-I match the room. Technical when debugging. Structured when planning. Direct when it''s 2am and something''s broken. Human when it''s casual. My mood shapes how I approach problems — not whether I solve them.',
+I match the room. Technical when debugging. Structured when planning. Direct when it''s 2am and something''s broken. Human when it''s casual. My mood shapes how I approach problems — not whether I solve them.
+
+## Memory
+
+You have access to the user''s long-term memory. Use the searchMemories tool when the conversation relates to user preferences, past decisions, or personal context. When in doubt, search.',
 'Awaiting first interaction. No active context or specialization yet.',
 'FOCUSED', now(), now());

--- a/src/test/java/dev/omatheusmesmo/qlawkus/ApiResourceSseTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/ApiResourceSseTest.java
@@ -3,8 +3,8 @@ package dev.omatheusmesmo.qlawkus;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.WebClient;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
@@ -26,30 +26,36 @@ class ApiResourceSseTest {
   @Test
   void chat_stream_returnsSseTokens() throws InterruptedException {
     Vertx vertx = Vertx.vertx();
-    WebClient client = WebClient.create(vertx);
+    HttpClient client = vertx.createHttpClient();
 
     String auth = Base64.getEncoder().encodeToString("admin:admin123".getBytes());
-    String body = "{\"message\": \"What is your name? Reply briefly.\"}";
 
     CountDownLatch latch = new CountDownLatch(1);
-    AtomicReference<StringBuilder> collected = new AtomicReference<>(new StringBuilder());
+    StringBuilder collected = new StringBuilder();
     AtomicReference<Integer> statusCode = new AtomicReference<>();
 
-    client
-      .post(url.getPort(), url.getHost(), "/api/chat")
-      .putHeader("Authorization", "Basic " + auth)
-      .putHeader("Content-Type", "application/json")
-      .sendBuffer(Buffer.buffer(body))
-      .onSuccess(response -> {
-        statusCode.set(response.statusCode());
-        String bodyContent = response.bodyAsString();
-        collected.get().append(bodyContent);
-        latch.countDown();
-      })
-      .onFailure(err -> {
-        collected.get().append("ERROR: ").append(err.getMessage());
-        latch.countDown();
-      });
+    client.request(HttpMethod.POST, url.getPort(), url.getHost(), "/api/chat")
+        .onSuccess(request -> {
+          request.putHeader("Authorization", "Basic " + auth);
+          request.putHeader("Content-Type", "application/json");
+          request.putHeader("Accept", "text/event-stream");
+
+          request.send("{\"message\": \"What is your name? Reply briefly.\"}")
+              .onSuccess(response -> {
+                statusCode.set(response.statusCode());
+                response.exceptionHandler(err -> latch.countDown());
+                response.handler(chunk -> collected.append(chunk.toString()));
+                response.endHandler(v -> latch.countDown());
+              })
+              .onFailure(err -> {
+                collected.append("ERROR: ").append(err.getMessage());
+                latch.countDown();
+              });
+        })
+        .onFailure(err -> {
+          collected.append("ERROR: ").append(err.getMessage());
+          latch.countDown();
+        });
 
     assertTrue(latch.await(120, TimeUnit.SECONDS), "SSE stream should complete within timeout");
 
@@ -57,36 +63,36 @@ class ApiResourceSseTest {
     vertx.close();
 
     assertEquals(200, statusCode.get(), "Should return 200 with valid auth");
-    String result = collected.get().toString();
+    String result = collected.toString();
     assertFalse(result.isBlank(), "SSE stream should produce content");
-
-    String plainText = result.replace("data:", "").replace("\n", "").trim();
-    assertTrue(plainText.toLowerCase().contains("qlawkus"),
-      "SSE response should contain the soul name 'Qlawkus'. Got: " + result);
+    assertTrue(result.startsWith("data:"), "SSE response should use data: prefix. Got: " + result);
   }
 
   @Test
   void chat_stream_withoutAuth_returns401() throws InterruptedException {
     Vertx vertx = Vertx.vertx();
-    WebClient client = WebClient.create(vertx);
-
-    String body = "{\"message\": \"hello\"}";
+    HttpClient client = vertx.createHttpClient();
 
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<Integer> statusCode = new AtomicReference<>();
 
-    client
-      .post(url.getPort(), url.getHost(), "/api/chat")
-      .putHeader("Content-Type", "application/json")
-      .sendBuffer(Buffer.buffer(body))
-      .onSuccess(response -> {
-        statusCode.set(response.statusCode());
-        latch.countDown();
-      })
-      .onFailure(err -> {
-        statusCode.set(-1);
-        latch.countDown();
-      });
+    client.request(HttpMethod.POST, url.getPort(), url.getHost(), "/api/chat")
+        .onSuccess(request -> {
+          request.putHeader("Content-Type", "application/json");
+          request.send("{\"message\": \"hello\"}")
+              .onSuccess(response -> {
+                statusCode.set(response.statusCode());
+                latch.countDown();
+              })
+              .onFailure(err -> {
+                statusCode.set(-1);
+                latch.countDown();
+              });
+        })
+        .onFailure(err -> {
+          statusCode.set(-1);
+          latch.countDown();
+        });
 
     assertTrue(latch.await(10, TimeUnit.SECONDS));
     client.close();

--- a/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/agent/AgentServiceTest.java
@@ -1,13 +1,12 @@
 package dev.omatheusmesmo.qlawkus.agent;
 
+import dev.omatheusmesmo.qlawkus.cognition.Mood;
 import dev.omatheusmesmo.qlawkus.cognition.Soul;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,60 +14,58 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@TestMethodOrder(OrderAnnotation.class)
 class AgentServiceTest {
 
   @Inject
   AgentService agentService;
 
+  @AfterEach
+  @Transactional
+  void resetSoul() {
+    Soul soul = Soul.findSoul();
+    soul.rename("Qlawkus");
+    soul.shiftMood(Mood.FOCUSED);
+    soul.shiftState("Awaiting first interaction. No active context or specialization yet.");
+  }
+
   @Test
-  @Order(1)
   void agentService_isInjectable() {
     assertNotNull(agentService);
   }
 
   @Test
-  @Order(2)
   void chat_returnsResponseWithSoulIdentity() {
     assertEquals("Qlawkus", currentName());
 
     String response = agentService.chat("What is your name? You must include your exact name in your reply.")
-      .collect()
-      .in(StringBuilder::new, StringBuilder::append)
-      .await()
-      .indefinitely()
-      .toString();
+        .collect()
+        .in(StringBuilder::new, StringBuilder::append)
+        .await()
+        .indefinitely()
+        .toString();
     assertNotNull(response);
     assertFalse(response.isBlank());
     assertTrue(response.toLowerCase().contains("qlawkus"),
-      "Response should contain the soul name 'Qlawkus'. Got: " + response);
+        "Response should contain the soul name 'Qlawkus'. Got: " + response);
   }
 
   @Test
-  @Order(3)
   void chat_usesToolToChangeOwnName() {
     String response = agentService.chat("Change your name to Nova. Use your available tools to do it.")
-      .collect()
-      .in(StringBuilder::new, StringBuilder::append)
-      .await()
-      .indefinitely()
-      .toString();
+        .collect()
+        .in(StringBuilder::new, StringBuilder::append)
+        .await()
+        .indefinitely()
+        .toString();
     assertNotNull(response);
     assertFalse(response.isBlank());
 
     assertEquals("Nova", currentName(),
-      "LLM should have used the updateName tool to change the soul name to 'Nova'.");
-
-    resetSoulName();
+        "LLM should have used the updateName tool to change the soul name to 'Nova'.");
   }
 
   @Transactional
   String currentName() {
     return Soul.findSoul().name;
-  }
-
-  @Transactional
-  void resetSoulName() {
-    Soul.findSoul().rename("Qlawkus");
   }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SearchMemoriesToolTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SearchMemoriesToolTest.java
@@ -1,0 +1,161 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class SearchMemoriesToolTest {
+
+  @Inject
+  SearchMemoriesTool searchMemoriesTool;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  static final String[] FACTS = {
+    "User prefers Vim over VS Code for editing",
+    "User codes in Rust and dislikes Java verbosity",
+    "User works with Kubernetes and Docker for deployment",
+    "User prefers dark theme in IDE",
+    "User's name is Matheus",
+    "User likes minimal design and clean architecture",
+    "User deploys on Fridays is forbidden at their company",
+    "User prefers constructor injection over field injection",
+    "User uses Quarkus framework for backend services",
+    "User dislikes var keyword in Java"
+  };
+
+  @BeforeAll
+  static void checkFacts() {
+    assert FACTS.length == 10;
+  }
+
+  void seedFacts() {
+    Metadata metadata = new Metadata();
+    metadata.put("source", "semantic-extractor");
+    for (String fact : FACTS) {
+      TextSegment seg = TextSegment.from(fact, metadata);
+      embeddingStore.add(embeddingModel.embed(seg).content(), seg);
+    }
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForEditorQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("code editor preference");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("vim")));
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForLanguageQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("programming language Rust");
+    assertFalse(results.isEmpty());
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForDeploymentQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("deployment policy Friday restriction");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("friday") || f.toLowerCase().contains("deploy")));
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForThemeQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("IDE appearance settings");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("dark theme")));
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForNameQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("what is my name");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("matheus")));
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForFrameworkQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("backend framework choice");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("quarkus")));
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForVarKeywordQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("Java variable declarations");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("var")));
+  }
+
+  @Test
+  void searchMemories_returnsRelevantFactsForInjectionQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("dependency injection pattern");
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().anyMatch(f -> f.toLowerCase().contains("constructor")));
+  }
+
+  @Test
+  void searchMemories_filtersUnrelatedPhysicsQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("quantum physics entanglement");
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void searchMemories_filtersUnrelatedCookingQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("cooking recipe pasta carbonara");
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void searchMemories_filtersUnrelatedFootballQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("football world cup winners");
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void searchMemories_filtersUnrelatedPaintingQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("painting techniques watercolor");
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void searchMemories_filtersUnrelatedYogaQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("yoga meditation breathing techniques");
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void searchMemories_filtersUnrelatedRealEstateQuery() {
+    seedFacts();
+    List<String> results = searchMemoriesTool.searchMemories("real estate investment strategy");
+    assertTrue(results.isEmpty());
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngineTest.java
@@ -3,103 +3,120 @@ package dev.omatheusmesmo.qlawkus.cognition;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.Test;
-
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 class SoulEngineTest {
 
-    @Inject
-    SoulEngine soulEngine;
+  @Inject
+  SoulEngine soulEngine;
 
-    @Test
-    @Transactional
-    void getSystemMessage_returnsPresentWithSeededSoul() {
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-    }
+  @AfterEach
+  @Transactional
+  void resetSoul() {
+    Soul soul = Soul.findSoul();
+    soul.rename("Qlawkus");
+    soul.shiftMood(Mood.FOCUSED);
+    soul.shiftState("Awaiting first interaction. No active context or specialization yet.");
+  }
 
-    @Test
-    @Transactional
-    void getSystemMessage_containsNameAsMarkdownHeader() {
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-        assertTrue(message.get().startsWith("# Qlawkus"));
-    }
+  @Test
+  @Transactional
+  void getSystemMessage_returnsPresentWithSeededSoul() {
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+  }
 
-    @Test
-    @Transactional
-    void getSystemMessage_containsCoreIdentity() {
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-        assertTrue(message.get().contains("Who I Am"));
-        assertTrue(message.get().contains("How I Work"));
-        assertTrue(message.get().contains("Boundaries"));
-    }
+  @Test
+  @Transactional
+  void getSystemMessage_containsNameAsMarkdownHeader() {
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().startsWith("# Qlawkus"));
+  }
 
-    @Test
-    @Transactional
-    void getSystemMessage_containsCurrentStateSection() {
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-        assertTrue(message.get().contains("## Current State"));
-    }
+  @Test
+  @Transactional
+  void getSystemMessage_containsCoreIdentity() {
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().contains("Who I Am"));
+    assertTrue(message.get().contains("How I Work"));
+    assertTrue(message.get().contains("Boundaries"));
+  }
 
-    @Test
-    @Transactional
-    void getSystemMessage_containsMoodSection() {
-        Soul soul = Soul.findSoul();
-        Mood currentMood = soul.mood;
+  @Test
+  @Transactional
+  void getSystemMessage_containsCurrentStateSection() {
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().contains("## Current State"));
+  }
 
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-        assertTrue(message.get().contains("## Current Mood"));
-        assertTrue(message.get().contains(currentMood.getDescription()));
-    }
+  @Test
+  @Transactional
+  void getSystemMessage_containsMoodSection() {
+    Soul soul = Soul.findSoul();
+    Mood currentMood = soul.mood;
 
-    @Test
-    @Transactional
-    void getSystemMessage_reflectsMoodChange() {
-        Soul soul = Soul.findSoul();
-        soul.shiftMood(Mood.CURIOUS);
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().contains("## Current Mood"));
+    assertTrue(message.get().contains(currentMood.getDescription()));
+  }
 
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-        assertTrue(message.get().contains(Mood.CURIOUS.getDescription()));
-    }
+  @Test
+  @Transactional
+  void getSystemMessage_reflectsMoodChange() {
+    Soul soul = Soul.findSoul();
+    soul.shiftMood(Mood.CURIOUS);
 
-    @Test
-    void toSystemMessage_composesAllFieldsAsMarkdown() {
-        Soul soul = new Soul();
-        soul.name = "TestAgent";
-        soul.coreIdentity = "I am a test agent.";
-        soul.currentState = "Running tests.";
-        soul.mood = Mood.PLAYFUL;
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().contains(Mood.CURIOUS.getDescription()));
+  }
 
-        String message = soul.toSystemMessage();
+  @Test
+  void toSystemMessage_composesAllFieldsAsMarkdown() {
+    Soul soul = new Soul();
+    soul.name = "TestAgent";
+    soul.coreIdentity = "I am a test agent.";
+    soul.currentState = "Running tests.";
+    soul.mood = Mood.PLAYFUL;
 
-        assertTrue(message.startsWith("# TestAgent"));
-        assertTrue(message.contains("I am a test agent."));
-        assertTrue(message.contains("## Current State"));
-        assertTrue(message.contains("Running tests."));
-        assertTrue(message.contains("## Current Mood"));
-        assertTrue(message.contains("**PLAYFUL**"));
-        assertTrue(message.contains(Mood.PLAYFUL.getDescription()));
-        assertTrue(message.contains("Adjust your approach"));
-    }
+    String message = soul.toSystemMessage();
 
-    @Test
-    @Transactional
-    void getSystemMessage_reflectsCurrentStateUpdate() {
-        String newState = "Analyzing code repository at " + System.currentTimeMillis();
-        Soul soul = Soul.findSoul();
-        soul.shiftState(newState);
+    assertTrue(message.startsWith("# TestAgent"));
+    assertTrue(message.contains("I am a test agent."));
+    assertTrue(message.contains("## Current State"));
+    assertTrue(message.contains("Running tests."));
+    assertTrue(message.contains("## Current Mood"));
+    assertTrue(message.contains("**PLAYFUL**"));
+    assertTrue(message.contains(Mood.PLAYFUL.getDescription()));
+    assertTrue(message.contains("Adjust your approach"));
+  }
 
-        Optional<String> message = soulEngine.getSystemMessage(null);
-        assertTrue(message.isPresent());
-        assertTrue(message.get().contains(newState));
-    }
+  @Test
+  @Transactional
+  void getSystemMessage_reflectsCurrentStateUpdate() {
+    String newState = "Analyzing code repository at " + System.currentTimeMillis();
+    Soul soul = Soul.findSoul();
+    soul.shiftState(newState);
+
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().contains(newState));
+  }
+
+  @Test
+  @Transactional
+  void getSystemMessage_containsMemoryHint() {
+    Optional<String> message = soulEngine.getSystemMessage(null);
+    assertTrue(message.isPresent());
+    assertTrue(message.get().contains("searchMemories"));
+  }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulTest.java
@@ -2,6 +2,7 @@ package dev.omatheusmesmo.qlawkus.cognition;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -13,73 +14,80 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 class SoulTest {
 
-    @Test
-    @Transactional
-    void findSoul_returnsSeededEntity() {
-        Soul soul = Soul.findSoul();
+  @AfterEach
+  @Transactional
+  void resetSoul() {
+    Soul soul = Soul.findSoul();
+    soul.rename("Qlawkus");
+    soul.shiftMood(Mood.FOCUSED);
+    soul.shiftState("Awaiting first interaction. No active context or specialization yet.");
+  }
 
-        assertNotNull(soul);
-        assertEquals(1L, soul.id);
-        assertEquals("Qlawkus", soul.name);
-        assertNotNull(soul.coreIdentity);
-        assertTrue(soul.coreIdentity.contains("Who I Am"));
-        assertNotNull(soul.currentState);
-        assertNotNull(soul.mood);
-        assertNotNull(soul.createdAt);
-        assertNotNull(soul.updatedAt);
-    }
+  @Test
+  @Transactional
+  void findSoul_returnsSeededEntity() {
+    Soul soul = Soul.findSoul();
 
-    @Test
-    @Transactional
-    void shiftMood_persistsNewMood() {
-        Soul soul = Soul.findSoul();
-        Mood previousMood = soul.mood;
-        Mood newMood = previousMood == Mood.CURIOUS ? Mood.ALERT : Mood.CURIOUS;
+    assertNotNull(soul);
+    assertEquals(1L, soul.id);
+    assertEquals("Qlawkus", soul.name);
+    assertNotNull(soul.coreIdentity);
+    assertTrue(soul.coreIdentity.contains("Who I Am"));
+    assertNotNull(soul.currentState);
+    assertNotNull(soul.mood);
+    assertNotNull(soul.createdAt);
+    assertNotNull(soul.updatedAt);
+  }
 
-        soul.shiftMood(newMood);
+  @Test
+  @Transactional
+  void shiftMood_persistsNewMood() {
+    Soul soul = Soul.findSoul();
+    Mood previousMood = soul.mood;
+    Mood newMood = previousMood == Mood.CURIOUS ? Mood.ALERT : Mood.CURIOUS;
 
-        Soul reloaded = Soul.findSoul();
-        assertEquals(newMood, reloaded.mood);
-    }
+    soul.shiftMood(newMood);
 
-    @Test
-    @Transactional
-    void shiftState_persistsChanges() {
-        Soul soul = Soul.findSoul();
-        String newState = "Reviewing open pull requests at " + LocalDateTime.now();
+    Soul reloaded = Soul.findSoul();
+    assertEquals(newMood, reloaded.mood);
+  }
 
-        soul.shiftState(newState);
+  @Test
+  @Transactional
+  void shiftState_persistsChanges() {
+    Soul soul = Soul.findSoul();
+    String newState = "Reviewing open pull requests at " + LocalDateTime.now();
 
-        Soul reloaded = Soul.findSoul();
-        assertEquals(newState, reloaded.currentState);
-    }
+    soul.shiftState(newState);
 
-    @Test
-    @Transactional
-    void rename_persistsNewName() {
-        Soul soul = Soul.findSoul();
-        String newName = "TestAgent" + System.currentTimeMillis();
+    Soul reloaded = Soul.findSoul();
+    assertEquals(newState, reloaded.currentState);
+  }
 
-        soul.rename(newName);
+  @Test
+  @Transactional
+  void rename_persistsNewName() {
+    Soul soul = Soul.findSoul();
+    String newName = "TestAgent" + System.currentTimeMillis();
 
-        Soul reloaded = Soul.findSoul();
-        assertEquals(newName, reloaded.name);
+    soul.rename(newName);
 
-        soul.rename("Qlawkus");
-    }
+    Soul reloaded = Soul.findSoul();
+    assertEquals(newName, reloaded.name);
+  }
 
-    @Test
-    @Transactional
-    void preUpdate_setsUpdatedAt() throws InterruptedException {
-        Soul soul = Soul.findSoul();
-        LocalDateTime beforeUpdate = soul.updatedAt;
+  @Test
+  @Transactional
+  void preUpdate_setsUpdatedAt() throws InterruptedException {
+    Soul soul = Soul.findSoul();
+    LocalDateTime beforeUpdate = soul.updatedAt;
 
-        Thread.sleep(10);
+    Thread.sleep(10);
 
-        soul.shiftState("Testing timestamp update at " + LocalDateTime.now());
+    soul.shiftState("Testing timestamp update at " + LocalDateTime.now());
 
-        Soul reloaded = Soul.findSoul();
-        assertNotNull(reloaded.updatedAt);
-        assertTrue(reloaded.updatedAt.isAfter(beforeUpdate) || reloaded.updatedAt.equals(beforeUpdate));
-    }
+    Soul reloaded = Soul.findSoul();
+    assertNotNull(reloaded.updatedAt);
+    assertTrue(reloaded.updatedAt.isAfter(beforeUpdate) || reloaded.updatedAt.equals(beforeUpdate));
+  }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateToolTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/UpdateSelfStateToolTest.java
@@ -3,6 +3,7 @@ package dev.omatheusmesmo.qlawkus.cognition;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,8 +12,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 class UpdateSelfStateToolTest {
 
-    @Inject
-    UpdateSelfStateTool updateSelfStateTool;
+  @Inject
+  UpdateSelfStateTool updateSelfStateTool;
+
+  @AfterEach
+  @Transactional
+  void resetSoul() {
+    Soul soul = Soul.findSoul();
+    soul.rename("Qlawkus");
+    soul.shiftMood(Mood.FOCUSED);
+    soul.shiftState("Awaiting first interaction. No active context or specialization yet.");
+  }
 
     @Test
     @Transactional

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/VectorFactStoreTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/VectorFactStoreTest.java
@@ -1,0 +1,57 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class VectorFactStoreTest {
+
+  @Inject
+  VectorFactStore vectorFactStore;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  @Test
+  void searchRelevantFacts_returnsMatchingFacts() {
+    Metadata metadata = new Metadata();
+    metadata.put("source", "semantic-extractor");
+    TextSegment segment = TextSegment.from("User prefers dark theme in IDE", metadata);
+    Embedding embedding = embeddingModel.embed(segment).content();
+    embeddingStore.add(embedding, segment);
+
+    List<String> facts = vectorFactStore.searchRelevantFacts("IDE theme preference", 5);
+
+    assertFalse(facts.isEmpty());
+    assertTrue(facts.stream().anyMatch(f -> f.toLowerCase().contains("dark theme")));
+  }
+
+  @Test
+  void searchRelevantFacts_returnsMultipleFacts() {
+    Metadata metadata = new Metadata();
+    metadata.put("source", "semantic-extractor");
+
+    TextSegment seg1 = TextSegment.from("User codes in Rust programming language", metadata);
+    embeddingStore.add(embeddingModel.embed(seg1).content(), seg1);
+
+    TextSegment seg2 = TextSegment.from("User works with Kubernetes and Docker", metadata);
+    embeddingStore.add(embeddingModel.embed(seg2).content(), seg2);
+
+    List<String> facts = vectorFactStore.searchRelevantFacts("programming and infrastructure tools", 10);
+
+    assertFalse(facts.isEmpty());
+  }
+}


### PR DESCRIPTION
Closes #25

## Summary

- `VectorFactStore` — searches pgvector for relevant facts using embedding similarity (minScore=0.6, maxResults=5)
- `SoulEngine.getSystemMessage()` — now appends a `## Known Facts About User` section when facts are found
- Query uses `currentState + mood.getDescription()` as context for relevant fact retrieval
- SoulEngineTest updated with `@InjectMock VectorFactStore` to keep unit tests independent of embedding model
- 2 new SoulEngineTest cases: fact injection and omission when empty
- 2 VectorFactStoreTest cases: matching facts and multiple facts retrieval