### PR TITLE
feat: add episodic memory flow — embed journal summaries into pgvector

### DIFF
--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJob.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJob.java
@@ -1,7 +1,12 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,6 +21,12 @@ public class EpisodicConsolidatorJob {
 
   @Inject
   ChatModel chatModel;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
 
   @Scheduled(cron = "{qlawkus.consolidator.cron:0 0 3 * * ?}")
   void consolidate() {
@@ -44,7 +55,23 @@ public class EpisodicConsolidatorJob {
     journal.messageCount = entities.size();
     journal.persist();
 
+    embedSummary(journal);
+
     Log.infof("Consolidated %d messages into journal for %s", entities.size(), date);
+  }
+
+  void embedSummary(Journal journal) {
+    try {
+      Metadata metadata = new Metadata();
+      metadata.put("source", "episodic-consolidator");
+      metadata.put("date", journal.date.toString());
+      TextSegment segment = TextSegment.from(journal.summary, metadata);
+      Embedding embedding = embeddingModel.embed(journal.summary).content();
+      embeddingStore.add(embedding, segment);
+      Log.infof("Embedded journal summary for %s", journal.date);
+    } catch (Exception e) {
+      Log.warnf(e, "Failed to embed journal summary for %s", journal.date);
+    }
   }
 
   String summarizeMessages(List<ChatMessageEntity> entities, LocalDate date) {

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Journal.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/Journal.java
@@ -10,6 +10,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 public class Journal extends PanacheEntityBase {
@@ -37,6 +38,10 @@ public class Journal extends PanacheEntityBase {
 
   public static boolean existsForDate(LocalDate date) {
     return count("date = ?1", date) > 0;
+  }
+
+  public static List<Journal> findByDateRange(LocalDate start, LocalDate end) {
+    return list("date >= ?1 and date <= ?2 order by date", start, end);
   }
 
   @PrePersist

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJobTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJobTest.java
@@ -1,8 +1,15 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -26,6 +33,12 @@ class EpisodicConsolidatorJobTest {
 
   @Inject
   EpisodicConsolidatorJob job;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
 
   @AfterEach
   @Transactional
@@ -100,5 +113,56 @@ class EpisodicConsolidatorJobTest {
     String summary = job.summarizeMessages(java.util.List.of(entity), LocalDate.now());
 
     assertEquals("Summarized conversation.", summary);
+  }
+
+  @Test
+  @Transactional
+  void consolidateDate_embedsSummaryIntoVectorStore() {
+    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("I prefer dark theme")).persist();
+    ChatMessageEntity.fromChatMessage("session-1", AiMessage.from("Noted.")).persist();
+
+    when(chatModel.chat(anyString())).thenReturn("User expressed preference for dark theme.");
+
+    job.consolidateDate(LocalDate.now());
+
+    Embedding queryEmbedding = embeddingModel.embed("dark theme preference").content();
+    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(5)
+            .minScore(0.5)
+            .build()
+    );
+
+    boolean found = results.matches().stream()
+        .map(EmbeddingMatch::embedded)
+        .map(TextSegment::text)
+        .anyMatch(text -> text.contains("dark theme"));
+
+    assertTrue(found, "Expected to find journal summary with 'dark theme' in vector store");
+  }
+
+  @Test
+  @Transactional
+  void consolidateDate_storesEpisodicMetadataInEmbedding() {
+    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("hello")).persist();
+
+    when(chatModel.chat(anyString())).thenReturn("User greeted the agent.");
+
+    job.consolidateDate(LocalDate.now());
+
+    Embedding queryEmbedding = embeddingModel.embed("user greeting").content();
+    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(5)
+            .minScore(0.5)
+            .build()
+    );
+
+    boolean hasSource = results.matches().stream()
+        .anyMatch(m -> "episodic-consolidator".equals(m.embedded().metadata().getString("source")));
+
+    assertTrue(hasSource, "Expected metadata source=episodic-consolidator");
   }
 }

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/JournalTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/JournalTest.java
@@ -90,4 +90,32 @@ class JournalTest {
     assertNotNull(journal.createdAt);
     assertNotNull(journal.updatedAt);
   }
+
+  @Test
+  @Transactional
+  void findByDateRange_returnsJournalsInRange() {
+    Journal j1 = new Journal();
+    j1.date = LocalDate.of(2026, 4, 20);
+    j1.summary = "Day 20";
+    j1.messageCount = 3;
+    j1.persist();
+
+    Journal j2 = new Journal();
+    j2.date = LocalDate.of(2026, 4, 22);
+    j2.summary = "Day 22";
+    j2.messageCount = 5;
+    j2.persist();
+
+    Journal j3 = new Journal();
+    j3.date = LocalDate.of(2026, 4, 25);
+    j3.summary = "Day 25";
+    j3.messageCount = 2;
+    j3.persist();
+
+    var results = Journal.findByDateRange(LocalDate.of(2026, 4, 19), LocalDate.of(2026, 4, 22));
+
+    assertEquals(2, results.size());
+    assertEquals(LocalDate.of(2026, 4, 20), results.get(0).date);
+    assertEquals(LocalDate.of(2026, 4, 22), results.get(1).date);
+  }
 }


### PR DESCRIPTION
## Summary

- Modifies `EpisodicConsolidatorJob` to embed journal summaries into pgvector with metadata (`source=episodic-consolidator`, `date=YYYY-MM-DD`) after persisting the Journal entity
- Adds `Journal.findByDateRange(start, end)` for date-range queries
- Journal summaries are now searchable via the existing `SearchMemoriesTool` — the agent can retrieve past episodic memories semantically
- Graceful fallback if embedding fails (journal still persisted, warning logged)

closes #27