### PR TITLE
feat(google-calendar): add TimezoneNormalizer for UTC-to-local conversion

### DIFF
--- a/tools/qlawkus-tools-google-calendar/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/deployment/GoogleCalendarProcessor.java
+++ b/tools/qlawkus-tools-google-calendar/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/deployment/GoogleCalendarProcessor.java
@@ -3,6 +3,7 @@ package dev.omatheusmesmo.qlawkus.tools.google.calendar.deployment;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.CalendarTool;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.GoogleCalendarConfig;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.GoogleCalendarRestClient;
+import dev.omatheusmesmo.qlawkus.tools.google.calendar.TimezoneNormalizer;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEvent;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventAttendee;
 import dev.omatheusmesmo.qlawkus.tools.google.calendar.model.CalendarEventList;
@@ -37,6 +38,7 @@ class GoogleCalendarProcessor {
                 .addBeanClass(CalendarTool.class)
                 .addBeanClass(GoogleCalendarConfig.class)
                 .addBeanClass(GoogleCalendarRestClient.class)
+                .addBeanClass(TimezoneNormalizer.class)
                 .setRemovable()
                 .build();
     }
@@ -46,6 +48,7 @@ class GoogleCalendarProcessor {
         return ReflectiveClassBuildItem.builder(
                 CalendarTool.class.getName(),
                 GoogleCalendarConfig.class.getName(),
+                TimezoneNormalizer.class.getName(),
                 CalendarEventList.class.getName(),
                 CalendarEvent.class.getName(),
                 EventDateTime.class.getName(),

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/CalendarTool.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/CalendarTool.java
@@ -37,6 +37,9 @@ public class CalendarTool {
     @RestClient
     GoogleCalendarRestClient calendarClient;
 
+    @Inject
+    TimezoneNormalizer timezoneNormalizer;
+
     @Tool("List upcoming Google Calendar events for the next N days. Returns event summary, time, location and attendees.")
     public String listEvents(int days) {
         if (days <= 0) {
@@ -123,7 +126,8 @@ public class CalendarTool {
 
             StringBuilder sb = new StringBuilder("Busy slots on " + date + ":\n");
             for (FreeBusyResponse.TimeRange range : calendar.busy()) {
-                sb.append("- ").append(range.start()).append(" to ").append(range.end()).append("\n");
+                sb.append("- ").append(timezoneNormalizer.displayLocal(range.start()))
+                        .append(" to ").append(timezoneNormalizer.displayLocal(range.end())).append("\n");
             }
             return sb.toString().trim();
         } catch (Exception e) {
@@ -169,8 +173,8 @@ public class CalendarTool {
                 Duration gap = Duration.between(slotStart, slotEnd);
                 if (!gap.minus(minSlot).isNegative()) {
                     focusSlots.add(String.format("- %s to %s (%dh%dm free)",
-                            slotStart.format(RFC3339),
-                            slotEnd.format(RFC3339),
+                            timezoneNormalizer.displayLocal(slotStart),
+                            timezoneNormalizer.displayLocal(slotEnd),
                             gap.toHours(),
                             gap.toMinutesPart()));
                 }
@@ -193,11 +197,15 @@ public class CalendarTool {
         sb.append(event.summary() != null ? event.summary() : "(no title)");
 
         if (event.start() != null) {
-            String start = event.start().dateTime() != null ? event.start().dateTime() : event.start().date();
+            String start = event.start().dateTime() != null
+                    ? timezoneNormalizer.displayLocal(event.start().dateTime())
+                    : event.start().date();
             sb.append(" | Start: ").append(start);
         }
         if (event.end() != null) {
-            String end = event.end().dateTime() != null ? event.end().dateTime() : event.end().date();
+            String end = event.end().dateTime() != null
+                    ? timezoneNormalizer.displayLocal(event.end().dateTime())
+                    : event.end().date();
             sb.append(" | End: ").append(end);
         }
         if (event.location() != null) {

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/GoogleCalendarConfig.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/GoogleCalendarConfig.java
@@ -45,4 +45,8 @@ public interface GoogleCalendarConfig {
     /** End of working hours (hour of day, 0-23). */
     @WithDefault("18")
     int workDayEnd();
+
+    /** User timezone for displaying times and converting input. Defaults to America/Sao_Paulo. */
+    @WithDefault("America/Sao_Paulo")
+    String timezone();
 }

--- a/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/TimezoneNormalizer.java
+++ b/tools/qlawkus-tools-google-calendar/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/calendar/TimezoneNormalizer.java
@@ -1,0 +1,43 @@
+package dev.omatheusmesmo.qlawkus.tools.google.calendar;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+@ApplicationScoped
+public class TimezoneNormalizer {
+
+    private static final DateTimeFormatter DISPLAY = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
+
+    private final ZoneId userZone;
+
+    TimezoneNormalizer(GoogleCalendarConfig config) {
+        this.userZone = ZoneId.of(config.timezone());
+    }
+
+    public OffsetDateTime toUtc(OffsetDateTime localTime) {
+        return localTime.atZoneSameInstant(userZone)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toOffsetDateTime();
+    }
+
+    public String displayLocal(OffsetDateTime utcTime) {
+        return utcTime.atZoneSameInstant(userZone).format(DISPLAY);
+    }
+
+    public String displayLocal(String utcIso) {
+        return displayLocal(OffsetDateTime.parse(utcIso));
+    }
+
+    public LocalDate todayLocal() {
+        return LocalDate.now(userZone);
+    }
+
+    public ZoneId userZone() {
+        return userZone;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TimezoneNormalizer` CDI bean that converts UTC↔local timezone for all calendar tool output
- Add `timezone` config to `GoogleCalendarConfig` (default: `America/Sao_Paulo`)
- All tool responses now display times in the user's local timezone
- Register `TimezoneNormalizer` in deployment processor for bean and reflection

Closes #38