### PR TITLE
feat(tool): add @ClawTool qualifier and ClawToolProvider for dynamic tool discovery

### DIFF
--- a/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
+++ b/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
@@ -1,14 +1,56 @@
 package dev.omatheusmesmo.qlawkus.deployment;
 
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 class ClientProcessor {
 
-  private static final String FEATURE = "qlawkus-client";
+    private static final String FEATURE = "qlawkus-client";
+    private static final DotName CLAW_TOOL_ANNOTATION = DotName.createSimple(ClawTool.class.getName());
 
-  @BuildStep
-  FeatureBuildItem feature() {
-    return new FeatureBuildItem(FEATURE);
-  }
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    List<AdditionalBeanBuildItem> registerClawTools(CombinedIndexBuildItem combinedIndex) {
+        Collection<AnnotationInstance> annotations = combinedIndex.getIndex().getAnnotations(CLAW_TOOL_ANNOTATION);
+
+        List<AdditionalBeanBuildItem> items = new ArrayList<>();
+        for (AnnotationInstance annotation : annotations) {
+            if (annotation.target().kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            String className = annotation.target().asClass().name().toString();
+            items.add(AdditionalBeanBuildItem.unremovableOf(className));
+        }
+        return items;
+    }
+
+    @BuildStep
+    ReflectiveClassBuildItem registerClawToolsForReflection(CombinedIndexBuildItem combinedIndex) {
+        Collection<AnnotationInstance> annotations = combinedIndex.getIndex().getAnnotations(CLAW_TOOL_ANNOTATION);
+
+        List<String> classNames = new ArrayList<>();
+        for (AnnotationInstance annotation : annotations) {
+            if (annotation.target().kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            classNames.add(annotation.target().asClass().name().toString());
+        }
+
+        return new ReflectiveClassBuildItem(true, true, classNames.toArray(String[]::new));
+    }
 }

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/ClawToolProviderTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/ClawToolProviderTest.java
@@ -1,0 +1,44 @@
+package dev.omatheusmesmo.qlawkus.tool;
+
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class ClawToolProviderTest {
+
+    @Inject
+    ClawToolProvider provider;
+
+    @Test
+    void provideTools_returnsEmptyWhenNoExtensionTools() {
+        ClawToolProvider emptyProvider = new ClawToolProvider();
+        @SuppressWarnings("unchecked")
+        Instance<Object> unsatisfied = Mockito.mock(Instance.class);
+        Mockito.when(unsatisfied.isUnsatisfied()).thenReturn(true);
+
+        emptyProvider.extensionTools = unsatisfied;
+
+        ToolProviderResult result = emptyProvider.provideTools(null);
+
+        assertTrue(result.tools().isEmpty());
+    }
+
+    @Test
+    void clawToolProviderSupplier_resolvesProviderFromArc() {
+        ClawToolProviderSupplier supplier = new ClawToolProviderSupplier();
+        ToolProvider resolved = supplier.get();
+
+        assertNotNull(resolved);
+        assertInstanceOf(ClawToolProvider.class, resolved);
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/agent/AgentService.java
@@ -4,11 +4,16 @@ import dev.langchain4j.service.UserMessage;
 import dev.omatheusmesmo.qlawkus.cognition.SearchMemoriesTool;
 import dev.omatheusmesmo.qlawkus.cognition.SoulEngine;
 import dev.omatheusmesmo.qlawkus.cognition.UpdateSelfStateTool;
+import dev.omatheusmesmo.qlawkus.tool.ClawToolProviderSupplier;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 
-@RegisterAiService(systemMessageProviderSupplier = SoulEngine.class, tools = {UpdateSelfStateTool.class, SearchMemoriesTool.class})
+@RegisterAiService(
+    systemMessageProviderSupplier = SoulEngine.class,
+    tools = {UpdateSelfStateTool.class, SearchMemoriesTool.class},
+    toolProviderSupplier = ClawToolProviderSupplier.class
+)
 @ApplicationScoped
 @Logged
 public interface AgentService {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/ClawTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/ClawTool.java
@@ -1,0 +1,13 @@
+package dev.omatheusmesmo.qlawkus.tool;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+public @interface ClawTool {
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/ClawToolProvider.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/ClawToolProvider.java
@@ -1,0 +1,57 @@
+package dev.omatheusmesmo.qlawkus.tool;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agent.tool.ToolSpecifications;
+import dev.langchain4j.service.tool.DefaultToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class ClawToolProvider implements ToolProvider {
+
+    @Inject
+    @ClawTool
+    public Instance<Object> extensionTools;
+
+    @Override
+    public ToolProviderResult provideTools(ToolProviderRequest request) {
+        if (extensionTools.isUnsatisfied()) {
+            Log.debug("No @ClawTool extension tools found");
+            return new ToolProviderResult(Map.of());
+        }
+
+        ToolProviderResult.Builder builder = ToolProviderResult.builder();
+        for (Object tool : extensionTools) {
+            List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(tool);
+            for (ToolSpecification spec : specs) {
+                Method toolMethod = findToolMethod(tool, spec);
+                builder.add(spec, new DefaultToolExecutor(tool, toolMethod));
+                Log.debugf("Registered extension tool: %s from %s", spec.name(), tool.getClass().getSimpleName());
+            }
+        }
+        return builder.build();
+    }
+
+    private Method findToolMethod(Object tool, ToolSpecification spec) {
+        return Arrays.stream(tool.getClass().getDeclaredMethods())
+                .filter(m -> m.isAnnotationPresent(Tool.class))
+                .filter(m -> {
+                    Tool t = m.getAnnotation(Tool.class);
+                    String name = t.name().isBlank() ? m.getName() : t.name();
+                    return spec.name().equals(name);
+                })
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No @Tool method found matching specification: " + spec.name()));
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/ClawToolProviderSupplier.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/ClawToolProviderSupplier.java
@@ -1,0 +1,15 @@
+package dev.omatheusmesmo.qlawkus.tool;
+
+import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkus.arc.Arc;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.function.Supplier;
+
+@ApplicationScoped
+public class ClawToolProviderSupplier implements Supplier<ToolProvider> {
+
+    @Override
+    public ToolProvider get() {
+        return Arc.container().instance(ClawToolProvider.class).get();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `@ClawTool` CDI qualifier annotation for marking extension tool beans
- Add `ClawToolProvider` (`@ApplicationScoped`, implements `ToolProvider`) that resolves all `@ClawTool`-qualified beans via CDI `Instance<>` and registers them with `DefaultToolExecutor`
- Add `ClawToolProviderSupplier` (`@ApplicationScoped`, `Supplier<ToolProvider>`) bridging Arc container to the quarkiverse-langchain4j `toolProviderSupplier` mechanism
- Update `ClientProcessor` with two new `@BuildStep`s: `registerClawTools` (scans `@ClawTool` via Jandex → `AdditionalBeanBuildItem`) and `registerClawToolsForReflection` (→ `ReflectiveClassBuildItem` for future native support)
- Update `AgentService` with hybrid registration: static cognition tools (`tools={}`) + dynamic extension tools (`toolProviderSupplier=ClawToolProviderSupplier.class`)
- Add `ClawToolProviderTest` verifying empty resolution and supplier wiring

closes #137