### PR TITLE
feat(google-auth): add Device Authorization Grant extension (RFC 8628)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -5,17 +5,22 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qlawkus-app</artifactId>
   <name>Qlawkus App</name>
   <packaging>quarkus</packaging>
 
-  <dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     <dependency>
       <groupId>dev.omatheusmesmo</groupId>
-      <artifactId>qlawkus-client</artifactId>
+      <artifactId>qlawkus-tools-google-auth</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -6,6 +6,9 @@ quarkus.security.users.embedded.users.qlawkus=${API_USER_PASSWORD:qlawkus}
 quarkus.security.users.embedded.roles.qlawkus=admin
 quarkus.http.auth.basic=true
 
+qlawkus.google.auth.client-id=${GOOGLE_CLIENT_ID}
+qlawkus.google.auth.client-secret=${GOOGLE_CLIENT_SECRET}
+
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,9 +5,13 @@
   <parent>
     <groupId>dev.omatheusmesmo</groupId>
     <artifactId>qlawkus</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>qlawkus-tools-parent</artifactId>
-  <packaging>pom</packaging>
+    <artifactId>qlawkus-tools-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>qlawkus-tools-google-auth</module>
+    </modules>
 </project>

--- a/tools/qlawkus-tools-google-auth/deployment/pom.xml
+++ b/tools/qlawkus-tools-google-auth/deployment/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>dev.omatheusmesmo</groupId>
+    <artifactId>qlawkus-tools-google-auth-parent</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>qlawkus-tools-google-auth-deployment</artifactId>
+  <name>Qlawkus Tools - Google Auth - Deployment</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>dev.omatheusmesmo</groupId>
+      <artifactId>qlawkus-tools-google-auth</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${quarkus.platform.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/qlawkus-tools-google-auth/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/deployment/GoogleAuthProcessor.java
+++ b/tools/qlawkus-tools-google-auth/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/deployment/GoogleAuthProcessor.java
@@ -1,0 +1,37 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth.deployment;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthResource;
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthConfig;
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleDeviceFlowClient;
+import dev.omatheusmesmo.qlawkus.tools.google.auth.DeviceCodeResponse;
+import dev.omatheusmesmo.qlawkus.tools.google.auth.TokenResponse;
+import dev.omatheusmesmo.qlawkus.tools.google.auth.RefreshTokenCapturedEvent;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+
+class GoogleAuthProcessor {
+
+    private static final String FEATURE = "google-auth";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem registerBeans() {
+        return AdditionalBeanBuildItem.unremovableOf(GoogleAuthResource.class);
+    }
+
+    @BuildStep
+    ReflectiveClassBuildItem registerReflection() {
+        return ReflectiveClassBuildItem.builder(
+                DeviceCodeResponse.class.getName(),
+                TokenResponse.class.getName(),
+                RefreshTokenCapturedEvent.class.getName(),
+                GoogleAuthConfig.class.getName()
+        ).methods().fields().build();
+    }
+}

--- a/tools/qlawkus-tools-google-auth/pom.xml
+++ b/tools/qlawkus-tools-google-auth/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+  <artifactId>qlawkus-tools-google-auth-parent</artifactId>
+  <name>Qlawkus Tools - Google Auth - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/tools/qlawkus-tools-google-auth/runtime/pom.xml
+++ b/tools/qlawkus-tools-google-auth/runtime/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>dev.omatheusmesmo</groupId>
+    <artifactId>qlawkus-tools-google-auth-parent</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>qlawkus-tools-google-auth</artifactId>
+  <name>Qlawkus Tools - Google Auth - Runtime</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>extension-descriptor</goal>
+            </goals>
+            <configuration>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${quarkus.platform.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>3.2.7</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/DeviceCodeResponse.java
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/DeviceCodeResponse.java
@@ -1,0 +1,11 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record DeviceCodeResponse(
+        @JsonProperty("device_code") String deviceCode,
+        @JsonProperty("user_code") String userCode,
+        @JsonProperty("verification_url") String verificationUrl,
+        @JsonProperty("expires_in") int expiresIn,
+        @JsonProperty("interval") int interval) {
+}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/GoogleAuthConfig.java
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/GoogleAuthConfig.java
@@ -1,0 +1,24 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "qlawkus.google.auth")
+public interface GoogleAuthConfig {
+
+    /**
+     * Google OAuth2 client ID.
+     */
+    String clientId();
+
+    /**
+     * Google OAuth2 client secret.
+     */
+    String clientSecret();
+
+    /**
+     * Space-separated OAuth2 scopes for all Google tools.
+     */
+    @WithDefault("openid email profile https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/devstorage.read_write")
+    String scopes();
+}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/GoogleAuthResource.java
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/GoogleAuthResource.java
@@ -1,0 +1,83 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth;
+
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Path("/api/google/auth")
+public class GoogleAuthResource {
+
+    @Inject
+    @RestClient
+    GoogleDeviceFlowClient deviceFlowClient;
+
+    @Inject
+    GoogleAuthConfig config;
+
+    @Inject
+    Event<RefreshTokenCapturedEvent> refreshTokenEvent;
+
+    private final ExecutorService pollExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "google-device-flow-poll");
+        t.setDaemon(true);
+        return t;
+    });
+
+    @GET
+    public DeviceCodeResponse authorize() {
+        Log.info("Initiating Google Device Authorization Grant flow");
+
+        DeviceCodeResponse codeResponse = deviceFlowClient.requestDeviceCode(
+                config.clientId(),
+                config.clientSecret(),
+                config.scopes());
+
+        Log.infof("Device code issued. Visit %s and enter code %s",
+                codeResponse.verificationUrl(), codeResponse.userCode());
+
+        pollExecutor.submit(() -> pollForToken(codeResponse.deviceCode(), codeResponse.interval()));
+
+        return codeResponse;
+    }
+
+    private void pollForToken(String deviceCode, int intervalSeconds) {
+        try {
+            Thread.sleep(Duration.ofSeconds(intervalSeconds));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+
+        TokenResponse response = deviceFlowClient.retrieveToken(
+                config.clientId(),
+                config.clientSecret(),
+                deviceCode,
+                "urn:ietf:params:oauth:grant-type:device_code");
+
+        if (response.error() != null) {
+            switch (response.error()) {
+                case "authorization_pending" -> pollForToken(deviceCode, intervalSeconds);
+                case "slow_down" -> pollForToken(deviceCode, intervalSeconds + 5);
+                default -> Log.errorf("Device flow error: %s - %s",
+                        response.error(), response.errorDescription());
+            }
+            return;
+        }
+
+        if (response.refreshToken() != null) {
+            Log.info("Refresh token captured from Device Flow, firing RefreshTokenCapturedEvent");
+            refreshTokenEvent.fireAsync(new RefreshTokenCapturedEvent(response.refreshToken()));
+        } else {
+            Log.warn("Device Flow completed but no refresh token returned");
+        }
+    }
+}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/GoogleDeviceFlowClient.java
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/GoogleDeviceFlowClient.java
@@ -1,0 +1,26 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.FormParam;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/oauth2")
+@RegisterRestClient(baseUri = "https://oauth2.googleapis.com")
+public interface GoogleDeviceFlowClient {
+
+    @POST
+    @Path("/device/code")
+    DeviceCodeResponse requestDeviceCode(
+            @FormParam("client_id") String clientId,
+            @FormParam("client_secret") String clientSecret,
+            @FormParam("scope") String scope);
+
+    @POST
+    @Path("/token")
+    TokenResponse retrieveToken(
+            @FormParam("client_id") String clientId,
+            @FormParam("client_secret") String clientSecret,
+            @FormParam("device_code") String deviceCode,
+            @FormParam("grant_type") String grantType);
+}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/RefreshTokenCapturedEvent.java
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/RefreshTokenCapturedEvent.java
@@ -1,0 +1,4 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth;
+
+public record RefreshTokenCapturedEvent(String refreshToken) {
+}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/TokenResponse.java
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/auth/TokenResponse.java
@@ -1,0 +1,12 @@
+package dev.omatheusmesmo.qlawkus.tools.google.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("expires_in") int expiresIn,
+        @JsonProperty("error") String error,
+        @JsonProperty("error_description") String errorDescription) {
+}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/resources/META-INF/microprofile.properties
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/resources/META-INF/microprofile.properties
@@ -1,0 +1,2 @@
+qlawkus.google.auth.client-id=${GOOGLE_CLIENT_ID}
+qlawkus.google.auth.client-secret=${GOOGLE_CLIENT_SECRET}

--- a/tools/qlawkus-tools-google-auth/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/tools/qlawkus-tools-google-auth/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+name: "Google Auth (Device Flow)"
+metadata:
+  keywords:
+  - "google"
+  - "device-flow"
+  - "oauth2"
+  categories:
+  - "productivity"
+  status: "experimental"


### PR DESCRIPTION
## Summary

- Rename extension from `quarkus-google-calendar` to `qlawkus-tools-google-auth`
- Replace OIDC web-app flow with Device Authorization Grant (RFC 8628) — works on VPS without browser/callback URL
- Remove `quarkus-oidc` dependency, add `quarkus-rest-client-jackson` for direct HTTP calls to Google token endpoints
- Endpoint `GET /api/google/auth` returns device code immediately, polls for token on background daemon thread
- Fire `RefreshTokenCapturedEvent` via CDI async event on successful token retrieval (decouples auth #32 from vault #33)
- Add `GoogleAuthConfig` with SmallRye `@ConfigMapping` (`qlawkus.google.auth.*`)

## Key Design Decisions

- **Device Flow over OIDC**: no public DNS, no callback URL, same UX as `gcloud auth login --no-launch-browser`
- **Sync endpoint + async polling**: caller gets device code instantly, token polling happens on a daemon thread
- **Shared auth extension**: `qlawkus-tools-google-auth` will be the base for all 5 Google tool extensions (Calendar, Mail, Drive, Sheets, Storage)

## Closes

Closes #32