### PR TITLE
feat(google-drive): add DriveTool extension

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>qlawkus-tools-google-calendar</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-gmail</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>qlawkus-tools-google-gmail</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-drive</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -16,5 +16,6 @@
         <module>qlawkus-tools-google-auth</module>
         <module>qlawkus-tools-google-calendar</module>
         <module>qlawkus-tools-google-gmail</module>
+        <module>qlawkus-tools-google-drive</module>
     </modules>
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -15,5 +15,6 @@
     <modules>
         <module>qlawkus-tools-google-auth</module>
         <module>qlawkus-tools-google-calendar</module>
+        <module>qlawkus-tools-google-gmail</module>
     </modules>
 </project>

--- a/tools/qlawkus-tools-google-drive/deployment/pom.xml
+++ b/tools/qlawkus-tools-google-drive/deployment/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-drive-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-drive-deployment</artifactId>
+    <name>Qlawkus Tools - Google Drive - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-drive</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-drive/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/deployment/GoogleDriveProcessor.java
+++ b/tools/qlawkus-tools-google-drive/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/deployment/GoogleDriveProcessor.java
@@ -1,0 +1,59 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.deployment;
+
+import dev.omatheusmesmo.qlawkus.tools.google.drive.DriveTool;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.GoogleDriveConfig;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.GoogleDriveRestClient;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.GoogleDriveDownloadClient;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.GoogleDriveUploadClient;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFile;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFileList;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DrivePermission;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DrivePermissionRequest;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+class GoogleDriveProcessor {
+
+    private static final String FEATURE = "google-drive";
+    private static final String REST_CLIENT_CAPABILITY = "io.quarkus.rest-client.jackson";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIf = IsDriveEnabled.class)
+    AdditionalBeanBuildItem registerDriveBeans(Capabilities capabilities) {
+        if (capabilities.isMissing(REST_CLIENT_CAPABILITY)) {
+            throw new ConfigurationException(
+                    "Drive tool requires quarkus-rest-client-jackson. "
+                            + "Add the extension or disable drive with qlawkus.google.drive.enabled=false");
+        }
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(DriveTool.class)
+                .addBeanClass(GoogleDriveConfig.class)
+                .addBeanClass(GoogleDriveRestClient.class)
+                .addBeanClass(GoogleDriveDownloadClient.class)
+                .addBeanClass(GoogleDriveUploadClient.class)
+                .setRemovable()
+                .build();
+    }
+
+    @BuildStep(onlyIf = IsDriveEnabled.class)
+    ReflectiveClassBuildItem registerDriveReflection() {
+        return ReflectiveClassBuildItem.builder(
+                DriveTool.class.getName(),
+                GoogleDriveConfig.class.getName(),
+                GoogleDriveDownloadClient.class.getName(),
+                GoogleDriveUploadClient.class.getName(),
+                DriveFileList.class.getName(),
+                DriveFile.class.getName(),
+                DrivePermission.class.getName(),
+                DrivePermissionRequest.class.getName()
+        ).methods().fields().build();
+    }
+}

--- a/tools/qlawkus-tools-google-drive/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/deployment/IsDriveEnabled.java
+++ b/tools/qlawkus-tools-google-drive/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/deployment/IsDriveEnabled.java
@@ -1,0 +1,15 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.deployment;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.util.function.BooleanSupplier;
+
+public class IsDriveEnabled implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("qlawkus.google.drive.enabled", Boolean.class)
+                .orElse(false);
+    }
+}

--- a/tools/qlawkus-tools-google-drive/pom.xml
+++ b/tools/qlawkus-tools-google-drive/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-drive-parent</artifactId>
+    <name>Qlawkus Tools - Google Drive - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/tools/qlawkus-tools-google-drive/runtime/pom.xml
+++ b/tools/qlawkus-tools-google-drive/runtime/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-drive-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-drive</artifactId>
+    <name>Qlawkus Tools - Google Drive - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/DriveTool.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/DriveTool.java
@@ -1,0 +1,131 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFile;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFileList;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DrivePermission;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DrivePermissionRequest;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.Base64;
+import java.util.stream.Collectors;
+
+@ClawTool
+@ApplicationScoped
+public class DriveTool {
+
+    @Inject
+    GoogleDriveConfig config;
+
+    @Inject
+    @RestClient
+    GoogleDriveRestClient driveClient;
+
+    @Inject
+    @RestClient
+    GoogleDriveUploadClient uploadClient;
+
+    @Inject
+    @RestClient
+    GoogleDriveDownloadClient downloadClient;
+
+    @Tool("List files in Google Drive. Optionally filter by query (e.g. \"name contains 'report'\", \"mimeType='application/pdf'\").")
+    public String listFiles(
+            @P(value = "Drive query filter, e.g. \"name contains 'report'\"", required = false) String query,
+            @P(value = "Maximum number of files to return", required = false) Integer maxResults) {
+
+        int limit = maxResults != null && maxResults > 0 ? maxResults : config.maxResults();
+        String fieldsParam = "files(" + config.fields() + ")";
+
+        try {
+            DriveFileList result = driveClient.listFiles(limit, query, fieldsParam);
+
+            if (result.files() == null || result.files().isEmpty()) {
+                return "No files found.";
+            }
+
+            return result.files().stream()
+                    .map(this::formatFileSummary)
+                    .collect(Collectors.joining("\n---\n"));
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to list Drive files");
+            return "Error listing files: " + e.getMessage();
+        }
+    }
+
+    @Tool("Upload a text file to Google Drive. Provide file name and text content.")
+    public String uploadFile(
+            @P("File name, e.g. 'report.txt'") String fileName,
+            @P("Text content of the file") String content,
+            @P(value = "MIME type (defaults to text/plain)", required = false) String mimeType) {
+
+        String type = mimeType != null && !mimeType.isBlank() ? mimeType : "text/plain";
+
+        try {
+            String base64Content = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(content.getBytes());
+
+            DriveFile uploaded = uploadClient.uploadSimple(
+                    "media",
+                    fileName,
+                    type,
+                    base64Content);
+
+            return "File uploaded: " + uploaded.name() + " (ID: " + uploaded.id() + ")\nLink: " + uploaded.webViewLink();
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to upload file to Drive");
+            return "Error uploading file: " + e.getMessage();
+        }
+    }
+
+    @Tool("Download a text file from Google Drive by its file ID. Returns the file content.")
+    public String downloadFile(
+            @P("Google Drive file ID") String fileId) {
+
+        try {
+            DriveFile metadata = driveClient.getFile(fileId, config.fields());
+            String content = downloadClient.downloadFile(fileId, "media");
+
+            if (content == null || content.isBlank()) {
+                return "File '" + metadata.name() + "' appears to be empty or binary (cannot display as text).";
+            }
+
+            return "File: " + metadata.name() + "\n---\n" + content;
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to download Drive file %s", fileId);
+            return "Error downloading file: " + e.getMessage();
+        }
+    }
+
+    @Tool("Share a Google Drive file with a user. Provide file ID, email, and role (reader, writer, owner).")
+    public String shareFile(
+            @P("Google Drive file ID") String fileId,
+            @P("Email address of the user to share with") String email,
+            @P(value = "Permission role: reader, writer, or owner", required = false) String role) {
+
+        String permissionRole = role != null && !role.isBlank() ? role : "reader";
+
+        try {
+            DrivePermission permission = driveClient.createPermission(
+                    fileId,
+                    new DrivePermissionRequest("user", permissionRole, email),
+                    "id,emailAddress,role");
+            return "File shared with " + permission.emailAddress() + " as " + permission.role();
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to share Drive file %s", fileId);
+            return "Error sharing file: " + e.getMessage();
+        }
+    }
+
+    private String formatFileSummary(DriveFile file) {
+        String size = file.size() != null ? file.size() + " bytes" : "N/A";
+        return String.format("%s (%s) | Type: %s | Modified: %s | Size: %s\nLink: %s",
+                file.name(), file.id(), file.mimeType(), file.modifiedTime(), size,
+                file.webViewLink() != null ? file.webViewLink() : "N/A");
+    }
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveConfig.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveConfig.java
@@ -1,0 +1,30 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "qlawkus.google.drive")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface GoogleDriveConfig {
+
+    /**
+     * Whether the Google Drive tool is enabled.
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Default maximum number of files returned per list request.
+     */
+    @WithDefault("10")
+    int maxResults();
+
+    /**
+     * Comma-separated list of Drive API fields to include in file responses.
+     * Defaults to id, name, mimeType, modifiedTime, size, webViewLink.
+     */
+    @WithDefault("id,name,mimeType,modifiedTime,size,webViewLink")
+    String fields();
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveDownloadClient.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveDownloadClient.java
@@ -1,0 +1,23 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFile;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/drive/v3/files")
+@RegisterRestClient(baseUri = "https://www.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleDriveDownloadClient {
+
+    @GET
+    @Path("/{fileId}")
+    String downloadFile(
+            @PathParam("fileId") String fileId,
+            @QueryParam("alt") String alt);
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveRestClient.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveRestClient.java
@@ -1,0 +1,40 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFile;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFileList;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DrivePermission;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DrivePermissionRequest;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/drive/v3/files")
+@RegisterRestClient(baseUri = "https://www.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleDriveRestClient {
+
+    @GET
+    DriveFileList listFiles(
+            @QueryParam("pageSize") Integer pageSize,
+            @QueryParam("q") String query,
+            @QueryParam("fields") String fields);
+
+    @GET
+    @Path("/{fileId}")
+    DriveFile getFile(
+            @PathParam("fileId") String fileId,
+            @QueryParam("fields") String fields);
+
+    @POST
+    @Path("/{fileId}/permissions")
+    DrivePermission createPermission(
+            @PathParam("fileId") String fileId,
+            DrivePermissionRequest request,
+            @QueryParam("fields") String fields);
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveUploadClient.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/GoogleDriveUploadClient.java
@@ -1,0 +1,24 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import dev.omatheusmesmo.qlawkus.tools.google.drive.model.DriveFile;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.HeaderParam;
+
+@RegisterRestClient(baseUri = "https://www.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleDriveUploadClient {
+
+    @POST
+    @Path("/upload/drive/v3/files")
+    DriveFile uploadSimple(
+            @QueryParam("uploadType") String uploadType,
+            @QueryParam("name") String name,
+            @HeaderParam("Content-Type") String contentType,
+            String content);
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DriveFile.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DriveFile.java
@@ -1,0 +1,14 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DriveFile(
+        String id,
+        String name,
+        String mimeType,
+        String modifiedTime,
+        Long size,
+        String webViewLink
+) {
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DriveFileList.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DriveFileList.java
@@ -1,0 +1,12 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DriveFileList(
+        String nextPageToken,
+        List<DriveFile> files
+) {
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DrivePermission.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DrivePermission.java
@@ -1,0 +1,12 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DrivePermission(
+        String id,
+        String type,
+        String role,
+        String emailAddress
+) {
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DrivePermissionRequest.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DrivePermissionRequest.java
@@ -1,0 +1,8 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.model;
+
+public record DrivePermissionRequest(
+        String type,
+        String role,
+        String emailAddress
+) {
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DriveUploadRequest.java
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/drive/model/DriveUploadRequest.java
@@ -1,0 +1,7 @@
+package dev.omatheusmesmo.qlawkus.tools.google.drive.model;
+
+public record DriveUploadRequest(
+        String name,
+        String mimeType
+) {
+}

--- a/tools/qlawkus-tools-google-drive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/tools/qlawkus-tools-google-drive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+name: "Google Drive"
+metadata:
+  keywords:
+    - "google"
+    - "drive"
+    - "productivity"
+  categories:
+    - "productivity"
+  status: "experimental"

--- a/tools/qlawkus-tools-google-gmail/deployment/pom.xml
+++ b/tools/qlawkus-tools-google-gmail/deployment/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-gmail-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-gmail-deployment</artifactId>
+    <name>Qlawkus Tools - Google Gmail - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-gmail</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-gmail/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/deployment/GoogleGmailProcessor.java
+++ b/tools/qlawkus-tools-google-gmail/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/deployment/GoogleGmailProcessor.java
@@ -1,0 +1,54 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail.deployment;
+
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.GmailTool;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.GoogleGmailConfig;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.GoogleGmailRestClient;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessage;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessageList;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessageRef;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailSendRequest;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+class GoogleGmailProcessor {
+
+    private static final String FEATURE = "google-gmail";
+    private static final String REST_CLIENT_CAPABILITY = "io.quarkus.rest-client.jackson";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIf = IsGmailEnabled.class)
+    AdditionalBeanBuildItem registerGmailBeans(Capabilities capabilities) {
+        if (capabilities.isMissing(REST_CLIENT_CAPABILITY)) {
+            throw new ConfigurationException(
+                    "Gmail tool requires quarkus-rest-client-jackson. "
+                            + "Add the extension or disable gmail with qlawkus.google.gmail.enabled=false");
+        }
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(GmailTool.class)
+                .addBeanClass(GoogleGmailConfig.class)
+                .addBeanClass(GoogleGmailRestClient.class)
+                .setRemovable()
+                .build();
+    }
+
+    @BuildStep(onlyIf = IsGmailEnabled.class)
+    ReflectiveClassBuildItem registerGmailReflection() {
+        return ReflectiveClassBuildItem.builder(
+                GmailTool.class.getName(),
+                GoogleGmailConfig.class.getName(),
+                GmailMessageList.class.getName(),
+                GmailMessageRef.class.getName(),
+                GmailMessage.class.getName(),
+                GmailMessage.GmailMessagePartHeader.class.getName(),
+                GmailSendRequest.class.getName()
+        ).methods().fields().build();
+    }
+}

--- a/tools/qlawkus-tools-google-gmail/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/deployment/IsGmailEnabled.java
+++ b/tools/qlawkus-tools-google-gmail/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/deployment/IsGmailEnabled.java
@@ -1,0 +1,15 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail.deployment;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.util.function.BooleanSupplier;
+
+public class IsGmailEnabled implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("qlawkus.google.gmail.enabled", Boolean.class)
+                .orElse(false);
+    }
+}

--- a/tools/qlawkus-tools-google-gmail/pom.xml
+++ b/tools/qlawkus-tools-google-gmail/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-gmail-parent</artifactId>
+    <name>Qlawkus Tools - Google Gmail - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/tools/qlawkus-tools-google-gmail/runtime/pom.xml
+++ b/tools/qlawkus-tools-google-gmail/runtime/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-gmail-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-gmail</artifactId>
+    <name>Qlawkus Tools - Google Gmail - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/GmailTool.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/GmailTool.java
@@ -1,0 +1,97 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessage;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessageList;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailSendRequest;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.Base64;
+import java.util.stream.Collectors;
+
+@ClawTool
+@ApplicationScoped
+public class GmailTool {
+
+    @Inject
+    GoogleGmailConfig config;
+
+    @Inject
+    @RestClient
+    GoogleGmailRestClient gmailClient;
+
+    @Tool("List recent Gmail messages. Optionally filter by query (e.g. 'is:unread', 'from:someone@example.com').")
+    public String listEmails(
+            @P(value = "Gmail query filter, e.g. 'is:unread'", required = false) String query,
+            @P(value = "Maximum number of messages to return", required = false) Integer maxResults) {
+
+        int limit = maxResults != null && maxResults > 0 ? maxResults : config.maxResults();
+
+        try {
+            GmailMessageList result = gmailClient.listMessages(config.userId(), limit, query);
+
+            if (result.messages().isEmpty()) {
+                return "No messages found.";
+            }
+
+            return result.messages().stream()
+                    .map(ref -> {
+                        try {
+                            GmailMessage msg = gmailClient.getMessage(config.userId(), ref.id(), "metadata");
+                            return formatMessageSummary(msg);
+                        } catch (Exception e) {
+                            return ref.id() + ": (failed to load)";
+                        }
+                    })
+                    .collect(Collectors.joining("\n---\n"));
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to list Gmail messages");
+            return "Error listing emails: " + e.getMessage();
+        }
+    }
+
+    @Tool("Send a Gmail message. Provide recipient email, subject and body text.")
+    public String sendEmail(
+            @P("Recipient email address") String to,
+            @P("Email subject") String subject,
+            @P("Email body text") String body) {
+
+        String rawEmail = buildRawEmail(to, subject, body);
+        String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(rawEmail.getBytes());
+
+        try {
+            gmailClient.sendMessage(config.userId(), new GmailSendRequest(encoded));
+            return "Email sent to " + to + ": " + subject;
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to send Gmail message");
+            return "Error sending email: " + e.getMessage();
+        }
+    }
+
+    @Tool("Search Gmail messages by query. Returns matching message summaries.")
+    public String searchEmails(
+            @P("Gmail search query, e.g. 'subject:meeting is:unread'") String query,
+            @P(value = "Maximum number of messages to return", required = false) Integer maxResults) {
+
+        return listEmails(query, maxResults);
+    }
+
+    private String formatMessageSummary(GmailMessage msg) {
+        return String.format("%s | From: %s | Date: %s\n%s",
+                msg.subject(), msg.from(), msg.date(),
+                msg.snippet() != null ? msg.snippet() : "");
+    }
+
+    private String buildRawEmail(String to, String subject, String body) {
+        return "To: " + to + "\r\n" +
+                "Subject: =?UTF-8?B?" + Base64.getEncoder().encodeToString(subject.getBytes()) + "?=\r\n" +
+                "Content-Type: text/plain; charset=UTF-8\r\n" +
+                "Content-Transfer-Encoding: base64\r\n\r\n" +
+                Base64.getEncoder().encodeToString(body.getBytes());
+    }
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/GoogleGmailConfig.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/GoogleGmailConfig.java
@@ -1,0 +1,23 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "qlawkus.google.gmail")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface GoogleGmailConfig {
+
+    /** Whether the Gmail tool is enabled. */
+    @WithDefault("false")
+    boolean enabled();
+
+    /** Gmail user identifier. Use {@code me} for the authenticated user. */
+    @WithDefault("me")
+    String userId();
+
+    /** Default maximum number of messages returned per request. */
+    @WithDefault("10")
+    int maxResults();
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/GoogleGmailRestClient.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/GoogleGmailRestClient.java
@@ -1,0 +1,40 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessage;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailMessageList;
+import dev.omatheusmesmo.qlawkus.tools.google.gmail.model.GmailSendRequest;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/gmail/v1/users")
+@RegisterRestClient(baseUri = "https://www.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleGmailRestClient {
+
+    @GET
+    @Path("/{userId}/messages")
+    GmailMessageList listMessages(
+            @PathParam("userId") String userId,
+            @QueryParam("maxResults") Integer maxResults,
+            @QueryParam("q") String query);
+
+    @GET
+    @Path("/{userId}/messages/{messageId}")
+    GmailMessage getMessage(
+            @PathParam("userId") String userId,
+            @PathParam("messageId") String messageId,
+            @QueryParam("format") String format);
+
+    @POST
+    @Path("/{userId}/messages/send")
+    GmailMessage sendMessage(
+            @PathParam("userId") String userId,
+            GmailSendRequest request);
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailMessage.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailMessage.java
@@ -1,0 +1,47 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GmailMessage(
+        String id,
+        String threadId,
+        List<GmailMessagePartHeader> headers,
+        String snippet) {
+
+    public GmailMessage {
+        headers = headers != null ? headers : List.of();
+    }
+
+    public String subject() {
+        return headers.stream()
+                .filter(h -> "Subject".equalsIgnoreCase(h.name()))
+                .map(GmailMessagePartHeader::value)
+                .findFirst()
+                .orElse("(no subject)");
+    }
+
+    public String from() {
+        return headers.stream()
+                .filter(h -> "From".equalsIgnoreCase(h.name()))
+                .map(GmailMessagePartHeader::value)
+                .findFirst()
+                .orElse("(unknown)");
+    }
+
+    public String date() {
+        return headers.stream()
+                .filter(h -> "Date".equalsIgnoreCase(h.name()))
+                .map(GmailMessagePartHeader::value)
+                .findFirst()
+                .orElse("");
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GmailMessagePartHeader(
+            String name,
+            String value) {
+    }
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailMessageList.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailMessageList.java
@@ -1,0 +1,16 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GmailMessageList(
+        List<GmailMessageRef> messages,
+        String nextPageToken,
+        int resultSizeEstimate) {
+
+    public GmailMessageList {
+        messages = messages != null ? messages : List.of();
+    }
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailMessageRef.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailMessageRef.java
@@ -1,0 +1,9 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GmailMessageRef(
+        String id,
+        String threadId) {
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailSendRequest.java
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/gmail/model/GmailSendRequest.java
@@ -1,0 +1,13 @@
+package dev.omatheusmesmo.qlawkus.tools.google.gmail.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GmailSendRequest(
+        String raw) {
+
+    public GmailSendRequest {
+    }
+}

--- a/tools/qlawkus-tools-google-gmail/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/tools/qlawkus-tools-google-gmail/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+name: "Google Gmail"
+metadata:
+  keywords:
+    - "google"
+    - "gmail"
+    - "productivity"
+  categories:
+    - "productivity"
+  status: "experimental"


### PR DESCRIPTION
## Summary

- Scaffold complete Quarkus extension (`qlawkus-tools-google-drive`) with runtime + deployment modules
- `DriveTool` provides AI agent tools: `listFiles`, `uploadFile`, `downloadFile`, `shareFile` via Google Drive API v3
- Uses MicroProfile REST Client with `GoogleAuthHeadersFilter` for auth
- Separate `GoogleDriveUploadClient` for the `/upload/drive/v3/files` endpoint
- Deployment processor registers beans conditionally (`IsDriveEnabled`) and DTOs for native reflection
- Config: `qlawkus.google.drive.enabled`, `maxResults`, `fields` — all with `@WithDefault`

Closes #161