### PR TITLE
feat(shell): prompt detection, default shell resolution, and clean profile

### DIFF
--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/InteractiveShellToolTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/InteractiveShellToolTest.java
@@ -26,7 +26,7 @@ class InteractiveShellToolTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void startSession_returnsSessionId() {
-        String sessionId = interactiveShellTool.startSession("bash", null);
+        String sessionId =         interactiveShellTool.startSession("bash", null, null);
 
         assertNotNull(sessionId, "Session ID should not be null");
         assertFalse(sessionId.isEmpty(), "Session ID should not be empty");
@@ -37,7 +37,7 @@ class InteractiveShellToolTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void sendInput_andReadSession_returnsOutput() throws Exception {
-        String sessionId = interactiveShellTool.startSession("bash", null);
+        String sessionId =         interactiveShellTool.startSession("bash", null, null);
 
         interactiveShellTool.sendInput(sessionId, "echo pty_test_output");
         Thread.sleep(1000);
@@ -54,7 +54,7 @@ class InteractiveShellToolTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void readSession_withOffset_returnsOnlyNewLines() throws Exception {
-        String sessionId = interactiveShellTool.startSession("bash", null);
+        String sessionId =         interactiveShellTool.startSession("bash", null, null);
 
         interactiveShellTool.sendInput(sessionId, "echo line1");
         Thread.sleep(800);
@@ -74,7 +74,7 @@ class InteractiveShellToolTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void closeSession_terminatesProcess() {
-        String sessionId = interactiveShellTool.startSession("bash", null);
+        String sessionId =         interactiveShellTool.startSession("bash", null, null);
 
         String result = interactiveShellTool.closeSession(sessionId);
         assertTrue(result.contains("closed"), "Close result should mention 'closed'");
@@ -87,7 +87,7 @@ class InteractiveShellToolTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void listSessions_showsActiveSession() {
-        String sessionId = interactiveShellTool.startSession("bash", null);
+        String sessionId =         interactiveShellTool.startSession("bash", null, null);
 
         List<SessionInfo> sessions = interactiveShellTool.listSessions();
         assertTrue(sessions.stream().anyMatch(s -> s.sessionId().equals(sessionId)),
@@ -112,7 +112,7 @@ class InteractiveShellToolTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void sendInput_preservesStateBetweenCommands() throws Exception {
-        String sessionId = interactiveShellTool.startSession("bash", null);
+        String sessionId = interactiveShellTool.startSession("bash", null, null);
 
         interactiveShellTool.sendInput(sessionId, "export PTY_VAR=hello_from_pty");
         Thread.sleep(800);
@@ -124,5 +124,49 @@ class InteractiveShellToolTest {
                 "PTY session should preserve env vars between commands, got: " + output.lines());
 
         interactiveShellTool.closeSession(sessionId);
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void startSession_withPrompts_detectsPromptInOutput() throws Exception {
+        String sessionId = interactiveShellTool.startSession("bash", null, "[#$>] ");
+
+        interactiveShellTool.sendInput(sessionId, "echo hello_prompt");
+        Thread.sleep(1000);
+
+        SessionOutput output = interactiveShellTool.readSession(sessionId, 0);
+        assertTrue(output.lines().stream().anyMatch(l -> l.contains("hello_prompt")),
+                "Output should contain echo output, got: " + output.lines());
+
+        interactiveShellTool.closeSession(sessionId);
+    }
+
+    @Test
+    void startSession_defaultShell_resolvedFromConfig() {
+        String shell = sessionManager.getDefaultShell();
+        assertNotNull(shell, "Default shell should not be null");
+        assertFalse(shell.isBlank(), "Default shell should not be blank");
+    }
+
+    @Test
+    void resolveCommand_bareShellName_appliesCleanProfile() {
+        String resolved = sessionManager.resolveCommand("bash");
+        if (!ShellTool.IS_WINDOWS && sessionManager.cleanProfile) {
+            assertTrue(resolved.contains("--norc"), "Bare 'bash' should get --norc with clean-profile=true, got: " + resolved);
+            assertTrue(resolved.contains("--noprofile"), "Bare 'bash' should get --noprofile with clean-profile=true, got: " + resolved);
+        }
+    }
+
+    @Test
+    void resolveCommand_nonShellCommand_unchanged() {
+        String resolved = sessionManager.resolveCommand("python3");
+        assertEquals("python3", resolved, "Non-shell command should pass through unchanged");
+    }
+
+    @Test
+    void resolveCommand_nullOrBlank_usesDefaultShell() {
+        String resolved = sessionManager.resolveCommand(null);
+        assertNotNull(resolved, "Null command should resolve to default shell");
+        assertFalse(resolved.isBlank(), "Default shell should not be blank");
     }
 }

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/PtySessionTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/tool/shell/PtySessionTest.java
@@ -1,0 +1,78 @@
+package dev.omatheusmesmo.qlawkus.tool.shell;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PtySessionTest {
+
+    @Test
+    void checkPrompt_matchingPattern_setsPromptDetected() {
+        PtySession session = createSessionWithPrompts(List.of(Pattern.compile("[#$>] ")));
+
+        session.checkPrompt("user@host:~$ ");
+        assertTrue(session.isPromptDetected(), "Should detect bash prompt pattern");
+    }
+
+    @Test
+    void checkPrompt_pythonRepl_setsPromptDetected() {
+        PtySession session = createSessionWithPrompts(List.of(Pattern.compile(">>> ")));
+
+        session.checkPrompt(">>> ");
+        assertTrue(session.isPromptDetected(), "Should detect Python REPL prompt");
+    }
+
+    @Test
+    void checkPrompt_noMatch_doesNotSetPromptDetected() {
+        PtySession session = createSessionWithPrompts(List.of(Pattern.compile(">>> ")));
+
+        session.checkPrompt("some output line");
+        assertFalse(session.isPromptDetected(), "Should not detect prompt in regular output");
+    }
+
+    @Test
+    void checkPrompt_emptyPatterns_doesNotSetPromptDetected() {
+        PtySession session = createSessionWithPrompts(List.of());
+
+        session.checkPrompt("$ ");
+        assertFalse(session.isPromptDetected(), "No patterns means no detection");
+    }
+
+    @Test
+    void clearPromptDetected_resetsFlag() {
+        PtySession session = createSessionWithPrompts(List.of(Pattern.compile("[#$>] ")));
+
+        session.checkPrompt("$ ");
+        assertTrue(session.isPromptDetected());
+
+        session.clearPromptDetected();
+        assertFalse(session.isPromptDetected(), "Should reset prompt detected flag");
+    }
+
+    @Test
+    void getPromptPatternStrings_returnsPatternStrings() {
+        PtySession session = createSessionWithPrompts(
+                List.of(Pattern.compile("[#$>] "), Pattern.compile(">>> ")));
+
+        List<String> patterns = session.getPromptPatternStrings();
+        assertEquals(2, patterns.size());
+        assertTrue(patterns.contains("[#$>] "));
+        assertTrue(patterns.contains(">>> "));
+    }
+
+    @Test
+    void checkPrompt_multiplePatterns_matchesAny() {
+        PtySession session = createSessionWithPrompts(
+                List.of(Pattern.compile("[#$>] "), Pattern.compile(">>> ")));
+
+        session.checkPrompt(">>> import os");
+        assertTrue(session.isPromptDetected(), "Should match Python pattern");
+    }
+
+    private PtySession createSessionWithPrompts(List<Pattern> patterns) {
+        return new PtySession("test-id", "test-cmd", null, new RollingBuffer(1000), null, patterns);
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/SessionInfo.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/SessionInfo.java
@@ -1,7 +1,9 @@
 package dev.omatheusmesmo.qlawkus.dto;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.List;
 
 @RegisterForReflection
-public record SessionInfo(String sessionId, String command, String status, long lastActivityMs) {
+public record SessionInfo(String sessionId, String command, String status, long lastActivityMs,
+                          List<String> promptPatterns) {
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/SessionOutput.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/dto/SessionOutput.java
@@ -4,5 +4,5 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 
 @RegisterForReflection
-public record SessionOutput(List<String> lines, boolean hasMore, int offset) {
+public record SessionOutput(List<String> lines, boolean hasMore, int offset, boolean promptDetected) {
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/InteractiveShellTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/InteractiveShellTool.java
@@ -15,12 +15,17 @@ public class InteractiveShellTool {
 
     @Tool("Start an interactive PTY session (e.g. bash, python REPL, docker exec). "
             + "Returns a sessionId for use with readSession/sendInput/closeSession. "
-            + "Parameters: command (required) — the command to run in the PTY, "
-            + "workdir (optional) — working directory (defaults to workspace root). "
+            + "Parameters: command (optional) — the command to run (defaults to system shell), "
+            + "workdir (optional) — working directory (defaults to workspace root), "
+            + "prompts (optional) — comma-separated regex patterns to detect shell prompts (e.g. \"[#$>] \",\">>> \"). "
+            + "readSession will include promptDetected=true when a prompt pattern matches. "
             + "NOTE: PTY sessions are not available in native image mode — use runCommand instead.")
-    public String startSession(String command, String workdir) {
+    public String startSession(String command, String workdir, String prompts) {
         try {
-            return sessionManager.startSession(command, workdir);
+            List<String> promptList = (prompts != null && !prompts.isBlank())
+                    ? List.of(prompts.split(","))
+                    : null;
+            return sessionManager.startSession(command, workdir, promptList);
         } catch (UnsupportedOperationException e) {
             return "ERROR: " + e.getMessage();
         } catch (IllegalStateException e) {
@@ -30,20 +35,21 @@ public class InteractiveShellTool {
         }
     }
 
-    @Tool("Read output from an interactive PTY session since a given line offset. " +
-            "Parameters: sessionId (required) — the session ID from startSession, " +
-            "offset (optional) — line offset to read from (default 0 for all buffered output)")
+    @Tool("Read output from an interactive PTY session since a given line offset. "
+            + "Returns promptDetected=true when a shell prompt pattern was matched in the output. "
+            + "Parameters: sessionId (required) — the session ID from startSession, "
+            + "offset (optional) — line offset to read from (default 0 for all buffered output)")
     public SessionOutput readSession(String sessionId, Integer offset) {
         try {
             return sessionManager.readSession(sessionId, offset != null ? offset : 0);
         } catch (IllegalArgumentException e) {
-            return new SessionOutput(List.of("ERROR: " + e.getMessage()), false, 0);
+            return new SessionOutput(List.of("ERROR: " + e.getMessage()), false, 0, false);
         }
     }
 
-    @Tool("Send input to an interactive PTY session (appended with newline by default). " +
-            "Parameters: sessionId (required) — the session ID, " +
-            "input (required) — the text to send to the PTY stdin")
+    @Tool("Send input to an interactive PTY session (appended with newline by default). "
+            + "Parameters: sessionId (required) — the session ID, "
+            + "input (required) — the text to send to the PTY stdin")
     public String sendInput(String sessionId, String input) {
         try {
             sessionManager.sendInput(sessionId, input + "\n");
@@ -55,8 +61,8 @@ public class InteractiveShellTool {
         }
     }
 
-    @Tool("Close an interactive PTY session, terminating its process. " +
-            "Parameter: sessionId (required) — the session ID to close")
+    @Tool("Close an interactive PTY session, terminating its process. "
+            + "Parameter: sessionId (required) — the session ID to close")
     public String closeSession(String sessionId) {
         try {
             sessionManager.closeSession(sessionId);
@@ -66,7 +72,7 @@ public class InteractiveShellTool {
         }
     }
 
-    @Tool("List all active PTY sessions with their id, command, status, and last activity time")
+    @Tool("List all active PTY sessions with their id, command, status, prompt patterns, and last activity time")
     public List<SessionInfo> listSessions() {
         return sessionManager.listSessions();
     }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/PtySession.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/PtySession.java
@@ -7,6 +7,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
 
 public class PtySession {
 
@@ -14,20 +18,57 @@ public class PtySession {
     private final String command;
     private final PtyProcess process;
     private final RollingBuffer outputBuffer;
-    private final Thread readerThread;
+    private Thread readerThread;
     private final Instant startedAt;
+    private final List<Pattern> promptPatterns;
     private volatile Instant lastActivity;
     private volatile String status;
+    private volatile boolean promptDetected;
 
-    PtySession(String sessionId, String command, PtyProcess process, RollingBuffer outputBuffer, Thread readerThread) {
+    PtySession(String sessionId, String command, PtyProcess process, RollingBuffer outputBuffer,
+               Thread readerThread, List<Pattern> promptPatterns) {
         this.sessionId = sessionId;
         this.command = command;
         this.process = process;
         this.outputBuffer = outputBuffer;
         this.readerThread = readerThread;
+        this.promptPatterns = promptPatterns != null ? promptPatterns : List.of();
         this.startedAt = Instant.now();
         this.lastActivity = Instant.now();
         this.status = "running";
+        this.promptDetected = false;
+    }
+
+    void setReaderThread(Thread thread) {
+        this.readerThread = thread;
+    }
+
+    void checkPrompt(String line) {
+        if (promptPatterns.isEmpty()) {
+            return;
+        }
+        for (Pattern pattern : promptPatterns) {
+            if (pattern.matcher(line).find()) {
+                promptDetected = true;
+                return;
+            }
+        }
+    }
+
+    public boolean isPromptDetected() {
+        return promptDetected;
+    }
+
+    public void clearPromptDetected() {
+        promptDetected = false;
+    }
+
+    public List<String> getPromptPatternStrings() {
+        List<String> result = new ArrayList<>();
+        for (Pattern p : promptPatterns) {
+            result.add(p.pattern());
+        }
+        return result;
     }
 
     public String getSessionId() {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/PtySessionManager.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tool/shell/PtySessionManager.java
@@ -6,6 +6,7 @@ import dev.omatheusmesmo.qlawkus.dto.SessionInfo;
 import dev.omatheusmesmo.qlawkus.dto.SessionOutput;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -22,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 @ApplicationScoped
 public class PtySessionManager {
@@ -48,10 +51,41 @@ public class PtySessionManager {
     @ConfigProperty(name = "qlawkus.shell.workspace-root", defaultValue = ".")
     String workspaceRoot;
 
+    @ConfigProperty(name = "qlawkus.shell.default-shell", defaultValue = "auto")
+    String defaultShellConfig;
+
+    @ConfigProperty(name = "qlawkus.shell.clean-profile", defaultValue = "true")
+    public boolean cleanProfile;
+
+    @ConfigProperty(name = "qlawkus.shell.prompts")
+    List<String> defaultPromptPatterns;
+
+    private String detectedDefaultShell;
+
     private final ConcurrentHashMap<String, PtySession> sessions = new ConcurrentHashMap<>();
 
     @Inject
     WorkspaceConfinement workspaceConfinement;
+
+    @PostConstruct
+    void init() {
+        detectedDefaultShell = detectDefaultShell();
+        if (!"auto".equals(defaultShellConfig)) {
+            detectedDefaultShell = defaultShellConfig;
+        }
+        Log.infof("Default shell: %s, clean-profile: %s", detectedDefaultShell, cleanProfile);
+    }
+
+    static String detectDefaultShell() {
+        if (ShellTool.IS_WINDOWS) {
+            return "cmd.exe";
+        }
+        String shell = System.getenv("SHELL");
+        if (shell != null && !shell.isBlank()) {
+            return shell;
+        }
+        return "/bin/sh";
+    }
 
     PtySessionManager() {
         nativeImageMode = "true".equals(System.getProperty("io.quarkus.native.image", "false"))
@@ -75,7 +109,7 @@ public class PtySessionManager {
         return nativeImageMode;
     }
 
-    public String startSession(String command, String workdir) throws IOException {
+    public String startSession(String command, String workdir, List<String> prompts) throws IOException {
         if (nativeImageMode) {
             throw new UnsupportedOperationException(NATIVE_IMAGE_UNAVAILABLE);
         }
@@ -84,9 +118,10 @@ public class PtySessionManager {
         }
 
         String sessionId = UUID.randomUUID().toString();
+        String effectiveCommand = resolveCommand(command);
         String[] cmdArgs = ShellTool.IS_WINDOWS
-                ? new String[]{"cmd", "/c", command}
-                : new String[]{"sh", "-c", command};
+                ? new String[]{"cmd", "/c", effectiveCommand}
+                : new String[]{"sh", "-c", effectiveCommand};
 
         java.io.File dir = resolveDir(workdir);
 
@@ -102,6 +137,8 @@ public class PtySessionManager {
                 .start();
 
         RollingBuffer buffer = new RollingBuffer(bufferLines);
+        List<Pattern> compiledPrompts = compilePromptPatterns(prompts);
+        PtySession session = new PtySession(sessionId, effectiveCommand, process, buffer, null, compiledPrompts);
 
         Thread readerThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
@@ -109,6 +146,7 @@ public class PtySessionManager {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     buffer.addLine(line);
+                    session.checkPrompt(line);
                 }
             } catch (IOException e) {
                 if (!"closed".equals(sessions.get(sessionId) != null ? sessions.get(sessionId).getStatus() : "")) {
@@ -119,7 +157,7 @@ public class PtySessionManager {
         readerThread.setDaemon(true);
         readerThread.start();
 
-        PtySession session = new PtySession(sessionId, command, process, buffer, readerThread);
+        session.setReaderThread(readerThread);
         sessions.put(sessionId, session);
 
         Log.infof("PTY session started: id=%s command='%s' dir=%s", sessionId, command, dir);
@@ -128,7 +166,7 @@ public class PtySessionManager {
 
     public SessionOutput readSession(String sessionId, int offset) {
         if (nativeImageMode) {
-            return new SessionOutput(List.of("ERROR: " + NATIVE_IMAGE_UNAVAILABLE), false, 0);
+            return new SessionOutput(List.of("ERROR: " + NATIVE_IMAGE_UNAVAILABLE), false, 0, false);
         }
         PtySession session = requireSession(sessionId);
         session.updateStatus();
@@ -136,8 +174,10 @@ public class PtySessionManager {
 
         List<String> lines = session.getOutputBuffer().getLinesFrom(offset);
         boolean hasMore = session.getOutputBuffer().hasMoreAfter(offset + lines.size());
+        boolean promptDetected = session.isPromptDetected();
+        session.clearPromptDetected();
 
-        return new SessionOutput(lines, hasMore, offset + lines.size());
+        return new SessionOutput(lines, hasMore, offset + lines.size(), promptDetected);
     }
 
     public void sendInput(String sessionId, String input) throws IOException {
@@ -168,7 +208,8 @@ public class PtySessionManager {
                     session.getSessionId(),
                     session.getCommand(),
                     session.getStatus(),
-                    session.getLastActivity().toEpochMilli()
+                    session.getLastActivity().toEpochMilli(),
+                    session.getPromptPatternStrings()
             ));
         }
         return result;
@@ -226,5 +267,62 @@ public class PtySessionManager {
             throw new SecurityException("Workdir blocked: " + security.reason());
         }
         return workspaceConfinement.resolveCanonical(workdir).toFile();
+    }
+
+    public String resolveCommand(String command) {
+        if (command == null || command.isBlank()) {
+            return applyCleanProfile(detectedDefaultShell);
+        }
+        String trimmed = command.trim();
+        if (isBareShellName(trimmed)) {
+            return applyCleanProfile(resolveShellPath(trimmed));
+        }
+        return command;
+    }
+
+    private boolean isBareShellName(String command) {
+        return !command.contains("/") && !command.contains("\\") && !command.contains(" ")
+                && List.of("bash", "sh", "zsh", "fish", "dash", "ksh", "csh", "tcsh").contains(command);
+    }
+
+    private String resolveShellPath(String shellName) {
+        if (ShellTool.IS_WINDOWS) {
+            return shellName;
+        }
+        return "/bin/" + shellName;
+    }
+
+    private String applyCleanProfile(String shellCommand) {
+        if (!cleanProfile || ShellTool.IS_WINDOWS) {
+            return shellCommand;
+        }
+        String lower = shellCommand.toLowerCase();
+        if (lower.endsWith("/bash") || lower.endsWith("/sh") || lower.endsWith("/zsh")
+                || lower.endsWith("/dash") || lower.endsWith("/ksh")) {
+            return shellCommand + " --norc --noprofile";
+        }
+        return shellCommand;
+    }
+
+    List<Pattern> compilePromptPatterns(List<String> prompts) {
+        List<String> effective = (prompts != null && !prompts.isEmpty()) ? prompts : defaultPromptPatterns;
+        if (effective == null || effective.isEmpty()) {
+            return List.of();
+        }
+        List<Pattern> compiled = new ArrayList<>();
+        for (String p : effective) {
+            if (p != null && !p.isBlank()) {
+                try {
+                    compiled.add(Pattern.compile(p));
+                } catch (PatternSyntaxException e) {
+                    Log.warnf("Invalid prompt pattern '%s': %s", p, e.getMessage());
+                }
+            }
+        }
+        return compiled;
+    }
+
+    public String getDefaultShell() {
+        return detectedDefaultShell;
     }
 }

--- a/client/runtime/src/main/resources/application.properties
+++ b/client/runtime/src/main/resources/application.properties
@@ -17,3 +17,6 @@ qlawkus.shell.pty.idle-timeout-minutes=30
 qlawkus.shell.pty.buffer-lines=50000
 qlawkus.shell.pty.default-cols=120
 qlawkus.shell.pty.default-rows=40
+qlawkus.shell.default-shell=auto
+qlawkus.shell.clean-profile=true
+qlawkus.shell.prompts=[#$>] ,>>> ,\\$ ,# 

--- a/integration-tests/src/main/java/dev/omatheusmesmo/qlawkus/it/PtyTestResource.java
+++ b/integration-tests/src/main/java/dev/omatheusmesmo/qlawkus/it/PtyTestResource.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
 
 @Path("/api/test/pty")
 @Authenticated
@@ -25,12 +26,13 @@ public class PtyTestResource {
 
     @POST
     @Path("/start")
-    public Response startSession(@QueryParam("cmd") String cmd, @QueryParam("workdir") String workdir) {
+    public Response startSession(@QueryParam("cmd") String cmd, @QueryParam("workdir") String workdir,
+            @QueryParam("prompts") String prompts) {
         try {
-            String sessionId = interactiveShellTool.startSession(cmd, workdir);
-            return Response.ok("{\"sessionId\":\"" + sessionId + "\"}").build();
+            String sessionId = interactiveShellTool.startSession(cmd, workdir, prompts);
+            return Response.ok(Map.of("sessionId", sessionId)).build();
         } catch (UnsupportedOperationException e) {
-            return Response.ok("{\"error\":\"" + e.getMessage() + "\"}").build();
+            return Response.ok(Map.of("error", e.getMessage())).build();
         }
     }
 
@@ -45,7 +47,7 @@ public class PtyTestResource {
     @Path("/send/{sessionId}")
     public Response sendInput(@PathParam("sessionId") String sessionId, @QueryParam("input") String input) {
         String result = interactiveShellTool.sendInput(sessionId, input);
-        return Response.ok("{\"result\":\"" + result + "\"}").build();
+        return Response.ok(Map.of("result", result)).build();
     }
 
     @DELETE
@@ -53,9 +55,9 @@ public class PtyTestResource {
     public Response closeSession(@PathParam("sessionId") String sessionId) {
         try {
             String result = interactiveShellTool.closeSession(sessionId);
-            return Response.ok("{\"result\":\"" + result + "\"}").build();
+            return Response.ok(Map.of("result", result)).build();
         } catch (UnsupportedOperationException e) {
-            return Response.ok("{\"error\":\"" + e.getMessage() + "\"}").build();
+            return Response.ok(Map.of("error", e.getMessage())).build();
         }
     }
 

--- a/integration-tests/src/main/java/dev/omatheusmesmo/qlawkus/it/ShellTestResource.java
+++ b/integration-tests/src/main/java/dev/omatheusmesmo/qlawkus/it/ShellTestResource.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 
 @Path("/api/test/shell")
 @Authenticated
@@ -45,6 +46,6 @@ public class ShellTestResource {
     @Path("/available")
     public Response isCommandAvailable(@QueryParam("cmd") String cmd) {
         boolean available = shellTool.isCommandAvailable(cmd);
-        return Response.ok().entity("{\"available\":" + available + "}").build();
+        return Response.ok(Map.of("available", available)).build();
     }
 }


### PR DESCRIPTION
## Summary

- Add configurable prompt pattern detection to InteractiveShellTool sessions — `readSession` returns `promptDetected=true` when a configured regex matches output, enabling LLM agents to know when a shell is ready for input
- Add default shell auto-detection from `$SHELL` env var (or `cmd.exe` on Windows), overridable via `qlawkus.shell.default-shell` config
- Add clean profile support — bare shell names (bash, sh, zsh, etc.) get `--norc --noprofile` appended when `qlawkus.shell.clean-profile=true` (default)
- Fix test resources to return entities via `Map.of()` instead of concatenated JSON strings
- Make `resolveCommand()` and `cleanProfile` public for Quarkus ClassLoader access in dev-mode tests

## Changes

- `InteractiveShellTool.startSession` now accepts optional `prompts` parameter (comma-separated regex patterns)
- `SessionOutput` record gains `promptDetected` field
- `SessionInfo` record gains `promptPatterns` field
- `PtySession` checks each output line against compiled prompt patterns
- `PtySessionManager` adds `detectDefaultShell()`, `resolveCommand()`, `applyCleanProfile()`, `compilePromptPatterns()`
- New `PtySessionTest` with 7 unit tests for prompt detection logic
- 4 new `InteractiveShellToolTest` cases (prompts, default shell, clean profile, resolve command)
- Config properties: `qlawkus.shell.default-shell`, `qlawkus.shell.clean-profile`, `qlawkus.shell.prompts`

## Test Results

- JVM: 133 tests pass, 0 failures
- Native: ShellToolIT 4/4, InteractiveShellToolIT 2/2

Closes #46