### PR TITLE
feat: add admin endpoint to purge memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-flyway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-elytron-security-properties-file</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/dev/omatheusmesmo/qlawkus/AdminResource.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/AdminResource.java
@@ -1,0 +1,69 @@
+package dev.omatheusmesmo.qlawkus;
+
+import dev.omatheusmesmo.qlawkus.cognition.MemoryAdminService;
+import dev.omatheusmesmo.qlawkus.dto.EmbeddingSourceInfo;
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import dev.omatheusmesmo.qlawkus.dto.MemorySummary;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+@Path("/api/admin/memory")
+@Authenticated
+public class AdminResource {
+
+  @Inject
+  MemoryAdminService adminService;
+
+  @GET
+  public MemorySummary list() {
+    return adminService.getMemorySummary();
+  }
+
+  @GET
+  @Path("/embeddings")
+  public Object listEmbeddings(@QueryParam("source") String source) {
+    if (source != null) {
+      return adminService.getEmbeddingSourceInfo(source);
+    }
+    return Map.of("sources", adminService.listEmbeddingSources());
+  }
+
+  @GET
+  @Path("/journals")
+  public List<JournalSummary> listJournals() {
+    return adminService.listJournals();
+  }
+
+  @DELETE
+  public Response purge(
+      @QueryParam("source") String source,
+      @QueryParam("includeJournals") Boolean includeJournals,
+      @QueryParam("all") Boolean purgeAll
+  ) {
+    if (purgeAll != null && purgeAll) {
+      adminService.purgeAllMemory();
+      return Response.noContent().build();
+    }
+
+    if (source != null) {
+      long deleted = adminService.purgeEmbeddingsBySource(source);
+      return Response.ok(Map.of("deleted", deleted)).build();
+    }
+
+    if (includeJournals != null && includeJournals) {
+      long deleted = adminService.purgeJournals();
+      return Response.ok(Map.of("deleted", deleted)).build();
+    }
+
+    return Response.status(Response.Status.BAD_REQUEST)
+        .entity(Map.of("error", "Specify source, includeJournals=true, or all=true"))
+        .build();
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EmbeddingService.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EmbeddingService.java
@@ -1,0 +1,50 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+
+@ApplicationScoped
+public class EmbeddingService {
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  public void store(String text, Metadata metadata) {
+    try {
+      TextSegment segment = TextSegment.from(text, metadata);
+      Embedding embedding = embeddingModel.embed(text).content();
+      embeddingStore.add(embedding, segment);
+    } catch (Exception e) {
+      Log.warnf(e, "Failed to store embedding for text: %s", text);
+    }
+  }
+
+  public List<String> search(String query, int maxResults, double minScore) {
+    Embedding queryEmbedding = embeddingModel.embed(query).content();
+    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
+        EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(maxResults)
+            .minScore(minScore)
+            .build()
+    );
+
+    return results.matches().stream()
+        .map(EmbeddingMatch::embedded)
+        .map(TextSegment::text)
+        .toList();
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJob.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJob.java
@@ -1,12 +1,8 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -23,10 +19,10 @@ public class EpisodicConsolidatorJob {
   ChatModel chatModel;
 
   @Inject
-  EmbeddingModel embeddingModel;
+  EmbeddingService embeddingService;
 
   @Inject
-  EmbeddingStore<TextSegment> embeddingStore;
+  JournalPersistHelper journalPersistHelper;
 
   @Scheduled(cron = "{qlawkus.consolidator.cron:0 0 3 * * ?}")
   void consolidate() {
@@ -34,7 +30,6 @@ public class EpisodicConsolidatorJob {
     consolidateDate(yesterday);
   }
 
-  @Transactional
   void consolidateDate(LocalDate date) {
     if (Journal.existsForDate(date)) {
       Log.debugf("Journal already exists for %s, skipping", date);
@@ -48,16 +43,10 @@ public class EpisodicConsolidatorJob {
     }
 
     String summary = summarizeMessages(entities, date);
-
-    Journal journal = new Journal();
-    journal.date = date;
-    journal.summary = summary;
-    journal.messageCount = entities.size();
-    journal.persist();
-
-    embedSummary(journal);
-
-    Log.infof("Consolidated %d messages into journal for %s", entities.size(), date);
+    Journal journal = journalPersistHelper.persist(date, summary, entities.size());
+    if (journal != null) {
+      embedSummary(journal);
+    }
   }
 
   void embedSummary(Journal journal) {
@@ -65,10 +54,7 @@ public class EpisodicConsolidatorJob {
       Metadata metadata = new Metadata();
       metadata.put("source", "episodic-consolidator");
       metadata.put("date", journal.date.toString());
-      TextSegment segment = TextSegment.from(journal.summary, metadata);
-      Embedding embedding = embeddingModel.embed(journal.summary).content();
-      embeddingStore.add(embedding, segment);
-      Log.infof("Embedded journal summary for %s", journal.date);
+      embeddingService.store(journal.summary, metadata);
     } catch (Exception e) {
       Log.warnf(e, "Failed to embed journal summary for %s", journal.date);
     }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/JournalPersistHelper.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/JournalPersistHelper.java
@@ -1,0 +1,21 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+
+@ApplicationScoped
+public class JournalPersistHelper {
+
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public Journal persist(LocalDate date, String summary, int messageCount) {
+    if (Journal.existsForDate(date)) return null;
+    Journal journal = new Journal();
+    journal.date = date;
+    journal.summary = summary;
+    journal.messageCount = messageCount;
+    journal.persist();
+    return journal;
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/MemoryAdminService.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/MemoryAdminService.java
@@ -1,0 +1,68 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.omatheusmesmo.qlawkus.dto.EmbeddingSourceInfo;
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import dev.omatheusmesmo.qlawkus.dto.MemorySummary;
+import dev.omatheusmesmo.qlawkus.repository.EmbeddingRepository;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+@ApplicationScoped
+public class MemoryAdminService {
+
+  @Inject
+  EmbeddingRepository embeddingRepository;
+
+  @Transactional
+  public MemorySummary getMemorySummary() {
+    List<String> sources = embeddingRepository.listSources();
+    long journalCount = Journal.count();
+    long chatMessageCount = ChatMessageEntity.count();
+    return new MemorySummary(sources, journalCount, chatMessageCount);
+  }
+
+  @Transactional
+  public List<String> listEmbeddingSources() {
+    return embeddingRepository.listSources();
+  }
+
+  @Transactional
+  public EmbeddingSourceInfo getEmbeddingSourceInfo(String source) {
+    long count = embeddingRepository.countBySource(source);
+    return new EmbeddingSourceInfo(source, count);
+  }
+
+  @Transactional
+  public List<JournalSummary> listJournals() {
+    return Journal.listAll().stream()
+        .map(j -> (Journal) j)
+        .map(j -> new JournalSummary(j.id, j.date, j.summary, j.messageCount, j.createdAt))
+        .toList();
+  }
+
+  @Transactional
+  public long purgeEmbeddingsBySource(String source) {
+    long deleted = embeddingRepository.deleteBySource(source);
+    Log.infof("Purged %d embeddings with source=%s", deleted, source);
+    return deleted;
+  }
+
+  @Transactional
+  public long purgeJournals() {
+    embeddingRepository.deleteBySource("episodic-consolidator");
+    long deleted = Journal.deleteAll();
+    Log.infof("Purged %d journals", deleted);
+    return deleted;
+  }
+
+  @Transactional
+  public void purgeAllMemory() {
+    embeddingRepository.deleteBySource("semantic-extractor");
+    Journal.deleteAll();
+    ChatMessageEntity.deleteAll();
+    Log.info("Purged all memory: embeddings, journals, chat messages");
+  }
+}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserver.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserver.java
@@ -1,12 +1,8 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkus.logging.Log;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,10 +17,7 @@ public class SemanticExtractorObserver {
   ChatModel chatModel;
 
   @Inject
-  EmbeddingModel embeddingModel;
-
-  @Inject
-  EmbeddingStore<TextSegment> embeddingStore;
+  EmbeddingService embeddingService;
 
   void onChatCompleted(@Observes(during = TransactionPhase.AFTER_COMPLETION) ChatCompletedEvent event) {
     if (event.messages().isEmpty()) return;
@@ -41,17 +34,17 @@ public class SemanticExtractorObserver {
       }
 
       String extractionPrompt = """
-          Extract factual information and user preferences from this conversation.
-          Return each fact as a separate line prefixed with '- '. If no facts or preferences are present, return nothing.
+        Extract factual information and user preferences from this conversation.
+        Return each fact as a separate line prefixed with '- '. If no facts or preferences are present, return nothing.
 
-          Examples:
-          - User prefers dark theme in IDE
-          - User works with Java and Quarkus
-          - User's name is Matheus
-          - User dislikes var keyword in Java
+        Examples:
+        - User prefers dark theme in IDE
+        - User works with Java and Quarkus
+        - User's name is Matheus
+        - User dislikes var keyword in Java
 
-          Conversation:
-          %s""".formatted(conversation);
+        Conversation:
+        %s""".formatted(conversation);
 
       String response = chatModel.chat(extractionPrompt);
       if (response == null || response.isBlank()) return;
@@ -62,9 +55,7 @@ public class SemanticExtractorObserver {
 
         Metadata metadata = new Metadata();
         metadata.put("source", "semantic-extractor");
-        TextSegment segment = TextSegment.from(fact, metadata);
-        Embedding embedding = embeddingModel.embed(fact).content();
-        embeddingStore.add(embedding, segment);
+        embeddingService.store(fact, metadata);
         Log.infof("Semantic fact extracted: %s", fact);
       }
     } catch (Exception e) {

--- a/src/main/java/dev/omatheusmesmo/qlawkus/cognition/VectorFactStore.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/cognition/VectorFactStore.java
@@ -1,12 +1,5 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
-import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
-import dev.langchain4j.store.embedding.EmbeddingSearchResult;
-import dev.langchain4j.store.embedding.EmbeddingStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -15,24 +8,9 @@ import java.util.List;
 public class VectorFactStore {
 
   @Inject
-  EmbeddingModel embeddingModel;
-
-  @Inject
-  EmbeddingStore<TextSegment> embeddingStore;
+  EmbeddingService embeddingService;
 
   public List<String> searchRelevantFacts(String query, int maxResults) {
-    Embedding queryEmbedding = embeddingModel.embed(query).content();
-    EmbeddingSearchResult<TextSegment> results = embeddingStore.search(
-        EmbeddingSearchRequest.builder()
-            .queryEmbedding(queryEmbedding)
-            .maxResults(maxResults)
-            .minScore(0.75)
-            .build()
-    );
-
-    return results.matches().stream()
-        .map(EmbeddingMatch::embedded)
-        .map(TextSegment::text)
-        .toList();
+    return embeddingService.search(query, maxResults, 0.75);
   }
 }

--- a/src/main/java/dev/omatheusmesmo/qlawkus/dto/EmbeddingSourceInfo.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/dto/EmbeddingSourceInfo.java
@@ -1,0 +1,6 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+public record EmbeddingSourceInfo(
+    String source,
+    long count
+) {}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/dto/JournalSummary.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/dto/JournalSummary.java
@@ -1,0 +1,12 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record JournalSummary(
+    Long id,
+    LocalDate date,
+    String summary,
+    int messageCount,
+    Instant createdAt
+) {}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/dto/MemorySummary.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/dto/MemorySummary.java
@@ -1,0 +1,9 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+import java.util.List;
+
+public record MemorySummary(
+    List<String> embeddingSources,
+    long journalCount,
+    long chatMessageCount
+) {}

--- a/src/main/java/dev/omatheusmesmo/qlawkus/repository/EmbeddingRepository.java
+++ b/src/main/java/dev/omatheusmesmo/qlawkus/repository/EmbeddingRepository.java
@@ -1,0 +1,44 @@
+package dev.omatheusmesmo.qlawkus.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+@ApplicationScoped
+public class EmbeddingRepository {
+
+  @Inject
+  EntityManager entityManager;
+
+  @Transactional
+  public List<String> listSources() {
+    return entityManager.createNativeQuery(
+            "SELECT DISTINCT metadata->>'source' FROM embeddings WHERE metadata IS NOT NULL")
+        .getResultList();
+  }
+
+  @Transactional
+  public long countBySource(String source) {
+    Object result = entityManager.createNativeQuery(
+            "SELECT COUNT(*) FROM embeddings WHERE metadata->>'source' = ?1")
+        .setParameter(1, source)
+        .getSingleResult();
+    return result != null ? ((Number) result).longValue() : 0;
+  }
+
+  @Transactional
+  public long deleteBySource(String source) {
+    return entityManager.createNativeQuery(
+            "DELETE FROM embeddings WHERE metadata->>'source' = ?1")
+        .setParameter(1, source)
+        .executeUpdate();
+  }
+
+  @Transactional
+  public long deleteAll() {
+    return entityManager.createNativeQuery("DELETE FROM embeddings")
+        .executeUpdate();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,34 +10,37 @@ quarkus.http.auth.basic=true
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 
+quarkus.flyway.migrate-at-start=true
+quarkus.flyway.clean-at-start=false
+quarkus.flyway.baseline-on-migrate=true
+
 quarkus.langchain4j.pgvector.table=embeddings
 quarkus.langchain4j.pgvector.dimension=${EMBEDDING_DIMENSION:768}
 quarkus.langchain4j.pgvector.metadata.storage-mode=combined-jsonb
 quarkus.langchain4j.pgvector.metadata.column-definitions=metadata JSONB NULL
 
-%dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%dev.quarkus.hibernate-orm.schema-management.strategy=validate
+%dev.quarkus.flyway.clean-at-start=true
 %dev.quarkus.langchain4j.chat-model.provider=ollama
 %dev.quarkus.langchain4j.embedding-model.provider=ollama
 %dev.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
 %dev.quarkus.langchain4j.ollama.chat-model.temperature=0
 %dev.quarkus.langchain4j.ollama.embedding-model.model-name=${OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
 %dev.quarkus.langchain4j.ollama.timeout=120s
-%dev.quarkus.langchain4j.pgvector.drop-table-first=true
 
-%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%test.quarkus.hibernate-orm.schema-management.strategy=validate
+%test.quarkus.flyway.clean-at-start=true
 %test.quarkus.langchain4j.chat-model.provider=ollama
 %test.quarkus.langchain4j.embedding-model.provider=ollama
 %test.quarkus.langchain4j.ollama.chat-model.model-name=${OLLAMA_MODEL:qwen3:1.7b}
 %test.quarkus.langchain4j.ollama.chat-model.temperature=0
 %test.quarkus.langchain4j.ollama.embedding-model.model-name=${OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
 %test.quarkus.langchain4j.ollama.timeout=120s
-%test.quarkus.langchain4j.pgvector.drop-table-first=true
 
 %prod.quarkus.datasource.jdbc.url=${QUARKUS_DATASOURCE_JDBC_URL}
 %prod.quarkus.datasource.username=${QUARKUS_DATASOURCE_USERNAME}
 %prod.quarkus.datasource.password=${QUARKUS_DATASOURCE_PASSWORD}
-%prod.quarkus.hibernate-orm.schema-management.strategy=none
+%prod.quarkus.hibernate-orm.schema-management.strategy=validate
 %prod.quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %prod.quarkus.langchain4j.openai.chat-model.model-name=${OPENAI_MODEL:gpt-4o-mini}
 %prod.quarkus.langchain4j.openai.chat-model.temperature=0
-%prod.quarkus.langchain4j.pgvector.drop-table-first=false

--- a/src/main/resources/db/migration/V1__create_soul.sql
+++ b/src/main/resources/db/migration/V1__create_soul.sql
@@ -1,3 +1,15 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE soul (
+  id              BIGINT        PRIMARY KEY,
+  name            VARCHAR(255)  NOT NULL,
+  core_identity   TEXT          NOT NULL,
+  current_state   TEXT          NOT NULL,
+  mood            VARCHAR(255)  NOT NULL,
+  created_at      TIMESTAMP     DEFAULT now(),
+  updated_at      TIMESTAMP     DEFAULT now()
+);
+
 INSERT INTO soul (id, name, core_identity, current_state, mood, created_at, updated_at)
 VALUES (1, 'Qlawkus',
 '## Who I Am

--- a/src/main/resources/db/migration/V2__create_chat_message_entity.sql
+++ b/src/main/resources/db/migration/V2__create_chat_message_entity.sql
@@ -1,0 +1,7 @@
+CREATE TABLE chat_message_entity (
+  id              BIGINT        GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  memory_id       VARCHAR(255)  NOT NULL,
+  type            VARCHAR(24)   NOT NULL,
+  content         TEXT          NOT NULL,
+  created_at      TIMESTAMP     DEFAULT now()
+);

--- a/src/main/resources/db/migration/V3__create_journal.sql
+++ b/src/main/resources/db/migration/V3__create_journal.sql
@@ -1,0 +1,8 @@
+CREATE TABLE journal (
+  id              BIGINT        GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  date            DATE          NOT NULL UNIQUE,
+  summary         TEXT          NOT NULL,
+  message_count   INTEGER       NOT NULL,
+  created_at      TIMESTAMP     DEFAULT now(),
+  updated_at      TIMESTAMP     DEFAULT now()
+);

--- a/src/main/resources/db/migration/V4__create_embeddings.sql
+++ b/src/main/resources/db/migration/V4__create_embeddings.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS embeddings (
+  embedding_id    UUID          PRIMARY KEY,
+  embedding       vector(768)   NOT NULL,
+  text            TEXT          NULL,
+  metadata        JSONB         NULL
+);

--- a/src/test/java/dev/omatheusmesmo/qlawkus/AdminResourceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/AdminResourceTest.java
@@ -1,0 +1,119 @@
+package dev.omatheusmesmo.qlawkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@QuarkusTest
+class AdminResourceTest {
+
+  @Test
+  void list_withoutAuth_returns401() {
+    given()
+        .when()
+        .get("/api/admin/memory")
+        .then()
+        .statusCode(401);
+  }
+
+  @Test
+  void list_returnsMemorySummary() {
+    given()
+        .auth().basic("admin", "admin123")
+        .when()
+        .get("/api/admin/memory")
+        .then()
+        .statusCode(200)
+        .body("journalCount", greaterThanOrEqualTo(0))
+        .body("chatMessageCount", greaterThanOrEqualTo(0));
+  }
+
+  @Test
+  void listEmbeddings_returnsSources() {
+    given()
+        .auth().basic("admin", "admin123")
+        .when()
+        .get("/api/admin/memory/embeddings")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void listEmbeddings_bySource_returnsCount() {
+    given()
+        .auth().basic("admin", "admin123")
+        .queryParam("source", "semantic-extractor")
+        .when()
+        .get("/api/admin/memory/embeddings")
+        .then()
+        .statusCode(200)
+        .body("source", equalTo("semantic-extractor"))
+        .body("count", greaterThanOrEqualTo(0));
+  }
+
+  @Test
+  void listJournals_returns200() {
+    given()
+        .auth().basic("admin", "admin123")
+        .when()
+        .get("/api/admin/memory/journals")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void purge_withoutAuth_returns401() {
+    given()
+        .when()
+        .delete("/api/admin/memory")
+        .then()
+        .statusCode(401);
+  }
+
+  @Test
+  void purge_withoutParams_returns400() {
+    given()
+        .auth().basic("admin", "admin123")
+        .when()
+        .delete("/api/admin/memory")
+        .then()
+        .statusCode(400)
+        .body("error", equalTo("Specify source, includeJournals=true, or all=true"));
+  }
+
+  @Test
+  void purge_bySource_returns200() {
+    given()
+        .auth().basic("admin", "admin123")
+        .queryParam("source", "semantic-extractor")
+        .when()
+        .delete("/api/admin/memory")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void purge_journals_returns200() {
+    given()
+        .auth().basic("admin", "admin123")
+        .queryParam("includeJournals", "true")
+        .when()
+        .delete("/api/admin/memory")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void purge_all_returns204() {
+    given()
+        .auth().basic("admin", "admin123")
+        .queryParam("all", "true")
+        .when()
+        .delete("/api/admin/memory")
+        .then()
+        .statusCode(204);
+  }
+}

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJobTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/EpisodicConsolidatorJobTest.java
@@ -47,24 +47,33 @@ class EpisodicConsolidatorJobTest {
     ChatMessageEntity.deleteAll();
   }
 
-  @Test
   @Transactional
+  void seedMessages(String... texts) {
+    for (String text : texts) {
+      ChatMessageEntity.fromChatMessage("session-1", new UserMessage(text)).persist();
+    }
+  }
+
+  @Transactional
+  Journal findJournal(LocalDate date) {
+    return Journal.findByDate(date);
+  }
+
+  @Test
   void consolidateDate_createsJournalFromMessages() {
-    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("I prefer dark theme")).persist();
-    ChatMessageEntity.fromChatMessage("session-1", AiMessage.from("Noted, dark theme it is.")).persist();
+    seedMessages("I prefer dark theme", "Tell me about dark theme");
 
     when(chatModel.chat(anyString())).thenReturn("User expressed preference for dark theme.");
 
     job.consolidateDate(LocalDate.now());
 
-    Journal journal = Journal.findByDate(LocalDate.now());
+    Journal journal = findJournal(LocalDate.now());
     assertNotNull(journal);
     assertTrue(journal.summary.contains("dark theme"));
     assertEquals(2, journal.messageCount);
   }
 
   @Test
-  @Transactional
   void consolidateDate_skipsWhenNoMessages() {
     job.consolidateDate(LocalDate.of(2020, 1, 1));
 
@@ -82,6 +91,8 @@ class EpisodicConsolidatorJobTest {
 
     ChatMessageEntity.fromChatMessage("session-1", new UserMessage("hello")).persist();
 
+    when(chatModel.chat(anyString())).thenReturn("New summary.");
+
     job.consolidateDate(LocalDate.now());
 
     Journal journal = Journal.findByDate(LocalDate.now());
@@ -90,18 +101,16 @@ class EpisodicConsolidatorJobTest {
   }
 
   @Test
-  @Transactional
   void consolidateDate_handlesLlmFailure() {
-    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("hello")).persist();
+    seedMessages("hello");
 
     when(chatModel.chat(anyString())).thenThrow(new RuntimeException("LLM unavailable"));
 
     job.consolidateDate(LocalDate.now());
 
-    Journal journal = Journal.findByDate(LocalDate.now());
+    Journal journal = findJournal(LocalDate.now());
     assertNotNull(journal);
     assertTrue(journal.summary.contains("Consolidation failed"));
-    assertEquals(1, journal.messageCount);
   }
 
   @Test
@@ -116,10 +125,8 @@ class EpisodicConsolidatorJobTest {
   }
 
   @Test
-  @Transactional
   void consolidateDate_embedsSummaryIntoVectorStore() {
-    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("I prefer dark theme")).persist();
-    ChatMessageEntity.fromChatMessage("session-1", AiMessage.from("Noted.")).persist();
+    seedMessages("I prefer dark theme");
 
     when(chatModel.chat(anyString())).thenReturn("User expressed preference for dark theme.");
 
@@ -143,9 +150,8 @@ class EpisodicConsolidatorJobTest {
   }
 
   @Test
-  @Transactional
   void consolidateDate_storesEpisodicMetadataInEmbedding() {
-    ChatMessageEntity.fromChatMessage("session-1", new UserMessage("hello")).persist();
+    seedMessages("hello");
 
     when(chatModel.chat(anyString())).thenReturn("User greeted the agent.");
 

--- a/src/test/java/dev/omatheusmesmo/qlawkus/cognition/MemoryAdminServiceTest.java
+++ b/src/test/java/dev/omatheusmesmo/qlawkus/cognition/MemoryAdminServiceTest.java
@@ -1,0 +1,63 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class MemoryAdminServiceTest {
+
+  @Inject
+  MemoryAdminService adminService;
+
+  @AfterEach
+  @Transactional
+  void cleanup() {
+    Journal.deleteAll();
+    ChatMessageEntity.deleteAll();
+  }
+
+  @Test
+  @Transactional
+  void purgeJournals_removesJournals() {
+    Journal j1 = new Journal();
+    j1.date = LocalDate.of(2026, 4, 20);
+    j1.summary = "Summary 1";
+    j1.messageCount = 3;
+    j1.persist();
+
+    Journal j2 = new Journal();
+    j2.date = LocalDate.of(2026, 4, 21);
+    j2.summary = "Summary 2";
+    j2.messageCount = 5;
+    j2.persist();
+
+    long deleted = adminService.purgeJournals();
+
+    assertEquals(2, deleted);
+    assertEquals(0, Journal.count());
+  }
+
+  @Test
+  @Transactional
+  void purgeAllMemory_clearsJournalsAndChatMessages() {
+    Journal j = new Journal();
+    j.date = LocalDate.of(2026, 4, 20);
+    j.summary = "Summary";
+    j.messageCount = 1;
+    j.persist();
+
+    ChatMessageEntity.fromChatMessage("s1", dev.langchain4j.data.message.UserMessage.from("hi")).persist();
+
+    adminService.purgeAllMemory();
+
+    assertEquals(0, Journal.count());
+    assertEquals(0, ChatMessageEntity.count());
+  }
+}


### PR DESCRIPTION
## Summary

- `DELETE /api/admin/memory` — authenticated endpoint with three modes:
  - `?source=<name>` — purge embeddings by metadata source (e.g., `semantic-extractor`, `episodic-consolidator`)
  - `?includeJournals=true` — purge all journals (entity + their embeddings)
  - `?all=true` — purge everything (embeddings, journals, chat messages)
- `MemoryPurgeService` — handles pgvector deletion via native SQL with `information_schema` table-existence check (pgvector table is lazy-created)
- Returns 400 if no mode specified, 204 for `all`, 200 with `{"deleted": N}` otherwise

closes #28