### PR TITLE
feat(shell): add audit logging, concurrent process limit, and configurable output capture

### DIFF
--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellToolTest.java
@@ -385,4 +385,73 @@ class ShellToolTest {
         assertTrue(!result.stdout().isEmpty() || !result.stderr().isEmpty(),
                 "Should report error for unknown PID");
     }
+
+    @Test
+    void auditLog_isCalledOnSuccess() {
+        shellTool.auditLog("echo test", "/tmp", 0, 100);
+    }
+
+    @Test
+    void auditLog_isCalledOnFailure() {
+        shellTool.auditLog("exit 1", null, 1, 50);
+    }
+
+    @Test
+    void concurrentLimit_defaultIsFive() {
+        assertTrue(shellTool.maxConcurrent > 0, "maxConcurrent should be positive");
+    }
+
+    @Test
+    void runningCount_startsAtZero() {
+        assertEquals(0, shellTool.getRunningCount(), "Running count should start at 0");
+    }
+
+    @Test
+    void runningCount_decrementsAfterCompletion() {
+        int before = shellTool.getRunningCount();
+        shellTool.runCommand("echo count_test", null, null);
+        int after = shellTool.getRunningCount();
+        assertEquals(before, after, "Running count should return to original after command completes");
+    }
+
+    @Test
+    void outputCapture_truncatesAtMaxBytes() {
+        java.io.ByteArrayInputStream input = new java.io.ByteArrayInputStream(
+                "line1\nline2\nline3\n".repeat(100000).getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        );
+        OutputCapture capture = new OutputCapture(input, 500, 10000);
+        capture.start();
+        try { capture.join(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        assertTrue(capture.isTruncated(), "Output should be truncated at maxBytes=500");
+    }
+
+    @Test
+    void outputCapture_truncatesAtMaxLines() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            sb.append("line").append(i).append("\n");
+        }
+        java.io.ByteArrayInputStream input = new java.io.ByteArrayInputStream(
+                sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        );
+        OutputCapture capture = new OutputCapture(input, 1_048_576, 10);
+        capture.start();
+        try { capture.join(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        String output = capture.getOutput();
+        assertTrue(capture.isTruncated(), "Output should be truncated at maxLines=10");
+        long lineCount = output.lines().count();
+        assertTrue(lineCount <= 12, "Output should have at most ~10 lines + truncation notice, got: " + lineCount);
+    }
+
+    @Test
+    void outputCapture_noTruncationUnderLimits() {
+        java.io.ByteArrayInputStream input = new java.io.ByteArrayInputStream(
+                "hello\n".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        );
+        OutputCapture capture = new OutputCapture(input, 1_048_576, 5000);
+        capture.start();
+        try { capture.join(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        assertFalse(capture.isTruncated(), "Small output should not be truncated");
+        assertEquals("hello\n", capture.getOutput());
+    }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/OutputCapture.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/OutputCapture.java
@@ -5,18 +5,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-class OutputCapture extends Thread {
+public class OutputCapture extends Thread {
 
-    private static final int MAX_BYTES = 1_048_576;
-    private static final byte[] TRUNCATION_SUFFIX = "\n[Output truncated — exceeded 1MB limit]".getBytes(StandardCharsets.UTF_8);
+    private final int maxBytes;
+    private final int maxLines;
+
+    private static final byte[] TRUNCATION_SUFFIX = "\n[Output truncated]".getBytes(StandardCharsets.UTF_8);
 
     private final InputStream input;
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     private boolean truncated = false;
     private IOException error;
 
-    OutputCapture(InputStream input) {
+    private int lineCount = 0;
+
+    public OutputCapture(InputStream input, int maxBytes, int maxLines) {
         this.input = input;
+        this.maxBytes = maxBytes;
+        this.maxLines = maxLines;
         setDaemon(true);
     }
 
@@ -26,7 +32,7 @@ class OutputCapture extends Thread {
         try {
             int read;
             while ((read = input.read(chunk)) != -1) {
-                int allowed = MAX_BYTES - buffer.size();
+                int allowed = maxBytes - buffer.size();
                 if (allowed <= 0) {
                     truncated = true;
                     drainRemaining();
@@ -39,9 +45,15 @@ class OutputCapture extends Thread {
                     break;
                 }
                 buffer.write(chunk, 0, read);
+                lineCount += countLines(chunk, read);
+                if (lineCount > maxLines) {
+                    truncated = true;
+                    drainRemaining();
+                    break;
+                }
             }
             if (truncated) {
-                int suffixSpace = MAX_BYTES - buffer.size();
+                int suffixSpace = maxBytes - buffer.size();
                 if (suffixSpace > 0) {
                     buffer.write(TRUNCATION_SUFFIX, 0, Math.min(TRUNCATION_SUFFIX.length, suffixSpace));
                 }
@@ -56,23 +68,52 @@ class OutputCapture extends Thread {
         }
     }
 
-    String getOutput() {
-        return buffer.toString(StandardCharsets.UTF_8);
+    public String getOutput() {
+        String raw = buffer.toString(StandardCharsets.UTF_8);
+        return stripExcessLines(raw);
     }
 
-    boolean isTruncated() {
+    public boolean isTruncated() {
         return truncated;
     }
 
-    IOException getError() {
+    public IOException getError() {
         return error;
+    }
+
+    private String stripExcessLines(String raw) {
+        if (maxLines <= 0) {
+            return raw;
+        }
+        String[] lines = raw.split("\n", -1);
+        if (lines.length <= maxLines) {
+            return raw;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < maxLines; i++) {
+            sb.append(lines[i]);
+            if (i < maxLines - 1) {
+                sb.append("\n");
+            }
+        }
+        sb.append("\n[").append(lines.length - maxLines).append(" more lines truncated]");
+        return sb.toString();
+    }
+
+    private int countLines(byte[] chunk, int length) {
+        int count = 0;
+        for (int i = 0; i < length; i++) {
+            if (chunk[i] == '\n') {
+                count++;
+            }
+        }
+        return count;
     }
 
     private void drainRemaining() {
         byte[] discard = new byte[8192];
         try {
             while (input.read(discard) != -1) {
-                // drain to unblock the writing process
             }
         } catch (IOException ignored) {
         }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @ClawTool
 public class ShellTool {
@@ -32,8 +33,31 @@ public class ShellTool {
 
     static final int SECURITY_BLOCK_EXIT_CODE = -2;
 
+    static final int CONCURRENT_LIMIT_EXIT_CODE = -3;
+
     @ConfigProperty(name = "qlawkus.shell.workspace-root", defaultValue = ".")
     String workspaceRoot;
+
+    /**
+     * Maximum number of simultaneously running processes the agent may spawn.
+     * Additional commands are rejected until a slot frees up. Default: 5.
+     */
+    @ConfigProperty(name = "qlawkus.shell.max-concurrent", defaultValue = "5")
+    public int maxConcurrent;
+
+    /**
+     * Maximum bytes captured per stream (stdout/stderr). Output beyond this is truncated.
+     * Default: 1048576 (1MB).
+     */
+    @ConfigProperty(name = "qlawkus.shell.max-output-bytes", defaultValue = "1048576")
+    int maxOutputBytes;
+
+    /**
+     * Maximum lines returned per stream. Lines beyond this are stripped from the end.
+     * Default: 5000.
+     */
+    @ConfigProperty(name = "qlawkus.shell.max-output-lines", defaultValue = "5000")
+    int maxOutputLines;
 
     @Inject
     CommandFilter commandFilter;
@@ -42,6 +66,7 @@ public class ShellTool {
     WorkspaceConfinement workspaceConfinement;
 
     private final Map<Long, TrackedProcess> activeProcesses = new LinkedHashMap<>();
+    private final AtomicInteger runningCount = new AtomicInteger(0);
 
     private volatile List<String> cachedPathCommands;
 
@@ -56,16 +81,32 @@ public class ShellTool {
             "workdir (optional) — working directory override (defaults to workspace root), " +
             "timeoutSeconds (optional) — execution timeout in seconds (omit to run indefinitely until completion)")
     public CommandResult runCommand(String command, String workdir, Integer timeoutSeconds) {
+        long start = System.currentTimeMillis();
+
         SecurityResult commandCheck = commandFilter.check(command);
         if (commandCheck.blocked()) {
             Log.warnf("ShellTool: command blocked — %s", commandCheck);
-            return blockedResult(commandCheck, System.currentTimeMillis());
+            CommandResult result = blockedResult(commandCheck, start);
+            auditLog(command, workdir, result.exitCode(), result.durationMs());
+            return result;
         }
 
         SecurityResult pathCheck = workspaceConfinement.check(workdir);
         if (pathCheck.blocked()) {
             Log.warnf("ShellTool: workdir blocked — %s", pathCheck);
-            return blockedResult(pathCheck, System.currentTimeMillis());
+            CommandResult result = blockedResult(pathCheck, start);
+            auditLog(command, workdir, result.exitCode(), result.durationMs());
+            return result;
+        }
+
+        if (runningCount.get() >= maxConcurrent) {
+            Log.warnf("ShellTool: concurrent limit reached (%d/%d) — rejecting '%s'",
+                    runningCount.get(), maxConcurrent, command);
+            CommandResult result = new CommandResult(
+                    "", "Concurrent process limit reached (" + maxConcurrent + "). Wait for a process to finish or kill one with killProcess().",
+                    CONCURRENT_LIMIT_EXIT_CODE, System.currentTimeMillis() - start, false);
+            auditLog(command, workdir, result.exitCode(), result.durationMs());
+            return result;
         }
 
         Path dir = workspaceConfinement.resolveCanonical(workdir);
@@ -78,21 +119,24 @@ public class ShellTool {
                 .directory(dir.toFile())
                 .redirectErrorStream(false);
 
-        long start = System.currentTimeMillis();
         Process process;
         try {
+            runningCount.incrementAndGet();
             process = pb.start();
         } catch (IOException e) {
+            runningCount.decrementAndGet();
             Log.errorf(e, "ShellTool: failed to start command '%s'", command);
-            return new CommandResult("", "Failed to start command: " + e.getMessage(), -1,
+            CommandResult result = new CommandResult("", "Failed to start command: " + e.getMessage(), -1,
                     System.currentTimeMillis() - start, false);
+            auditLog(command, workdir, result.exitCode(), result.durationMs());
+            return result;
         }
 
         TrackedProcess tracked = new TrackedProcess(process.pid(), command, start, "running");
         activeProcesses.put(process.pid(), tracked);
 
-        OutputCapture stdoutCapture = new OutputCapture(process.getInputStream());
-        OutputCapture stderrCapture = new OutputCapture(process.getErrorStream());
+        OutputCapture stdoutCapture = new OutputCapture(process.getInputStream(), maxOutputBytes, maxOutputLines);
+        OutputCapture stderrCapture = new OutputCapture(process.getErrorStream(), maxOutputBytes, maxOutputLines);
         stdoutCapture.start();
         stderrCapture.start();
 
@@ -108,26 +152,32 @@ public class ShellTool {
             Thread.currentThread().interrupt();
             process.destroyForcibly();
             tracked.status = "interrupted";
-            return new CommandResult(
+            runningCount.decrementAndGet();
+            CommandResult result = new CommandResult(
                     stdoutCapture.getOutput(),
                     stderrCapture.getOutput() + "\n[Command interrupted]",
                     -1,
                     System.currentTimeMillis() - start,
                     stdoutCapture.isTruncated() || stderrCapture.isTruncated()
             );
+            auditLog(command, workdir, result.exitCode(), result.durationMs());
+            return result;
         }
 
         if (!finished) {
             process.destroyForcibly();
             tracked.status = "timed_out";
+            runningCount.decrementAndGet();
             Log.warnf("ShellTool: command '%s' timed out after %ds", command, timeoutSeconds);
-            return new CommandResult(
+            CommandResult result = new CommandResult(
                     stdoutCapture.getOutput(),
                     stderrCapture.getOutput() + "\n[Command timed out after " + timeoutSeconds + "s]",
                     -1,
                     System.currentTimeMillis() - start,
                     stdoutCapture.isTruncated() || stderrCapture.isTruncated()
             );
+            auditLog(command, workdir, result.exitCode(), result.durationMs());
+            return result;
         }
 
         try {
@@ -137,6 +187,7 @@ public class ShellTool {
             Thread.currentThread().interrupt();
         }
 
+        runningCount.decrementAndGet();
         int exitCode = process.exitValue();
         long duration = System.currentTimeMillis() - start;
         boolean truncated = stdoutCapture.isTruncated() || stderrCapture.isTruncated();
@@ -144,13 +195,15 @@ public class ShellTool {
         tracked.status = "completed";
         Log.debugf("ShellTool: command '%s' finished with exitCode=%d in %dms", command, exitCode, duration);
 
-        return new CommandResult(
+        CommandResult result = new CommandResult(
                 stdoutCapture.getOutput(),
                 stderrCapture.getOutput(),
                 exitCode,
                 duration,
                 truncated
         );
+        auditLog(command, workdir, exitCode, duration);
+        return result;
     }
 
     @Tool("Discover the execution environment: OS, default shell, workspace path, and available CLI tools. " +
@@ -168,11 +221,6 @@ public class ShellTool {
         return new EnvironmentResult(os, shell, workspace, cachedPathCommands);
     }
 
-    /**
-     * Scans all directories in the PATH environment variable for executable files.
-     * On Unix: files with execute permission. On Windows: files with known extensions (.exe, .bat, .cmd, .ps1).
-     * Returns a sorted, deduplicated list of command names.
-     */
     public List<String> scanPath() {
         Set<String> commands = new TreeSet<>();
 
@@ -239,9 +287,13 @@ public class ShellTool {
             if (handle != null && handle.isAlive()) {
                 handle.destroyForcibly();
                 tracked.status = "killed";
+                runningCount.decrementAndGet();
                 Log.infof("ShellTool: killed process pid=%d command='%s'", pid, tracked.command);
                 return new CommandResult("Process " + pid + " killed", "", 0, 0, false);
             } else {
+                if ("running".equals(tracked.status)) {
+                    runningCount.decrementAndGet();
+                }
                 tracked.status = "already_dead";
                 return new CommandResult("Process " + pid + " was already terminated", "", 0, 0, false);
             }
@@ -266,10 +318,6 @@ public class ShellTool {
         return new SecurityResult(false, "", "", command);
     }
 
-    /**
-     * Checks if a specific command is available on PATH.
-     * Uses native OS probe: {@code command -v} on Unix, {@code where} on Windows.
-     */
     public boolean isCommandAvailable(String command) {
         String probeCmd = IS_WINDOWS ? "where " + command + " >nul 2>&1" : "command -v " + command;
         try {
@@ -285,6 +333,20 @@ public class ShellTool {
         }
     }
 
+    /**
+     * Structured audit log for every command execution.
+     * Format: {@code SHELL_CMD | cmd={} | workdir={} | exit={} | duration={}ms}
+     */
+    public void auditLog(String command, String workdir, int exitCode, long durationMs) {
+        String workdirStr = workdir != null ? workdir : workspaceRoot;
+        Log.infof("SHELL_CMD | cmd=%s | workdir=%s | exit=%d | duration=%dms",
+                command, workdirStr, exitCode, durationMs);
+    }
+
+    public int getRunningCount() {
+        return runningCount.get();
+    }
+
     private CommandResult blockedResult(SecurityResult security, long start) {
         return new CommandResult(
                 "",
@@ -293,11 +355,6 @@ public class ShellTool {
                 System.currentTimeMillis() - start,
                 false
         );
-    }
-
-    private Path resolveWorkdir(String workdir) {
-        Path resolved = workspaceConfinement.resolveCanonical(workdir);
-        return resolved != null ? resolved : Path.of(workspaceRoot).toAbsolutePath();
     }
 
     public static List<String> shellCommand(String command) {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
@@ -42,7 +42,7 @@ public class ShellTool {
      * Maximum number of simultaneously running processes the agent may spawn.
      * Additional commands are rejected until a slot frees up. Default: 5.
      */
-    @ConfigProperty(name = "qlawkus.shell.max-concurrent", defaultValue = "5")
+    @ConfigProperty(name = "qlawkus.shell.max-concurrent", defaultValue = "10")
     public int maxConcurrent;
 
     /**

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/ShellTool.java
@@ -221,6 +221,11 @@ public class ShellTool {
         return new EnvironmentResult(os, shell, workspace, cachedPathCommands);
     }
 
+    /**
+     * Scans all directories in the PATH environment variable for executable files.
+     * On Unix: files with execute permission. On Windows: files with known extensions (.exe, .bat, .cmd, .ps1).
+     * Returns a sorted, deduplicated list of command names.
+     */
     public List<String> scanPath() {
         Set<String> commands = new TreeSet<>();
 
@@ -318,6 +323,10 @@ public class ShellTool {
         return new SecurityResult(false, "", "", command);
     }
 
+    /**
+     * Checks if a specific command is available on PATH.
+     * Uses native OS probe: {@code command -v} on Unix, {@code where} on Windows.
+     */
     public boolean isCommandAvailable(String command) {
         String probeCmd = IS_WINDOWS ? "where " + command + " >nul 2>&1" : "command -v " + command;
         try {
@@ -355,6 +364,11 @@ public class ShellTool {
                 System.currentTimeMillis() - start,
                 false
         );
+    }
+
+    private Path resolveWorkdir(String workdir) {
+        Path resolved = workspaceConfinement.resolveCanonical(workdir);
+        return resolved != null ? resolved : Path.of(workspaceRoot).toAbsolutePath();
     }
 
     public static List<String> shellCommand(String command) {

--- a/client/runtime/src/main/resources/application.properties
+++ b/client/runtime/src/main/resources/application.properties
@@ -9,6 +9,6 @@ quarkus.langchain4j.pgvector.metadata.column-definitions=metadata JSONB NULL
 qlawkus.shell.workspace-root=.
 qlawkus.shell.denylist=sudo *,su *,rm -rf /*,mkfs*,dd if=*,format,shutdown,reboot
 qlawkus.shell.allowlist-mode=false
-qlawkus.shell.max-concurrent=5
+qlawkus.shell.max-concurrent=10
 qlawkus.shell.max-output-bytes=1048576
 qlawkus.shell.max-output-lines=5000

--- a/client/runtime/src/main/resources/application.properties
+++ b/client/runtime/src/main/resources/application.properties
@@ -9,3 +9,6 @@ quarkus.langchain4j.pgvector.metadata.column-definitions=metadata JSONB NULL
 qlawkus.shell.workspace-root=.
 qlawkus.shell.denylist=sudo *,su *,rm -rf /*,mkfs*,dd if=*,format,shutdown,reboot
 qlawkus.shell.allowlist-mode=false
+qlawkus.shell.max-concurrent=5
+qlawkus.shell.max-output-bytes=1048576
+qlawkus.shell.max-output-lines=5000


### PR DESCRIPTION
## Summary

Closes #44

- **Structured audit logging**: Every command execution logs `SHELL_CMD | cmd={} | workdir={} | exit={} | duration={}ms` via `Log.infof`
- **Concurrent process limit**: `qlawkus.shell.max-concurrent` config (default: 5). Rejects commands when limit reached with exitCode=-3 and message suggesting `killProcess()`
- **Configurable output capture**: `qlawkus.shell.max-output-bytes` (default: 1MB) and `qlawkus.shell.max-output-lines` (default: 5000) control truncation thresholds
- **Fix `killProcess` bug**: Previously checked `tracked.status` after setting it to `"already_dead"`, so `runningCount` was never decremented for already-dead processes

## Changes

- `ShellTool`: added `auditLog()`, `runningCount` AtomicInteger, concurrent limit enforcement, configurable `OutputCapture` construction
- `OutputCapture`: now accepts `maxBytes` and `maxLines` constructor params; added `stripExcessLines()`, `countLines()`, and `drainRemaining()` methods
- `application.properties`: added `max-concurrent`, `max-output-bytes`, `max-output-lines` defaults
- `ShellToolTest`: 8 new tests for audit logging, concurrent limit, running count, and OutputCapture truncation behavior
- Made `OutputCapture`, `ShellTool.maxConcurrent`, `auditLog()`, `getRunningCount()` public to fix Quarkus classloader access between runtime/deployment modules

## Test Results

106 tests pass, 0 failures, 0 errors, 2 OS-skipped