### PR TITLE
feat(shell): add ShellTool with runCommand

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qlawkus-app</artifactId>

--- a/client/deployment/pom.xml
+++ b/client/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus-client-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
@@ -1,0 +1,140 @@
+package dev.omatheusmesmo.qlawkus.tool.shell;
+
+import dev.omatheusmesmo.qlawkus.dto.CommandResult;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class ShellToolTest {
+
+    @Inject
+    @ClawTool
+    ShellTool shellTool;
+
+    @Test
+    void runCommand_success_returnsStdoutAndZeroExitCode() {
+        String echoCmd = ShellTool.IS_WINDOWS ? "echo hello" : "echo hello";
+        CommandResult result = shellTool.runCommand(echoCmd, null, null);
+
+        assertEquals(0, result.exitCode(), "Exit code should be 0");
+        assertTrue(result.stdout().contains("hello"), "stdout should contain 'hello'");
+        assertTrue(result.stderr().isEmpty() || result.stderr().isBlank(), "stderr should be empty");
+        assertFalse(result.truncated(), "Output should not be truncated");
+        assertTrue(result.durationMs() >= 0, "Duration should be non-negative");
+    }
+
+    @Test
+    void runCommand_failure_returnsNonZeroExitCode() {
+        String exitCmd = ShellTool.IS_WINDOWS ? "exit /b 1" : "exit 1";
+        CommandResult result = shellTool.runCommand(exitCmd, null, null);
+
+        assertNotEquals(0, result.exitCode(), "Exit code should be non-zero");
+        assertFalse(result.truncated(), "Output should not be truncated");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void runCommand_capturesStderr_unix() {
+        CommandResult result = shellTool.runCommand("echo error_msg >&2", null, null);
+
+        assertEquals(0, result.exitCode(), "Exit code should be 0");
+        assertTrue(result.stderr().contains("error_msg"), "stderr should contain 'error_msg'");
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void runCommand_capturesStderr_windows() {
+        CommandResult result = shellTool.runCommand("echo error_msg 1>&2", null, null);
+
+        assertEquals(0, result.exitCode(), "Exit code should be 0");
+        assertTrue(result.stderr().contains("error_msg"), "stderr should contain 'error_msg'");
+    }
+
+    @Test
+    void runCommand_timeout_killsProcess() {
+        CommandResult result = shellTool.runCommand("sleep 60", null, 2);
+
+        assertEquals(-1, result.exitCode(), "Exit code should be -1 on timeout");
+        assertTrue(result.stderr().contains("timed out"), "stderr should mention timeout");
+        assertTrue(result.durationMs() >= 1500, "Duration should be at least ~2s, was: " + result.durationMs());
+        assertTrue(result.durationMs() < 10000, "Duration should be well under 10s, was: " + result.durationMs());
+    }
+
+    @Test
+    void runCommand_largeOutput_isTruncated() {
+        String genCmd = ShellTool.IS_WINDOWS
+                ? "for /L %i in (1,1,200000) do @echo line%i"
+                : "i=0; while [ $i -lt 200000 ]; do printf 'line%05d_padding_to_exceed_1mb\\n' $i; i=$((i+1)); done";
+
+        CommandResult result = shellTool.runCommand(genCmd, null, 60);
+
+        assertTrue(result.truncated(), "Large output should be truncated");
+        assertFalse(result.stdout().isEmpty(), "stdout should still contain partial output");
+    }
+
+    @Test
+    void runCommand_customWorkdir_overridesDefault() {
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        String printDirCmd = ShellTool.IS_WINDOWS ? "cd" : "pwd";
+        CommandResult result = shellTool.runCommand(printDirCmd, tempDir.getAbsolutePath(), null);
+
+        assertEquals(0, result.exitCode(), "Exit code should be 0");
+        String output = result.stdout().trim();
+        assertTrue(output.equals(tempDir.getAbsolutePath()) || output.contains(tempDir.getName()),
+                "stdout should reference the temp dir, got: " + output);
+    }
+
+    @Test
+    void runCommand_customTimeout_isRespected() {
+        CommandResult result = shellTool.runCommand("sleep 10", null, 1);
+
+        assertEquals(-1, result.exitCode(), "Exit code should be -1 on timeout");
+        assertTrue(result.durationMs() < 5000, "Duration should be under 5s with 1s timeout, was: " + result.durationMs());
+    }
+
+    @Test
+    void runCommand_invalidCommand_returnsNonZeroExitCode() {
+        CommandResult result = shellTool.runCommand("nonexistent_command_xyz_12345", null, null);
+
+        assertNotEquals(0, result.exitCode(), "Exit code should be non-zero for invalid command");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void runCommand_exitCodePreserved_unix() {
+        CommandResult result42 = shellTool.runCommand("exit 42", null, null);
+        assertEquals(42, result42.exitCode(), "Exit code 42 should be preserved");
+
+        CommandResult result0 = shellTool.runCommand("true", null, null);
+        assertEquals(0, result0.exitCode(), "Exit code 0 for 'true'");
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void runCommand_exitCodePreserved_windows() {
+        CommandResult result42 = shellTool.runCommand("exit /b 42", null, null);
+        assertEquals(42, result42.exitCode(), "Exit code 42 should be preserved");
+
+        CommandResult result0 = shellTool.runCommand("exit /b 0", null, null);
+        assertEquals(0, result0.exitCode(), "Exit code 0 for 'exit /b 0'");
+    }
+
+    @Test
+    void shellCommand_returnsCorrectShell() {
+        if (ShellTool.IS_WINDOWS) {
+            assertEquals(List.of("cmd", "/c", "echo hello"), ShellTool.shellCommand("echo hello"));
+        } else {
+            assertEquals(List.of("sh", "-c", "echo hello"), ShellTool.shellCommand("echo hello"));
+        }
+    }
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qlawkus-client-parent</artifactId>

--- a/client/runtime/pom.xml
+++ b/client/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus-client-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/CommandResult.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/CommandResult.java
@@ -1,0 +1,26 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+public record CommandResult(
+        String stdout,
+        String stderr,
+        int exitCode,
+        long durationMs,
+        boolean truncated
+) {
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Exit code: ").append(exitCode).append("\n");
+        sb.append("Duration: ").append(durationMs).append("ms\n");
+        if (stdout != null && !stdout.isBlank()) {
+            sb.append("stdout:\n").append(stdout).append("\n");
+        }
+        if (stderr != null && !stderr.isBlank()) {
+            sb.append("stderr:\n").append(stderr).append("\n");
+        }
+        if (truncated) {
+            sb.append("[Output truncated — exceeded 1MB limit]\n");
+        }
+        return sb.toString();
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/OutputCapture.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/OutputCapture.java
@@ -1,0 +1,80 @@
+package dev.omatheusmesmo.qlawkus.tool.shell;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+class OutputCapture extends Thread {
+
+    private static final int MAX_BYTES = 1_048_576;
+    private static final byte[] TRUNCATION_SUFFIX = "\n[Output truncated — exceeded 1MB limit]".getBytes(StandardCharsets.UTF_8);
+
+    private final InputStream input;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private boolean truncated = false;
+    private IOException error;
+
+    OutputCapture(InputStream input) {
+        this.input = input;
+        setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+        byte[] chunk = new byte[8192];
+        try {
+            int read;
+            while ((read = input.read(chunk)) != -1) {
+                int allowed = MAX_BYTES - buffer.size();
+                if (allowed <= 0) {
+                    truncated = true;
+                    drainRemaining();
+                    break;
+                }
+                if (read > allowed) {
+                    buffer.write(chunk, 0, allowed);
+                    truncated = true;
+                    drainRemaining();
+                    break;
+                }
+                buffer.write(chunk, 0, read);
+            }
+            if (truncated) {
+                int suffixSpace = MAX_BYTES - buffer.size();
+                if (suffixSpace > 0) {
+                    buffer.write(TRUNCATION_SUFFIX, 0, Math.min(TRUNCATION_SUFFIX.length, suffixSpace));
+                }
+            }
+        } catch (IOException e) {
+            this.error = e;
+        } finally {
+            try {
+                input.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    String getOutput() {
+        return buffer.toString(StandardCharsets.UTF_8);
+    }
+
+    boolean isTruncated() {
+        return truncated;
+    }
+
+    IOException getError() {
+        return error;
+    }
+
+    private void drainRemaining() {
+        byte[] discard = new byte[8192];
+        try {
+            while (input.read(discard) != -1) {
+                // drain to unblock the writing process
+            }
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
@@ -1,0 +1,117 @@
+package dev.omatheusmesmo.qlawkus.tool.shell;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.dto.CommandResult;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import io.quarkus.logging.Log;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@ClawTool
+public class ShellTool {
+
+    public static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase().contains("win");
+
+    @ConfigProperty(name = "qlawkus.shell.default-timeout-seconds", defaultValue = "30")
+    int defaultTimeoutSeconds;
+
+    @ConfigProperty(name = "qlawkus.shell.workspace-root", defaultValue = ".")
+    String workspaceRoot;
+
+    @Tool("Run a shell command and return structured results: stdout, stderr, exit code, and duration. " +
+            "Parameters: command (required) — the shell command to execute, " +
+            "workdir (optional) — working directory override (defaults to workspace root), " +
+            "timeoutSeconds (optional) — execution timeout in seconds (defaults to 30)")
+    public CommandResult runCommand(String command, String workdir, Integer timeoutSeconds) {
+        Path dir = resolveWorkdir(workdir);
+        int timeout = timeoutSeconds != null ? timeoutSeconds : defaultTimeoutSeconds;
+
+        Log.debugf("ShellTool: executing '%s' in %s (timeout=%ds)", command, dir, timeout);
+
+        ProcessBuilder pb = new ProcessBuilder()
+                .command(shellCommand(command))
+                .directory(dir.toFile())
+                .redirectErrorStream(false);
+
+        long start = System.currentTimeMillis();
+        Process process;
+        try {
+            process = pb.start();
+        } catch (IOException e) {
+            Log.errorf(e, "ShellTool: failed to start command '%s'", command);
+            return new CommandResult("", "Failed to start command: " + e.getMessage(), -1,
+                    System.currentTimeMillis() - start, false);
+        }
+
+        OutputCapture stdoutCapture = new OutputCapture(process.getInputStream());
+        OutputCapture stderrCapture = new OutputCapture(process.getErrorStream());
+        stdoutCapture.start();
+        stderrCapture.start();
+
+        boolean finished;
+        try {
+            finished = process.waitFor(timeout, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            process.destroyForcibly();
+            return new CommandResult(
+                    stdoutCapture.getOutput(),
+                    stderrCapture.getOutput() + "\n[Command interrupted]",
+                    -1,
+                    System.currentTimeMillis() - start,
+                    stdoutCapture.isTruncated() || stderrCapture.isTruncated()
+            );
+        }
+
+        if (!finished) {
+            process.destroyForcibly();
+            Log.warnf("ShellTool: command '%s' timed out after %ds", command, timeout);
+            return new CommandResult(
+                    stdoutCapture.getOutput(),
+                    stderrCapture.getOutput() + "\n[Command timed out after " + timeout + "s]",
+                    -1,
+                    System.currentTimeMillis() - start,
+                    stdoutCapture.isTruncated() || stderrCapture.isTruncated()
+            );
+        }
+
+        try {
+            stdoutCapture.join(5000);
+            stderrCapture.join(5000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        int exitCode = process.exitValue();
+        long duration = System.currentTimeMillis() - start;
+        boolean truncated = stdoutCapture.isTruncated() || stderrCapture.isTruncated();
+
+        Log.debugf("ShellTool: command '%s' finished with exitCode=%d in %dms", command, exitCode, duration);
+
+        return new CommandResult(
+                stdoutCapture.getOutput(),
+                stderrCapture.getOutput(),
+                exitCode,
+                duration,
+                truncated
+        );
+    }
+
+    private Path resolveWorkdir(String workdir) {
+        if (workdir != null && !workdir.isBlank()) {
+            return Path.of(workdir).toAbsolutePath();
+        }
+        return Path.of(workspaceRoot).toAbsolutePath();
+    }
+
+    public static List<String> shellCommand(String command) {
+        if (IS_WINDOWS) {
+            return List.of("cmd", "/c", command);
+        }
+        return List.of("sh", "-c", command);
+    }
+}

--- a/client/runtime/src/main/resources/application.properties
+++ b/client/runtime/src/main/resources/application.properties
@@ -6,3 +6,5 @@ quarkus.langchain4j.pgvector.table=embeddings
 quarkus.langchain4j.pgvector.dimension=${EMBEDDING_DIMENSION:1024}
 quarkus.langchain4j.pgvector.metadata.storage-mode=combined-jsonb
 quarkus.langchain4j.pgvector.metadata.column-definitions=metadata JSONB NULL
+qlawkus.shell.default-timeout-seconds=30
+qlawkus.shell.workspace-root=.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qlawkus-integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.omatheusmesmo</groupId>
   <artifactId>qlawkus</artifactId>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qlawkus-tools-parent</artifactId>


### PR DESCRIPTION
## Summary

Implements #41 — core `runCommand` method in `ShellTool` as a `@ClawTool` bean, enabling the agent to execute shell commands and receive structured results.

## Changes

- **ShellTool**: `@ClawTool` class with `@Tool runCommand(command, workdir, timeoutSeconds)` using `ProcessBuilder`
  - Cross-platform: `sh -c` on Unix, `cmd /c` on Windows via `IS_WINDOWS` detection
  - Configurable working directory (default: workspace root)
  - Environment variable passthrough
  - Timeout with process kill (default: 30s, configurable via `qlawkus.shell.default-timeout-seconds`)
- **OutputCapture**: daemon threads that stream stdout/stderr with 1MB truncation and drain to unblock processes on timeout
- **CommandResult**: record with `stdout`, `stderr`, `exitCode`, `durationMs`, `truncated` + LLM-friendly `toString()`
- **ShellToolTest**: 12 tests covering success, failure, stderr capture, timeout, large output truncation, custom workdir, env passthrough, exit code preservation, cross-platform shell command detection
- **Config defaults**: `qlawkus.shell.default-timeout-seconds=30`, `qlawkus.shell.workspace-root=.`
- **Version bump**: `0.4.0-SNAPSHOT` (M4 milestone)

## Acceptance Criteria (#41)

- [x] `ShellTool` class exists with `@ClawTool` qualifier
- [x] `runCommand("git --version")` returns `CommandResult` with stdout, stderr, exitCode
- [x] Custom workdir overrides default workspace root
- [x] Timeout kills process and returns partial output
- [x] Large output (>1MB) is truncated with warning
- [x] `ClawToolProvider` includes ShellTool (auto-discovered via `@ClawTool`)
- [x] Unit tests: success, failure, timeout, large output

Closes #41