### PR TITLE
feat(shell): workspace confinement, command filtering, killProcess, optional timeout (#43)

### DIFF
--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
@@ -3,6 +3,7 @@ package dev.omatheusmesmo.qlawkus.tool.shell;
 import dev.omatheusmesmo.qlawkus.dto.CommandResult;
 import dev.omatheusmesmo.qlawkus.dto.EnvironmentResult;
 import dev.omatheusmesmo.qlawkus.dto.ProcessInfo;
+import dev.omatheusmesmo.qlawkus.dto.SecurityResult;
 import dev.omatheusmesmo.qlawkus.tool.ClawTool;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import java.io.File;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,6 +22,12 @@ class ShellToolTest {
     @Inject
     @ClawTool
     ShellTool shellTool;
+
+    @Inject
+    CommandFilter commandFilter;
+
+    @Inject
+    WorkspaceConfinement workspaceConfinement;
 
     @Test
     void runCommand_success_returnsStdoutAndZeroExitCode() {
@@ -62,13 +68,21 @@ class ShellToolTest {
     }
 
     @Test
-    void runCommand_timeout_killsProcess() {
+    void runCommand_explicitTimeout_killsProcess() {
         CommandResult result = shellTool.runCommand("sleep 60", null, 2);
 
         assertEquals(-1, result.exitCode(), "Exit code should be -1 on timeout");
         assertTrue(result.stderr().contains("timed out"), "stderr should mention timeout");
         assertTrue(result.durationMs() >= 1500, "Duration should be at least ~2s, was: " + result.durationMs());
         assertTrue(result.durationMs() < 10000, "Duration should be well under 10s, was: " + result.durationMs());
+    }
+
+    @Test
+    void runCommand_noTimeout_runsUntilCompletion() {
+        CommandResult result = shellTool.runCommand("echo fast", null, null);
+
+        assertEquals(0, result.exitCode(), "Exit code should be 0");
+        assertTrue(result.stdout().contains("fast"), "stdout should contain 'fast'");
     }
 
     @Test
@@ -84,23 +98,14 @@ class ShellToolTest {
     }
 
     @Test
-    void runCommand_customWorkdir_overridesDefault() {
-        File tempDir = new File(System.getProperty("java.io.tmpdir"));
-        String printDirCmd = ShellTool.IS_WINDOWS ? "cd" : "pwd";
-        CommandResult result = shellTool.runCommand(printDirCmd, tempDir.getAbsolutePath(), null);
+    void runCommand_customWorkdir_insideWorkspace() {
+        String workspace = workspaceConfinement.getWorkspacePath().toString();
+        CommandResult result = shellTool.runCommand("pwd", workspace, null);
 
         assertEquals(0, result.exitCode(), "Exit code should be 0");
         String output = result.stdout().trim();
-        assertTrue(output.equals(tempDir.getAbsolutePath()) || output.contains(tempDir.getName()),
-                "stdout should reference the temp dir, got: " + output);
-    }
-
-    @Test
-    void runCommand_customTimeout_isRespected() {
-        CommandResult result = shellTool.runCommand("sleep 10", null, 1);
-
-        assertEquals(-1, result.exitCode(), "Exit code should be -1 on timeout");
-        assertTrue(result.durationMs() < 5000, "Duration should be under 5s with 1s timeout, was: " + result.durationMs());
+        assertTrue(output.contains(workspace) || output.equals(workspace),
+                "stdout should reference the workspace dir, got: " + output);
     }
 
     @Test
@@ -141,7 +146,7 @@ class ShellToolTest {
 
     @Test
     void listEnvironment_returnsOsAndShellAndWorkspace() {
-        EnvironmentResult env = shellTool.listEnvironment();
+        EnvironmentResult env = shellTool.listEnvironment(false);
 
         assertNotNull(env.os(), "OS should not be null");
         assertFalse(env.os().isBlank(), "OS should not be blank");
@@ -153,24 +158,41 @@ class ShellToolTest {
     }
 
     @Test
-    void listEnvironment_probesCommandsOnPath() {
-        EnvironmentResult env = shellTool.listEnvironment();
+    void listEnvironment_cachedCommandsAvailable() {
+        EnvironmentResult env = shellTool.listEnvironment(false);
 
         List<String> available = env.availableCommands();
         assertNotNull(available, "Available commands list should not be null");
+        assertFalse(available.isEmpty(), "PATH should have at least some commands");
         assertFalse(available.contains("nonexistent_command_xyz_12345"),
                 "Nonexistent command should not appear in available list");
     }
 
     @Test
-    void listEnvironment_toString_containsAllFields() {
-        EnvironmentResult env = shellTool.listEnvironment();
-        String str = env.toString();
+    void listEnvironment_refreshRescansPath() {
+        EnvironmentResult cached = shellTool.listEnvironment(false);
+        EnvironmentResult refreshed = shellTool.listEnvironment(true);
 
-        assertTrue(str.contains("OS:"), "toString should contain OS");
-        assertTrue(str.contains("Shell:"), "toString should contain Shell");
-        assertTrue(str.contains("Workspace:"), "toString should contain Workspace");
-        assertTrue(str.contains("Available commands:"), "toString should contain Available commands");
+        assertFalse(refreshed.availableCommands().isEmpty(), "Refreshed scan should find commands");
+        assertEquals(cached.availableCommands().size(), refreshed.availableCommands().size(),
+                "Refresh should find same commands unless something changed");
+    }
+
+    @Test
+    void scanPath_findsCommonCommands() {
+        List<String> commands = shellTool.scanPath();
+
+        assertFalse(commands.isEmpty(), "PATH scan should find executables");
+        assertTrue(commands.contains("ls") || commands.contains("dir") || commands.contains("echo"),
+                "Should find at least one common command, got: " + commands);
+    }
+
+    @Test
+    void scanPath_doesNotContainFakeCommands() {
+        List<String> commands = shellTool.scanPath();
+
+        assertFalse(commands.contains("nonexistent_command_xyz_12345"),
+                "Fake command should not appear in PATH scan");
     }
 
     @Test
@@ -209,13 +231,158 @@ class ShellToolTest {
 
     @Test
     void isCommandAvailable_echoAlwaysAvailable() {
-        String probeCmd = ShellTool.IS_WINDOWS ? "echo" : "echo";
-        assertTrue(shellTool.isCommandAvailable(probeCmd), "echo should always be available");
+        assertTrue(shellTool.isCommandAvailable("echo"), "echo should always be available");
     }
 
     @Test
     void isCommandAvailable_nonexistentReturnsFalse() {
         assertFalse(shellTool.isCommandAvailable("nonexistent_command_xyz_12345"),
                 "Nonexistent command should return false");
+    }
+
+    @Test
+    void commandFilter_denylist_blocksSudo() {
+        SecurityResult result = commandFilter.check("sudo rm -rf /");
+        assertTrue(result.blocked(), "sudo should be blocked");
+        assertTrue(result.pattern().contains("sudo"), "Pattern should mention sudo");
+    }
+
+    @Test
+    void commandFilter_denylist_blocksRmRfRoot() {
+        SecurityResult result = commandFilter.check("rm -rf /");
+        assertTrue(result.blocked(), "rm -rf / should be blocked");
+    }
+
+    @Test
+    void commandFilter_denylist_blocksMkfs() {
+        SecurityResult result = commandFilter.check("mkfs.ext4 /dev/sda1");
+        assertTrue(result.blocked(), "mkfs should be blocked");
+    }
+
+    @Test
+    void commandFilter_denylist_blocksShutdown() {
+        SecurityResult result = commandFilter.check("shutdown -h now");
+        assertTrue(result.blocked(), "shutdown should be blocked");
+    }
+
+    @Test
+    void commandFilter_denylist_allowsSafeCommand() {
+        SecurityResult result = commandFilter.check("ls -la");
+        assertFalse(result.blocked(), "ls should be allowed");
+    }
+
+    @Test
+    void commandFilter_denylist_allowsGit() {
+        SecurityResult result = commandFilter.check("git status");
+        assertFalse(result.blocked(), "git should be allowed");
+    }
+
+    @Test
+    void commandFilter_allowlistMode_blocksNonAllowlisted() {
+        CommandFilter testFilter = new CommandFilter();
+        testFilter.denylist = List.of();
+        testFilter.allowlistMode = true;
+        testFilter.allowlist = List.of("git *", "ls", "echo *");
+
+        assertTrue(testFilter.check("git status").blocked() == false, "git should be allowed in allowlist");
+        assertTrue(testFilter.check("rm -rf /").blocked(), "rm should be blocked in allowlist mode");
+        assertTrue(testFilter.check("docker ps").blocked(), "docker should be blocked in allowlist mode");
+    }
+
+    @Test
+    void commandFilter_globMatch_exactMatch() {
+        assertTrue(CommandFilter.globMatch("shutdown", "shutdown"));
+        assertTrue(CommandFilter.globMatch("shutdown", "shutdown -h now"));
+        assertFalse(CommandFilter.globMatch("shutdown", "echo shutdown"));
+    }
+
+    @Test
+    void commandFilter_globMatch_wildcardPrefix() {
+        assertTrue(CommandFilter.globMatch("sudo *", "sudo rm -rf /"));
+        assertTrue(CommandFilter.globMatch("sudo *", "sudo apt install"));
+        assertFalse(CommandFilter.globMatch("sudo *", "echo hello"));
+    }
+
+    @Test
+    void commandFilter_globMatch_wildcardSuffix() {
+        assertTrue(CommandFilter.globMatch("mkfs*", "mkfs.ext4 /dev/sda1"));
+        assertTrue(CommandFilter.globMatch("mkfs*", "mkfs"));
+        assertFalse(CommandFilter.globMatch("mkfs*", "ls mkfs"));
+    }
+
+    @Test
+    void workspaceConfinement_blocksPathTraversal() {
+        String workspace = workspaceConfinement.getWorkspacePath().toString();
+        String traversalPath = workspace + "/../../../etc/passwd";
+
+        SecurityResult result = workspaceConfinement.check(traversalPath);
+        assertTrue(result.blocked(), "Path traversal should be blocked");
+        assertEquals("path_traversal", result.pattern());
+    }
+
+    @Test
+    void workspaceConfinement_allowsPathInsideWorkspace() {
+        String workspace = workspaceConfinement.getWorkspacePath().toString();
+        String insidePath = workspace + "/src/main";
+
+        SecurityResult result = workspaceConfinement.check(insidePath);
+        assertFalse(result.blocked(), "Path inside workspace should be allowed, got: " + result);
+    }
+
+    @Test
+    void workspaceConfinement_allowsNullWorkdir() {
+        SecurityResult result = workspaceConfinement.check(null);
+        assertFalse(result.blocked(), "Null workdir should default to workspace root and be allowed");
+    }
+
+    @Test
+    void workspaceConfinement_blocksAbsoluteOutsidePath() {
+        SecurityResult result = workspaceConfinement.check("/etc/passwd");
+        assertTrue(result.blocked(), "Absolute path outside workspace should be blocked, got: " + result);
+    }
+
+    @Test
+    void runCommand_denylistBlocksSudo() {
+        CommandResult result = shellTool.runCommand("sudo apt install something", null, null);
+
+        assertEquals(ShellTool.SECURITY_BLOCK_EXIT_CODE, result.exitCode(), "Blocked command should return -2");
+        assertTrue(result.stderr().contains("BLOCKED"), "stderr should contain BLOCKED");
+    }
+
+    @Test
+    void runCommand_workspaceConfinementBlocksTraversal() {
+        String workspace = workspaceConfinement.getWorkspacePath().toString();
+        CommandResult result = shellTool.runCommand("cat /etc/passwd",
+                workspace + "/../../../etc", null);
+
+        assertEquals(ShellTool.SECURITY_BLOCK_EXIT_CODE, result.exitCode(), "Path traversal should return -2");
+        assertTrue(result.stderr().contains("BLOCKED"), "stderr should contain BLOCKED");
+    }
+
+    @Test
+    void checkSecurity_allowsSafeCommand() {
+        SecurityResult result = shellTool.checkSecurity("git status", null);
+        assertFalse(result.blocked(), "git status should be allowed");
+    }
+
+    @Test
+    void checkSecurity_blocksDangerousCommand() {
+        SecurityResult result = shellTool.checkSecurity("sudo rm -rf /", null);
+        assertTrue(result.blocked(), "sudo rm -rf / should be blocked");
+    }
+
+    @Test
+    void checkSecurity_blocksTraversalWorkdir() {
+        String workspace = workspaceConfinement.getWorkspacePath().toString();
+        SecurityResult result = shellTool.checkSecurity("ls", workspace + "/../../etc");
+        assertTrue(result.blocked(), "Traversal workdir should be blocked");
+    }
+
+    @Test
+    void killProcess_forUnknownPid_returnsError() {
+        CommandResult result = shellTool.killProcess(999999998L);
+
+        assertTrue(!result.stdout().isEmpty() || !result.stderr().isEmpty(),
+                "Should report error for unknown PID");
     }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/SecurityResult.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/SecurityResult.java
@@ -1,0 +1,16 @@
+package dev.omatheusmesmo.qlawkus.dto;
+
+public record SecurityResult(
+        boolean blocked,
+        String reason,
+        String pattern,
+        String command
+) {
+    @Override
+    public String toString() {
+        if (!blocked) {
+            return "Security: ALLOWED — command is safe to execute";
+        }
+        return "Security: BLOCKED — " + reason + " (matched pattern: '" + pattern + "', command: '" + command + "')";
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/CommandFilter.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/CommandFilter.java
@@ -1,0 +1,134 @@
+package dev.omatheusmesmo.qlawkus.tool.shell;
+
+import dev.omatheusmesmo.qlawkus.dto.SecurityResult;
+import io.quarkus.logging.Log;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Validates shell commands against a security policy.
+ *
+ * <p>Two mutually exclusive modes:</p>
+ * <ul>
+ *   <li><b>Denylist mode</b> (default) — all commands are allowed except those matching the denylist patterns.</li>
+ *   <li><b>Allowlist mode</b> — only commands matching the allowlist patterns are allowed; everything else is blocked.
+ *       When active, the denylist is ignored entirely.</li>
+ * </ul>
+ *
+ * <p>Patterns support glob syntax: {@code *} matches any characters, {@code ?} matches a single character.
+ * Without wildcards, a pattern matches the exact command or a command that starts with the pattern followed by a space
+ * (e.g. {@code "sudo"} matches both {@code "sudo"} and {@code "sudo apt install"}).</p>
+ */
+@ApplicationScoped
+public class CommandFilter {
+
+    /**
+     * Comma-separated list of denied command patterns. Always active in denylist mode.
+     * Supports glob wildcards ({@code *}, {@code ?}).
+     * Default: {@code sudo *,su *,rm -rf /*,mkfs*,dd if=*,format,shutdown,reboot}
+     */
+    @ConfigProperty(name = "qlawkus.shell.denylist", defaultValue = "sudo *,su *,rm -rf /*,mkfs*,dd if=*,format,shutdown,reboot")
+    public List<String> denylist;
+
+    /**
+     * When {@code true}, switches to allowlist mode: only commands matching {@link #allowlist} are allowed.
+     * The denylist is completely ignored in this mode. Default: {@code false}.
+     */
+    @ConfigProperty(name = "qlawkus.shell.allowlist-mode", defaultValue = "false")
+    public boolean allowlistMode;
+
+    /**
+     * Comma-separated list of allowed command patterns. Only used when {@link #allowlistMode} is {@code true}.
+     * Supports glob wildcards ({@code *}, {@code ?}).
+     * Default: empty (no commands allowed in allowlist mode until explicitly configured).
+     */
+    @ConfigProperty(name = "qlawkus.shell.allowlist", defaultValue = "none")
+    public List<String> allowlist;
+
+    /**
+     * Checks a command against the active security policy.
+     * In allowlist mode, only allowlist patterns are evaluated (denylist is skipped).
+     * In denylist mode, only denylist patterns are evaluated.
+     *
+     * @param command the shell command to validate
+     * @return {@link SecurityResult} with {@code blocked=true} if the command violates the policy
+     */
+    public SecurityResult check(String command) {
+        String trimmed = command.trim();
+
+        if (allowlistMode) {
+            if (allowlist.isEmpty() || (allowlist.size() == 1 && "none".equals(allowlist.get(0)))) {
+                Log.warnf("CommandFilter: allowlist mode active but no allowlist configured — '%s'", trimmed);
+                return new SecurityResult(true, "Allowlist mode active but no allowlist configured", "allowlist", trimmed);
+            }
+            boolean allowed = false;
+            for (String pattern : allowlist) {
+                String p = pattern.trim();
+                if (!p.isEmpty() && globMatch(p, trimmed)) {
+                    allowed = true;
+                    break;
+                }
+            }
+            if (!allowed) {
+                Log.warnf("CommandFilter: blocked by allowlist — '%s'", trimmed);
+                return new SecurityResult(true, "Command not in allowlist", "allowlist", trimmed);
+            }
+            return new SecurityResult(false, "", "", trimmed);
+        }
+
+        for (String pattern : denylist) {
+            String p = pattern.trim();
+            if (!p.isEmpty() && globMatch(p, trimmed)) {
+                Log.warnf("CommandFilter: blocked by denylist pattern '%s' — '%s'", p, trimmed);
+                return new SecurityResult(true, "Command matches denied pattern", p, trimmed);
+            }
+        }
+
+        return new SecurityResult(false, "", "", trimmed);
+    }
+
+    /**
+     * Glob pattern match against command text. Supports {@code *} (any chars) and {@code ?} (single char).
+     * Without wildcards, matches exact text or text starting with the pattern followed by a space.
+     */
+    public static boolean globMatch(String pattern, String text) {
+        if (!pattern.contains("*")) {
+            return text.equals(pattern) || text.startsWith(pattern + " ");
+        }
+
+        String regex = globToRegex(pattern);
+        return text.matches(regex);
+    }
+
+    static String globToRegex(String glob) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("^");
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            switch (c) {
+                case '*' -> sb.append(".*");
+                case '?' -> sb.append(".");
+                case '.', '(', ')', '+', '|', '^', '$', '@', '%', '{', '}', '[', ']', '\\' ->
+                        sb.append('\\').append(c);
+                default -> sb.append(c);
+            }
+        }
+        sb.append("$");
+        return sb.toString();
+    }
+
+    public List<String> getDenylist() {
+        return List.copyOf(denylist);
+    }
+
+    public List<String> getAllowlist() {
+        return List.copyOf(allowlist);
+    }
+
+    public boolean isAllowlistMode() {
+        return allowlistMode;
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
@@ -4,17 +4,23 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.omatheusmesmo.qlawkus.dto.CommandResult;
 import dev.omatheusmesmo.qlawkus.dto.EnvironmentResult;
 import dev.omatheusmesmo.qlawkus.dto.ProcessInfo;
+import dev.omatheusmesmo.qlawkus.dto.SecurityResult;
 import dev.omatheusmesmo.qlawkus.tool.ClawTool;
 import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 @ClawTool
@@ -22,27 +28,50 @@ public class ShellTool {
 
     public static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase().contains("win");
 
-    static final List<String> PROBED_COMMANDS = List.of(
-            "git", "gh", "docker", "kubectl", "mvn", "gradle", "npm", "python3", "java", "curl", "wget", "ssh"
-    );
+    static final Set<String> WINDOWS_EXTENSIONS = Set.of(".exe", ".bat", ".cmd", ".ps1");
 
-    @ConfigProperty(name = "qlawkus.shell.default-timeout-seconds", defaultValue = "30")
-    int defaultTimeoutSeconds;
+    static final int SECURITY_BLOCK_EXIT_CODE = -2;
 
     @ConfigProperty(name = "qlawkus.shell.workspace-root", defaultValue = ".")
     String workspaceRoot;
 
+    @Inject
+    CommandFilter commandFilter;
+
+    @Inject
+    WorkspaceConfinement workspaceConfinement;
+
     private final Map<Long, TrackedProcess> activeProcesses = new LinkedHashMap<>();
+
+    private volatile List<String> cachedPathCommands;
+
+    @PostConstruct
+    void init() {
+        cachedPathCommands = scanPath();
+        Log.infof("ShellTool: PATH scan found %d available commands", cachedPathCommands.size());
+    }
 
     @Tool("Run a shell command and return structured results: stdout, stderr, exit code, and duration. " +
             "Parameters: command (required) — the shell command to execute, " +
             "workdir (optional) — working directory override (defaults to workspace root), " +
-            "timeoutSeconds (optional) — execution timeout in seconds (defaults to 30)")
+            "timeoutSeconds (optional) — execution timeout in seconds (omit to run indefinitely until completion)")
     public CommandResult runCommand(String command, String workdir, Integer timeoutSeconds) {
-        Path dir = resolveWorkdir(workdir);
-        int timeout = timeoutSeconds != null ? timeoutSeconds : defaultTimeoutSeconds;
+        SecurityResult commandCheck = commandFilter.check(command);
+        if (commandCheck.blocked()) {
+            Log.warnf("ShellTool: command blocked — %s", commandCheck);
+            return blockedResult(commandCheck, System.currentTimeMillis());
+        }
 
-        Log.debugf("ShellTool: executing '%s' in %s (timeout=%ds)", command, dir, timeout);
+        SecurityResult pathCheck = workspaceConfinement.check(workdir);
+        if (pathCheck.blocked()) {
+            Log.warnf("ShellTool: workdir blocked — %s", pathCheck);
+            return blockedResult(pathCheck, System.currentTimeMillis());
+        }
+
+        Path dir = workspaceConfinement.resolveCanonical(workdir);
+
+        Log.debugf("ShellTool: executing '%s' in %s (timeout=%s)", command, dir,
+                timeoutSeconds != null ? timeoutSeconds + "s" : "none");
 
         ProcessBuilder pb = new ProcessBuilder()
                 .command(shellCommand(command))
@@ -69,7 +98,12 @@ public class ShellTool {
 
         boolean finished;
         try {
-            finished = process.waitFor(timeout, TimeUnit.SECONDS);
+            if (timeoutSeconds != null) {
+                finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+            } else {
+                process.waitFor();
+                finished = true;
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             process.destroyForcibly();
@@ -86,10 +120,10 @@ public class ShellTool {
         if (!finished) {
             process.destroyForcibly();
             tracked.status = "timed_out";
-            Log.warnf("ShellTool: command '%s' timed out after %ds", command, timeout);
+            Log.warnf("ShellTool: command '%s' timed out after %ds", command, timeoutSeconds);
             return new CommandResult(
                     stdoutCapture.getOutput(),
-                    stderrCapture.getOutput() + "\n[Command timed out after " + timeout + "s]",
+                    stderrCapture.getOutput() + "\n[Command timed out after " + timeoutSeconds + "s]",
                     -1,
                     System.currentTimeMillis() - start,
                     stdoutCapture.isTruncated() || stderrCapture.isTruncated()
@@ -119,29 +153,70 @@ public class ShellTool {
         );
     }
 
-    @Tool("Discover the execution environment: OS, default shell, workspace path, and available CLI tools on PATH")
-    public EnvironmentResult listEnvironment() {
+    @Tool("Discover the execution environment: OS, default shell, workspace path, and available CLI tools. " +
+            "Set refresh=true to rescan PATH for newly installed commands.")
+    public EnvironmentResult listEnvironment(boolean refresh) {
+        if (refresh) {
+            cachedPathCommands = scanPath();
+            Log.infof("ShellTool: PATH rescan found %d available commands", cachedPathCommands.size());
+        }
+
         String os = System.getProperty("os.name", "unknown");
         String shell = IS_WINDOWS ? "cmd" : System.getenv().getOrDefault("SHELL", "sh");
-        String workspace = Path.of(workspaceRoot).toAbsolutePath().toString();
+        String workspace = workspaceConfinement.getWorkspacePath().toString();
 
-        List<String> available = new ArrayList<>();
-        for (String cmd : PROBED_COMMANDS) {
-            if (isCommandAvailable(cmd)) {
-                available.add(cmd);
+        return new EnvironmentResult(os, shell, workspace, cachedPathCommands);
+    }
+
+    /**
+     * Scans all directories in the PATH environment variable for executable files.
+     * On Unix: files with execute permission. On Windows: files with known extensions (.exe, .bat, .cmd, .ps1).
+     * Returns a sorted, deduplicated list of command names.
+     */
+    public List<String> scanPath() {
+        Set<String> commands = new TreeSet<>();
+
+        String pathEnv = System.getenv("PATH");
+        if (pathEnv == null || pathEnv.isBlank()) {
+            return List.of();
+        }
+
+        String separator = IS_WINDOWS ? ";" : ":";
+        for (String dir : pathEnv.split(separator)) {
+            File directory = new File(dir);
+            if (!directory.isDirectory()) {
+                continue;
+            }
+            File[] files = directory.listFiles();
+            if (files == null) {
+                continue;
+            }
+            for (File file : files) {
+                if (!file.isFile()) {
+                    continue;
+                }
+                if (IS_WINDOWS) {
+                    String name = file.getName().toLowerCase();
+                    for (String ext : WINDOWS_EXTENSIONS) {
+                        if (name.endsWith(ext)) {
+                            commands.add(file.getName().substring(0, name.length() - ext.length()));
+                            break;
+                        }
+                    }
+                } else {
+                    if (Files.isExecutable(file.toPath())) {
+                        commands.add(file.getName());
+                    }
+                }
             }
         }
 
-        Log.debugf("ShellTool: listEnvironment — os=%s, shell=%s, workspace=%s, available=%s",
-                os, shell, workspace, available);
-
-        return new EnvironmentResult(os, shell, workspace, available);
+        return List.copyOf(commands);
     }
 
     @Tool("List processes spawned by the agent that are still tracked, with pid, command, and status")
     public List<ProcessInfo> listActiveProcesses() {
         List<ProcessInfo> processes = new ArrayList<>();
-        long now = System.currentTimeMillis();
 
         for (TrackedProcess tp : activeProcesses.values()) {
             processes.add(new ProcessInfo(tp.pid, tp.command, tp.startedAtMs, tp.status));
@@ -151,6 +226,50 @@ public class ShellTool {
         return processes;
     }
 
+    @Tool("Kill a running process by PID. Use listActiveProcesses to find the PID first. " +
+            "Parameter: pid (required) — the process ID to kill")
+    public CommandResult killProcess(long pid) {
+        TrackedProcess tracked = activeProcesses.get(pid);
+        if (tracked == null) {
+            return new CommandResult("", "No tracked process with PID " + pid, -1, 0, false);
+        }
+
+        try {
+            ProcessHandle handle = ProcessHandle.of(pid).orElse(null);
+            if (handle != null && handle.isAlive()) {
+                handle.destroyForcibly();
+                tracked.status = "killed";
+                Log.infof("ShellTool: killed process pid=%d command='%s'", pid, tracked.command);
+                return new CommandResult("Process " + pid + " killed", "", 0, 0, false);
+            } else {
+                tracked.status = "already_dead";
+                return new CommandResult("Process " + pid + " was already terminated", "", 0, 0, false);
+            }
+        } catch (Exception e) {
+            return new CommandResult("", "Failed to kill process " + pid + ": " + e.getMessage(), -1, 0, false);
+        }
+    }
+
+    @Tool("Check whether a command and workdir are safe to execute before running them. " +
+            "Returns SecurityResult with blocked=true/false, reason, and matched pattern. " +
+            "Parameters: command (required) — the command to check, workdir (optional) — the working directory to check")
+    public SecurityResult checkSecurity(String command, String workdir) {
+        SecurityResult commandCheck = commandFilter.check(command);
+        if (commandCheck.blocked()) {
+            return commandCheck;
+        }
+
+        if (workdir != null && !workdir.isBlank()) {
+            return workspaceConfinement.check(workdir);
+        }
+
+        return new SecurityResult(false, "", "", command);
+    }
+
+    /**
+     * Checks if a specific command is available on PATH.
+     * Uses native OS probe: {@code command -v} on Unix, {@code where} on Windows.
+     */
     public boolean isCommandAvailable(String command) {
         String probeCmd = IS_WINDOWS ? "where " + command + " >nul 2>&1" : "command -v " + command;
         try {
@@ -166,11 +285,19 @@ public class ShellTool {
         }
     }
 
+    private CommandResult blockedResult(SecurityResult security, long start) {
+        return new CommandResult(
+                "",
+                security.toString(),
+                SECURITY_BLOCK_EXIT_CODE,
+                System.currentTimeMillis() - start,
+                false
+        );
+    }
+
     private Path resolveWorkdir(String workdir) {
-        if (workdir != null && !workdir.isBlank()) {
-            return Path.of(workdir).toAbsolutePath();
-        }
-        return Path.of(workspaceRoot).toAbsolutePath();
+        Path resolved = workspaceConfinement.resolveCanonical(workdir);
+        return resolved != null ? resolved : Path.of(workspaceRoot).toAbsolutePath();
     }
 
     public static List<String> shellCommand(String command) {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/WorkspaceConfinement.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/WorkspaceConfinement.java
@@ -1,0 +1,55 @@
+package dev.omatheusmesmo.qlawkus.tool.shell;
+
+import dev.omatheusmesmo.qlawkus.dto.SecurityResult;
+import io.quarkus.logging.Log;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class WorkspaceConfinement {
+
+    @ConfigProperty(name = "qlawkus.shell.workspace-root", defaultValue = ".")
+    String workspaceRoot;
+
+    public SecurityResult check(String workdir) {
+        Path resolved = resolveCanonical(workdir);
+        Path workspace = resolveCanonical(workspaceRoot);
+
+        if (resolved == null || workspace == null) {
+            Log.warnf("WorkspaceConfinement: cannot resolve paths — workdir='%s', workspace='%s'", workdir, workspaceRoot);
+            return new SecurityResult(true, "Cannot resolve working directory", "path_resolution", workdir != null ? workdir : workspaceRoot);
+        }
+
+        if (!resolved.startsWith(workspace)) {
+            Log.warnf("WorkspaceConfinement: path escapes workspace — workdir='%s' (resolved='%s'), workspace='%s'",
+                    workdir, resolved, workspace);
+            return new SecurityResult(true, "Working directory escapes workspace root", "path_traversal", workdir);
+        }
+
+        return new SecurityResult(false, "", "", workdir);
+    }
+
+    public Path getWorkspacePath() {
+        Path resolved = resolveCanonical(workspaceRoot);
+        return resolved != null ? resolved : Path.of(workspaceRoot).toAbsolutePath();
+    }
+
+    Path resolveCanonical(String pathStr) {
+        if (pathStr == null || pathStr.isBlank()) {
+            return resolveCanonical(workspaceRoot);
+        }
+        try {
+            return Path.of(pathStr).toAbsolutePath().toRealPath();
+        } catch (IOException e) {
+            try {
+                return Path.of(pathStr).toAbsolutePath().normalize();
+            } catch (Exception ex) {
+                return null;
+            }
+        }
+    }
+}

--- a/client/runtime/src/main/resources/application.properties
+++ b/client/runtime/src/main/resources/application.properties
@@ -6,5 +6,6 @@ quarkus.langchain4j.pgvector.table=embeddings
 quarkus.langchain4j.pgvector.dimension=${EMBEDDING_DIMENSION:1024}
 quarkus.langchain4j.pgvector.metadata.storage-mode=combined-jsonb
 quarkus.langchain4j.pgvector.metadata.column-definitions=metadata JSONB NULL
-qlawkus.shell.default-timeout-seconds=30
 qlawkus.shell.workspace-root=.
+qlawkus.shell.denylist=sudo *,su *,rm -rf /*,mkfs*,dd if=*,format,shutdown,reboot
+qlawkus.shell.allowlist-mode=false


### PR DESCRIPTION
## Summary
- Implement issue #43 — security as infrastructure for ShellTool
- **CommandFilter**: configurable denylist with glob matching (`sudo *`, `rm -rf /*`, `mkfs*`, `dd if=*`, `format`, `shutdown`, `reboot`) + optional allowlist mode
- **WorkspaceConfinement**: canonical path resolution, blocks `../` traversal and paths outside workspace root
- **SecurityResult** record with `blocked`, `reason`, `pattern`, `command` + LLM-friendly `toString()`
- **Security checks** integrated into `runCommand()` — returns exitCode=-2 with SecurityResult in stderr on block
- **`checkSecurity()` @Tool** — proactive validation before running commands
- **`killProcess()` @Tool** — terminate tracked processes by PID (paired with `listActiveProcesses`)
- **Removed mandatory timeout**: `null` timeout = run until completion (fixes anti-pattern for long-running processes like dev servers)
- Config: `qlawkus.shell.denylist`, `qlawkus.shell.allowlist-mode`, `qlawkus.shell.allowlist`
- 39 tests passing (0 failures, 0 errors, 2 OS-skipped)

## Test plan
- [x] `commandFilter_denylist_blocksSudo` — sudo blocked
- [x] `commandFilter_denylist_blocksRmRfRoot` — rm -rf / blocked
- [x] `commandFilter_denylist_blocksMkfs` — mkfs blocked
- [x] `commandFilter_denylist_blocksShutdown` — shutdown blocked
- [x] `commandFilter_denylist_allowsSafeCommand` — ls allowed
- [x] `commandFilter_denylist_allowsGit` — git allowed
- [x] `commandFilter_allowlistMode_blocksNonAllowlisted` — non-allowlisted blocked
- [x] `commandFilter_globMatch_*` — exact, wildcard prefix, wildcard suffix
- [x] `workspaceConfinement_blocksPathTraversal` — ../etc blocked
- [x] `workspaceConfinement_allowsPathInsideWorkspace` — inside allowed
- [x] `workspaceConfinement_blocksAbsoluteOutsidePath` — /etc/passwd blocked
- [x] `runCommand_denylistBlocksSudo` — returns exitCode=-2
- [x] `runCommand_workspaceConfinementBlocksTraversal` — returns exitCode=-2
- [x] `checkSecurity_*` — allows safe, blocks dangerous, blocks traversal
- [x] `killProcess_forUnknownPid_returnsError` — graceful error
- [x] `runCommand_noTimeout_runsUntilCompletion` — no mandatory timeout

## Breaking changes
- `qlawkus.shell.default-timeout-seconds` removed — timeout is now opt-in (pass `timeoutSeconds` explicitly)
- `runCommand` with `null` timeout blocks until process completes (previously defaulted to 30s)