### PR TITLE
feat(shell): add listEnvironment and listActiveProcesses (#42)

### DIFF
--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
@@ -1,6 +1,8 @@
 package dev.omatheusmesmo.qlawkus.tool.shell;
 
 import dev.omatheusmesmo.qlawkus.dto.CommandResult;
+import dev.omatheusmesmo.qlawkus.dto.EnvironmentResult;
+import dev.omatheusmesmo.qlawkus.dto.ProcessInfo;
 import dev.omatheusmesmo.qlawkus.tool.ClawTool;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -23,8 +25,7 @@ class ShellToolTest {
 
     @Test
     void runCommand_success_returnsStdoutAndZeroExitCode() {
-        String echoCmd = ShellTool.IS_WINDOWS ? "echo hello" : "echo hello";
-        CommandResult result = shellTool.runCommand(echoCmd, null, null);
+        CommandResult result = shellTool.runCommand("echo hello", null, null);
 
         assertEquals(0, result.exitCode(), "Exit code should be 0");
         assertTrue(result.stdout().contains("hello"), "stdout should contain 'hello'");
@@ -136,5 +137,85 @@ class ShellToolTest {
         } else {
             assertEquals(List.of("sh", "-c", "echo hello"), ShellTool.shellCommand("echo hello"));
         }
+    }
+
+    @Test
+    void listEnvironment_returnsOsAndShellAndWorkspace() {
+        EnvironmentResult env = shellTool.listEnvironment();
+
+        assertNotNull(env.os(), "OS should not be null");
+        assertFalse(env.os().isBlank(), "OS should not be blank");
+        assertNotNull(env.shell(), "Shell should not be null");
+        assertFalse(env.shell().isBlank(), "Shell should not be blank");
+        assertNotNull(env.workspace(), "Workspace should not be null");
+        assertFalse(env.workspace().isBlank(), "Workspace should not be blank");
+        assertNotNull(env.availableCommands(), "Available commands should not be null");
+    }
+
+    @Test
+    void listEnvironment_probesCommandsOnPath() {
+        EnvironmentResult env = shellTool.listEnvironment();
+
+        List<String> available = env.availableCommands();
+        assertNotNull(available, "Available commands list should not be null");
+        assertFalse(available.contains("nonexistent_command_xyz_12345"),
+                "Nonexistent command should not appear in available list");
+    }
+
+    @Test
+    void listEnvironment_toString_containsAllFields() {
+        EnvironmentResult env = shellTool.listEnvironment();
+        String str = env.toString();
+
+        assertTrue(str.contains("OS:"), "toString should contain OS");
+        assertTrue(str.contains("Shell:"), "toString should contain Shell");
+        assertTrue(str.contains("Workspace:"), "toString should contain Workspace");
+        assertTrue(str.contains("Available commands:"), "toString should contain Available commands");
+    }
+
+    @Test
+    void listActiveProcesses_tracksSpawnedProcesses() {
+        shellTool.runCommand("echo tracked_process_test", null, null);
+
+        List<ProcessInfo> processes = shellTool.listActiveProcesses();
+
+        assertFalse(processes.isEmpty(), "Should have tracked at least one process");
+        boolean found = processes.stream()
+                .anyMatch(p -> p.command().contains("tracked_process_test"));
+        assertTrue(found, "Should find the tracked process by command, got: " + processes);
+    }
+
+    @Test
+    void listActiveProcesses_completedProcessHasCompletedStatus() {
+        shellTool.runCommand("echo completed_status_test", null, null);
+
+        List<ProcessInfo> processes = shellTool.listActiveProcesses();
+
+        boolean found = processes.stream()
+                .anyMatch(p -> p.command().contains("completed_status_test") && "completed".equals(p.status()));
+        assertTrue(found, "Completed process should have 'completed' status, got: " + processes);
+    }
+
+    @Test
+    void listActiveProcesses_timedOutProcessHasTimedOutStatus() {
+        shellTool.runCommand("sleep 60", null, 1);
+
+        List<ProcessInfo> processes = shellTool.listActiveProcesses();
+
+        boolean found = processes.stream()
+                .anyMatch(p -> p.command().contains("sleep 60") && "timed_out".equals(p.status()));
+        assertTrue(found, "Timed out process should have 'timed_out' status, got: " + processes);
+    }
+
+    @Test
+    void isCommandAvailable_echoAlwaysAvailable() {
+        String probeCmd = ShellTool.IS_WINDOWS ? "echo" : "echo";
+        assertTrue(shellTool.isCommandAvailable(probeCmd), "echo should always be available");
+    }
+
+    @Test
+    void isCommandAvailable_nonexistentReturnsFalse() {
+        assertFalse(shellTool.isCommandAvailable("nonexistent_command_xyz_12345"),
+                "Nonexistent command should return false");
     }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/EnvironmentResult.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/EnvironmentResult.java
@@ -1,0 +1,20 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+import java.util.List;
+
+public record EnvironmentResult(
+        String os,
+        String shell,
+        String workspace,
+        List<String> availableCommands
+) {
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("OS: ").append(os).append("\n");
+        sb.append("Shell: ").append(shell).append("\n");
+        sb.append("Workspace: ").append(workspace).append("\n");
+        sb.append("Available commands: ").append(availableCommands).append("\n");
+        return sb.toString();
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/ProcessInfo.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/ProcessInfo.java
@@ -1,0 +1,13 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+public record ProcessInfo(
+        long pid,
+        String command,
+        long startedAtMs,
+        String status
+) {
+    @Override
+    public String toString() {
+        return "PID %d | %s | started %dms ago | %s".formatted(pid, command, System.currentTimeMillis() - startedAtMs, status);
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
@@ -2,13 +2,19 @@ package dev.omatheusmesmo.qlawkus.tool.shell;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.omatheusmesmo.qlawkus.dto.CommandResult;
+import dev.omatheusmesmo.qlawkus.dto.EnvironmentResult;
+import dev.omatheusmesmo.qlawkus.dto.ProcessInfo;
 import dev.omatheusmesmo.qlawkus.tool.ClawTool;
 import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @ClawTool
@@ -16,11 +22,17 @@ public class ShellTool {
 
     public static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase().contains("win");
 
+    static final List<String> PROBED_COMMANDS = List.of(
+            "git", "gh", "docker", "kubectl", "mvn", "gradle", "npm", "python3", "java", "curl", "wget", "ssh"
+    );
+
     @ConfigProperty(name = "qlawkus.shell.default-timeout-seconds", defaultValue = "30")
     int defaultTimeoutSeconds;
 
     @ConfigProperty(name = "qlawkus.shell.workspace-root", defaultValue = ".")
     String workspaceRoot;
+
+    private final Map<Long, TrackedProcess> activeProcesses = new LinkedHashMap<>();
 
     @Tool("Run a shell command and return structured results: stdout, stderr, exit code, and duration. " +
             "Parameters: command (required) — the shell command to execute, " +
@@ -47,6 +59,9 @@ public class ShellTool {
                     System.currentTimeMillis() - start, false);
         }
 
+        TrackedProcess tracked = new TrackedProcess(process.pid(), command, start, "running");
+        activeProcesses.put(process.pid(), tracked);
+
         OutputCapture stdoutCapture = new OutputCapture(process.getInputStream());
         OutputCapture stderrCapture = new OutputCapture(process.getErrorStream());
         stdoutCapture.start();
@@ -58,6 +73,7 @@ public class ShellTool {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             process.destroyForcibly();
+            tracked.status = "interrupted";
             return new CommandResult(
                     stdoutCapture.getOutput(),
                     stderrCapture.getOutput() + "\n[Command interrupted]",
@@ -69,6 +85,7 @@ public class ShellTool {
 
         if (!finished) {
             process.destroyForcibly();
+            tracked.status = "timed_out";
             Log.warnf("ShellTool: command '%s' timed out after %ds", command, timeout);
             return new CommandResult(
                     stdoutCapture.getOutput(),
@@ -90,6 +107,7 @@ public class ShellTool {
         long duration = System.currentTimeMillis() - start;
         boolean truncated = stdoutCapture.isTruncated() || stderrCapture.isTruncated();
 
+        tracked.status = "completed";
         Log.debugf("ShellTool: command '%s' finished with exitCode=%d in %dms", command, exitCode, duration);
 
         return new CommandResult(
@@ -99,6 +117,53 @@ public class ShellTool {
                 duration,
                 truncated
         );
+    }
+
+    @Tool("Discover the execution environment: OS, default shell, workspace path, and available CLI tools on PATH")
+    public EnvironmentResult listEnvironment() {
+        String os = System.getProperty("os.name", "unknown");
+        String shell = IS_WINDOWS ? "cmd" : System.getenv().getOrDefault("SHELL", "sh");
+        String workspace = Path.of(workspaceRoot).toAbsolutePath().toString();
+
+        List<String> available = new ArrayList<>();
+        for (String cmd : PROBED_COMMANDS) {
+            if (isCommandAvailable(cmd)) {
+                available.add(cmd);
+            }
+        }
+
+        Log.debugf("ShellTool: listEnvironment — os=%s, shell=%s, workspace=%s, available=%s",
+                os, shell, workspace, available);
+
+        return new EnvironmentResult(os, shell, workspace, available);
+    }
+
+    @Tool("List processes spawned by the agent that are still tracked, with pid, command, and status")
+    public List<ProcessInfo> listActiveProcesses() {
+        List<ProcessInfo> processes = new ArrayList<>();
+        long now = System.currentTimeMillis();
+
+        for (TrackedProcess tp : activeProcesses.values()) {
+            processes.add(new ProcessInfo(tp.pid, tp.command, tp.startedAtMs, tp.status));
+        }
+
+        Log.debugf("ShellTool: listActiveProcesses — %d tracked processes", processes.size());
+        return processes;
+    }
+
+    public boolean isCommandAvailable(String command) {
+        String probeCmd = IS_WINDOWS ? "where " + command + " >nul 2>&1" : "command -v " + command;
+        try {
+            Process p = new ProcessBuilder()
+                    .command(shellCommand(probeCmd))
+                    .redirectErrorStream(true)
+                    .start();
+            boolean finished = p.waitFor(5, TimeUnit.SECONDS);
+            return finished && p.exitValue() == 0;
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     private Path resolveWorkdir(String workdir) {
@@ -113,5 +178,19 @@ public class ShellTool {
             return List.of("cmd", "/c", command);
         }
         return List.of("sh", "-c", command);
+    }
+
+    static class TrackedProcess {
+        final long pid;
+        final String command;
+        final long startedAtMs;
+        volatile String status;
+
+        TrackedProcess(long pid, String command, long startedAtMs, String status) {
+            this.pid = pid;
+            this.command = command;
+            this.startedAtMs = startedAtMs;
+            this.status = status;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Implement issue #42 — agent observability over its environment
- `listEnvironment()`: returns OS, default shell, workspace path, and probed available CLI tools (git, gh, docker, kubectl, mvn, gradle, npm, python3, java, curl, wget, ssh)
- `listActiveProcesses()`: returns agent-spawned processes with pid, command, startedAt, status (completed/timed_out)
- `ProcessInfo` record with elapsed time in toString()
- `EnvironmentResult` record with LLM-friendly toString()
- Process tracking via `TrackedProcess` inner class and `activeProcesses` map
- `isCommandAvailable()`: cross-platform probe (command -v / where)
- 8 new tests (20 total, 0 failures, 0 errors, 2 OS-skipped)

## Test plan
- [x] `listEnvironment_returnsOsAndShellAndWorkspace` — verifies all fields populated
- [x] `listEnvironment_probesCommandsOnPath` — verifies nonexistent commands excluded
- [x] `listEnvironment_toString_containsAllFields` — LLM-readable format
- [x] `listActiveProcesses_tracksSpawnedProcesses` — tracked process appears in list
- [x] `listActiveProcesses_completedProcessHasCompletedStatus` — status = "completed"
- [x] `listActiveProcesses_timedOutProcessHasTimedOutStatus` — status = "timed_out"
- [x] `isCommandAvailable_echoAlwaysAvailable` — echo is always found
- [x] `isCommandAvailable_nonexistentReturnsFalse` — fake command returns false