### PR TITLE
fix(native): use ReflectiveClassBuildItem builder and verify Mandrel native build

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,5 +1,5 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add these to your ~/.sdkman/etc/config:
 # sdkman_auto_env=true
-java=25.0.2-open
+java=25.0.2.r25-mandrel
 maven=3.9.9

--- a/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
+++ b/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
@@ -62,6 +62,9 @@ class ClientProcessor {
             classNames.add(annotation.target().asClass().name().toString());
         }
 
-        return new ReflectiveClassBuildItem(true, true, classNames.toArray(String[]::new));
+        return ReflectiveClassBuildItem.builder(classNames)
+                .methods()
+                .fields()
+                .build();
     }
 }

--- a/integration-tests/src/test/java/dev/omatheusmesmo/qlawkus/it/SmokeIT.java
+++ b/integration-tests/src/test/java/dev/omatheusmesmo/qlawkus/it/SmokeIT.java
@@ -1,7 +1,45 @@
 package dev.omatheusmesmo.qlawkus.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusIntegrationTest
-class SmokeIT extends SmokeTest {
+class SmokeIT {
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void nativeImage_startsAndRespondsOnApiChat() throws Exception {
+        String auth = Base64.getEncoder().encodeToString("qlawkus:qlawkus-test".getBytes());
+
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUri + "api/chat"))
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .header("Authorization", "Basic " + auth)
+                .POST(HttpRequest.BodyPublishers.ofString("{\"message\":\"Say exactly: hello\"}"))
+                .build();
+
+        HttpResponse<String> httpResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, httpResponse.statusCode(),
+                "Native image SSE endpoint should return 200");
+        assertFalse(httpResponse.body().isBlank(),
+                "Native image SSE response should contain LLM output");
+    }
 }


### PR DESCRIPTION
## Summary
- Migrate from deprecated `ReflectiveClassBuildItem(boolean,boolean,String...)` to builder pattern API
- Rewrite `SmokeIT` as standalone HTTP-only test compatible with `@QuarkusIntegrationTest` (`@Inject` not supported in integration test mode)
- Switch `.sdkmanrc` from Temurin to Mandrel 25.0.2.r25

## Verification
- JVM build: 56 unit tests + 48 integration tests — all passing
- Native build: Mandrel 25.0.2 — BUILD SUCCESS
- SmokeIT against native image — PASS

Closes #140