### PR TITLE
feat: implement EpisodicConsolidatorJob with Journal entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatMessageEntity.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatMessageEntity.java
@@ -13,7 +13,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 
 @Entity
@@ -34,7 +36,7 @@ public class ChatMessageEntity extends PanacheEntityBase {
   public String content;
 
   @Column(nullable = false)
-  public LocalDateTime createdAt;
+  public Instant createdAt;
 
   public static List<ChatMessageEntity> findByMemoryIdOrdered(String memoryId) {
     return list("memoryId = ?1 order by createdAt", memoryId);
@@ -44,9 +46,15 @@ public class ChatMessageEntity extends PanacheEntityBase {
     return delete("memoryId = ?1", memoryId);
   }
 
+  public static List<ChatMessageEntity> findByDateRange(LocalDate date) {
+    Instant start = date.atStartOfDay(ZoneOffset.UTC).toInstant();
+    Instant end = date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+    return list("createdAt >= ?1 and createdAt < ?2 order by createdAt", start, end);
+  }
+
   @PrePersist
   void persistCreatedAt() {
-    createdAt = LocalDateTime.now();
+    createdAt = Instant.now();
   }
 
   public static ChatMessageEntity fromChatMessage(String memoryId, ChatMessage message) {

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJob.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJob.java
@@ -1,0 +1,73 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkus.logging.Log;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@ApplicationScoped
+public class EpisodicConsolidatorJob {
+
+  @Inject
+  ChatModel chatModel;
+
+  @Scheduled(cron = "{qlawkus.consolidator.cron:0 0 3 * * ?}")
+  void consolidate() {
+    LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minusDays(1);
+    consolidateDate(yesterday);
+  }
+
+  @Transactional
+  void consolidateDate(LocalDate date) {
+    if (Journal.existsForDate(date)) {
+      Log.debugf("Journal already exists for %s, skipping", date);
+      return;
+    }
+
+    List<ChatMessageEntity> entities = ChatMessageEntity.findByDateRange(date);
+    if (entities.isEmpty()) {
+      Log.debugf("No messages found for %s, skipping", date);
+      return;
+    }
+
+    String summary = summarizeMessages(entities, date);
+
+    Journal journal = new Journal();
+    journal.date = date;
+    journal.summary = summary;
+    journal.messageCount = entities.size();
+    journal.persist();
+
+    Log.infof("Consolidated %d messages into journal for %s", entities.size(), date);
+  }
+
+  String summarizeMessages(List<ChatMessageEntity> entities, LocalDate date) {
+    StringBuilder conversation = new StringBuilder();
+    for (ChatMessageEntity entity : entities) {
+      ChatMessage message = entity.toChatMessage();
+      conversation.append(message.type().name()).append(": ").append(message).append("\n");
+    }
+
+    String prompt = """
+        Summarize this day's conversation into a concise journal entry.
+        Focus on: key topics discussed, decisions made, user preferences revealed, and notable interactions.
+        Write in third person, past tense. Be factual and brief.
+
+        Date: %s
+        Messages (%d):
+        %s""".formatted(date, entities.size(), conversation);
+
+    try {
+      return chatModel.chat(prompt);
+    } catch (Exception e) {
+      Log.warnf(e, "Failed to summarize messages for %s", date);
+      return "Consolidation failed for " + date + ": " + e.getMessage();
+    }
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Journal.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Journal.java
@@ -1,0 +1,52 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Entity
+public class Journal extends PanacheEntityBase {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  public Long id;
+
+  @Column(nullable = false, unique = true)
+  public LocalDate date;
+
+  @Column(columnDefinition = "TEXT", nullable = false)
+  public String summary;
+
+  @Column(nullable = false)
+  public int messageCount;
+
+  public Instant createdAt;
+
+  public Instant updatedAt;
+
+  public static Journal findByDate(LocalDate date) {
+    return find("date = ?1", date).firstResult();
+  }
+
+  public static boolean existsForDate(LocalDate date) {
+    return count("date = ?1", date) > 0;
+  }
+
+  @PrePersist
+  void onCreate() {
+    createdAt = Instant.now();
+    updatedAt = Instant.now();
+  }
+
+  @PreUpdate
+  void onUpdate() {
+    updatedAt = Instant.now();
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Soul.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Soul.java
@@ -10,7 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Cacheable
@@ -30,9 +30,9 @@ public class Soul extends PanacheEntityBase {
     @Enumerated(EnumType.STRING)
     public Mood mood;
 
-    public LocalDateTime createdAt;
+  public Instant createdAt;
 
-    public LocalDateTime updatedAt;
+  public Instant updatedAt;
 
     public static Soul findSoul() {
         return findById(1L);
@@ -54,16 +54,16 @@ public class Soul extends PanacheEntityBase {
         this.coreIdentity = newCoreIdentity;
     }
 
-    @PrePersist
-    void onCreate() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
-    }
+  @PrePersist
+  void onCreate() {
+    createdAt = Instant.now();
+    updatedAt = Instant.now();
+  }
 
-    @PreUpdate
-    void onUpdate() {
-        updatedAt = LocalDateTime.now();
-    }
+  @PreUpdate
+  void onUpdate() {
+    updatedAt = Instant.now();
+  }
 
     public String toSystemMessage() {
         StringBuilder sb = new StringBuilder();

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJobTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJobTest.java
@@ -1,0 +1,104 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class EpisodicConsolidatorJobTest {
+
+  @InjectMock
+  ChatModel chatModel;
+
+  @Inject
+  EpisodicConsolidatorJob job;
+
+  @AfterEach
+  @Transactional
+  void cleanup() {
+    Journal.deleteAll();
+    ChatMessageEntity.deleteAll();
+  }
+
+  @Test
+  @Transactional
+  void consolidateDate_createsJournalFromMessages() {
+    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("I prefer dark theme")).persist();
+    ChatMessageEntity.fromChatMessage("session-1", AiMessage.from("Noted, dark theme it is.")).persist();
+
+    when(chatModel.chat(anyString())).thenReturn("User expressed preference for dark theme.");
+
+    job.consolidateDate(LocalDate.now());
+
+    Journal journal = Journal.findByDate(LocalDate.now());
+    assertNotNull(journal);
+    assertTrue(journal.summary.contains("dark theme"));
+    assertEquals(2, journal.messageCount);
+  }
+
+  @Test
+  @Transactional
+  void consolidateDate_skipsWhenNoMessages() {
+    job.consolidateDate(LocalDate.of(2020, 1, 1));
+
+    assertEquals(0, Journal.count());
+  }
+
+  @Test
+  @Transactional
+  void consolidateDate_skipsWhenJournalAlreadyExists() {
+    Journal existing = new Journal();
+    existing.date = LocalDate.now();
+    existing.summary = "Existing summary";
+    existing.messageCount = 5;
+    existing.persist();
+
+    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("hello")).persist();
+
+    job.consolidateDate(LocalDate.now());
+
+    Journal journal = Journal.findByDate(LocalDate.now());
+    assertEquals("Existing summary", journal.summary);
+    assertEquals(5, journal.messageCount);
+  }
+
+  @Test
+  @Transactional
+  void consolidateDate_handlesLlmFailure() {
+    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("hello")).persist();
+
+    when(chatModel.chat(anyString())).thenThrow(new RuntimeException("LLM unavailable"));
+
+    job.consolidateDate(LocalDate.now());
+
+    Journal journal = Journal.findByDate(LocalDate.now());
+    assertNotNull(journal);
+    assertTrue(journal.summary.contains("Consolidation failed"));
+    assertEquals(1, journal.messageCount);
+  }
+
+  @Test
+  void summarizeMessages_returnsSummary() {
+    when(chatModel.chat(anyString())).thenReturn("Summarized conversation.");
+
+    ChatMessageEntity entity = ChatMessageEntity.fromChatMessage("session-1", new UserMessage("test message"));
+
+    String summary = job.summarizeMessages(java.util.List.of(entity), LocalDate.now());
+
+    assertEquals("Summarized conversation.", summary);
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/JournalTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/JournalTest.java
@@ -1,0 +1,93 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class JournalTest {
+
+  @AfterEach
+  @Transactional
+  void cleanup() {
+    Journal.deleteAll();
+  }
+
+  @Test
+  @Transactional
+  void persist_andFindById() {
+    Journal journal = new Journal();
+    journal.date = LocalDate.of(2026, 4, 22);
+    journal.summary = "Discussed Java patterns and refactoring strategies.";
+    journal.messageCount = 12;
+    journal.persist();
+
+    Journal found = Journal.findById(journal.id);
+
+    assertNotNull(found);
+    assertEquals(LocalDate.of(2026, 4, 22), found.date);
+    assertEquals("Discussed Java patterns and refactoring strategies.", found.summary);
+    assertEquals(12, found.messageCount);
+  }
+
+  @Test
+  @Transactional
+  void findByDate_returnsMatchingJournal() {
+    Journal journal = new Journal();
+    journal.date = LocalDate.of(2026, 4, 22);
+    journal.summary = "Summary A";
+    journal.messageCount = 5;
+    journal.persist();
+
+    Journal found = Journal.findByDate(LocalDate.of(2026, 4, 22));
+
+    assertNotNull(found);
+    assertEquals("Summary A", found.summary);
+  }
+
+  @Test
+  @Transactional
+  void findByDate_returnsNullForMissingDate() {
+    Journal found = Journal.findByDate(LocalDate.of(2020, 1, 1));
+
+    assertEquals(null, found);
+  }
+
+  @Test
+  @Transactional
+  void existsForDate_returnsTrueWhenPresent() {
+    Journal journal = new Journal();
+    journal.date = LocalDate.of(2026, 4, 22);
+    journal.summary = "Summary";
+    journal.messageCount = 3;
+    journal.persist();
+
+    assertTrue(Journal.existsForDate(LocalDate.of(2026, 4, 22)));
+  }
+
+  @Test
+  @Transactional
+  void existsForDate_returnsFalseWhenAbsent() {
+    assertEquals(false, Journal.existsForDate(LocalDate.of(2020, 1, 1)));
+  }
+
+  @Test
+  @Transactional
+  void prePersist_setsTimestamps() {
+    Journal journal = new Journal();
+    journal.date = LocalDate.now();
+    journal.summary = "Test";
+    journal.messageCount = 1;
+    journal.persist();
+
+    assertNotNull(journal.createdAt);
+    assertNotNull(journal.updatedAt);
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/SoulTest.java
@@ -5,7 +5,7 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,7 +56,7 @@ class SoulTest {
   @Transactional
   void shiftState_persistsChanges() {
     Soul soul = Soul.findSoul();
-    String newState = "Reviewing open pull requests at " + LocalDateTime.now();
+    String newState = "Reviewing open pull requests at " + Instant.now();
 
     soul.shiftState(newState);
 
@@ -80,11 +80,11 @@ class SoulTest {
   @Transactional
   void preUpdate_setsUpdatedAt() throws InterruptedException {
     Soul soul = Soul.findSoul();
-    LocalDateTime beforeUpdate = soul.updatedAt;
+    Instant beforeUpdate = soul.updatedAt;
 
     Thread.sleep(10);
 
-    soul.shiftState("Testing timestamp update at " + LocalDateTime.now());
+    soul.shiftState("Testing timestamp update at " + Instant.now());
 
     Soul reloaded = Soul.findSoul();
     assertNotNull(reloaded.updatedAt);


### PR DESCRIPTION
## Summary

- Implements `EpisodicConsolidatorJob` — a `@Scheduled` job (cron: 3 AM UTC) that summarizes the previous day's chat messages into a `Journal` entry using the LLM
- Creates `Journal` entity (date unique, summary TEXT, messageCount, Instant timestamps)
- Adds `ChatMessageEntity.findByDateRange(LocalDate)` for date-range queries with UTC bounds
- Migrates all timestamp fields from `LocalDateTime` to `Instant` across `Soul`, `ChatMessageEntity`, and `Journal` for UTC consistency
- Adds `quarkus-scheduler` dependency; scheduler disabled for dev/test profiles

closes #26