### PR TITLE
feat(google-calendar): add checkAvailability method with freeBusy API

### DIFF
--- a/tools/qlawkus-tools-google-calendar/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/deployment/GoogleCalendarProcessor.java
+++ b/tools/qlawkus-tools-google-calendar/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/deployment/GoogleCalendarProcessor.java
@@ -7,6 +7,8 @@ import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEvent;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventAttendee;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventList;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.EventDateTime;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.FreeBusyRequest;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.FreeBusyResponse;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -47,7 +49,12 @@ class GoogleCalendarProcessor {
                 CalendarEventList.class.getName(),
                 CalendarEvent.class.getName(),
                 EventDateTime.class.getName(),
-                CalendarEventAttendee.class.getName()
+                CalendarEventAttendee.class.getName(),
+                FreeBusyRequest.class.getName(),
+                FreeBusyRequest.FreeBusyItem.class.getName(),
+                FreeBusyResponse.class.getName(),
+                FreeBusyResponse.FreeBusyCalendar.class.getName(),
+                FreeBusyResponse.TimeRange.class.getName()
         ).methods().fields().build();
     }
 }

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/CalendarTool.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/CalendarTool.java
@@ -7,6 +7,8 @@ import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEvent;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventAttendee;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventList;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.EventDateTime;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.FreeBusyRequest;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.FreeBusyResponse;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -14,9 +16,9 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -95,6 +97,36 @@ public class CalendarTool {
         } catch (Exception e) {
             Log.errorf(e, "Failed to create Google Calendar event");
             return "Error creating calendar event: " + e.getMessage();
+        }
+    }
+
+    @Tool("Check calendar availability for a given date. Returns busy time ranges so you can find free slots.")
+    public String checkAvailability(
+            @P("Date to check, e.g. 2026-05-10") LocalDate date) {
+
+        String timeMin = date.atTime(OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC)).format(RFC3339);
+        String timeMax = date.atTime(OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC)).format(RFC3339);
+
+        FreeBusyRequest request = new FreeBusyRequest(
+                timeMin, timeMax,
+                List.of(new FreeBusyRequest.FreeBusyItem(config.calendarId())));
+
+        try {
+            FreeBusyResponse response = calendarClient.queryFreeBusy(request);
+            FreeBusyResponse.FreeBusyCalendar calendar = response.calendars().get(config.calendarId());
+
+            if (calendar == null || calendar.busy().isEmpty()) {
+                return "No busy slots on " + date + ". Full day available.";
+            }
+
+            StringBuilder sb = new StringBuilder("Busy slots on " + date + ":\n");
+            for (FreeBusyResponse.TimeRange range : calendar.busy()) {
+                sb.append("- ").append(range.start()).append(" to ").append(range.end()).append("\n");
+            }
+            return sb.toString().trim();
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to check calendar availability");
+            return "Error checking availability: " + e.getMessage();
         }
     }
 

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/GoogleCalendarRestClient.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/GoogleCalendarRestClient.java
@@ -3,6 +3,8 @@ package dev.omatheusmesmo.qlawkus.tools.google.calendar;
 import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEvent;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventList;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.FreeBusyRequest;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.FreeBusyResponse;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -32,4 +34,8 @@ public interface GoogleCalendarRestClient {
     CalendarEvent createEvent(
             @PathParam("calendarId") String calendarId,
             CalendarEvent event);
+
+    @POST
+    @Path("/freeBusy")
+    FreeBusyResponse queryFreeBusy(FreeBusyRequest request);
 }

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/model/FreeBusyRequest.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/model/FreeBusyRequest.java
@@ -1,0 +1,13 @@
+package dev.omatheusmesmo.qlawkus.tools.google.calendar.model;
+
+import java.util.List;
+
+public record FreeBusyRequest(
+        String timeMin,
+        String timeMax,
+        List<FreeBusyItem> items) {
+
+    public record FreeBusyItem(
+            String id) {
+    }
+}

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/model/FreeBusyResponse.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/model/FreeBusyResponse.java
@@ -1,0 +1,30 @@
+package dev.omatheusmesmo.qlawkus.tools.google.calendar.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FreeBusyResponse(
+        Map<String, FreeBusyCalendar> calendars) {
+
+    public FreeBusyResponse {
+        calendars = calendars != null ? calendars : Map.of();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record FreeBusyCalendar(
+            List<TimeRange> busy) {
+
+        public FreeBusyCalendar {
+            busy = busy != null ? busy : List.of();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record TimeRange(
+            String start,
+            String end) {
+    }
+}


### PR DESCRIPTION
## Summary
- Add `checkAvailability(date)` method to `CalendarTool` using Google Calendar freeBusy API
- Add `FreeBusyRequest` and `FreeBusyResponse` DTOs
- Add `POST /calendar/v3/freeBusy` endpoint to `GoogleCalendarRestClient`
- Register all new DTOs for native reflection in `GoogleCalendarProcessor`

Closes #36