### PR TITLE
feat(google-sheets): add SheetsTool extension

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>qlawkus-tools-google-drive</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-sheets</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -17,5 +17,6 @@
         <module>qlawkus-tools-google-calendar</module>
         <module>qlawkus-tools-google-gmail</module>
         <module>qlawkus-tools-google-drive</module>
+        <module>qlawkus-tools-google-sheets</module>
     </modules>
 </project>

--- a/tools/qlawkus-tools-google-sheets/deployment/pom.xml
+++ b/tools/qlawkus-tools-google-sheets/deployment/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-sheets-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-sheets-deployment</artifactId>
+    <name>Qlawkus Tools - Google Sheets - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-sheets</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-sheets/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/deployment/GoogleSheetsProcessor.java
+++ b/tools/qlawkus-tools-google-sheets/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/deployment/GoogleSheetsProcessor.java
@@ -1,0 +1,52 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets.deployment;
+
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.GoogleSheetsConfig;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.GoogleSheetsRestClient;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.SheetsTool;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.SheetValues;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.UpdateValuesRequest;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.UpdateValuesResponse;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+class GoogleSheetsProcessor {
+
+    private static final String FEATURE = "google-sheets";
+    private static final String REST_CLIENT_CAPABILITY = "io.quarkus.rest-client.jackson";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIf = IsSheetsEnabled.class)
+    AdditionalBeanBuildItem registerSheetsBeans(Capabilities capabilities) {
+        if (capabilities.isMissing(REST_CLIENT_CAPABILITY)) {
+            throw new ConfigurationException(
+                    "Sheets tool requires quarkus-rest-client-jackson. "
+                            + "Add the extension or disable sheets with qlawkus.google.sheets.enabled=false");
+        }
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(SheetsTool.class)
+                .addBeanClass(GoogleSheetsConfig.class)
+                .addBeanClass(GoogleSheetsRestClient.class)
+                .setRemovable()
+                .build();
+    }
+
+    @BuildStep(onlyIf = IsSheetsEnabled.class)
+    ReflectiveClassBuildItem registerSheetsReflection() {
+        return ReflectiveClassBuildItem.builder(
+                SheetsTool.class.getName(),
+                GoogleSheetsConfig.class.getName(),
+                GoogleSheetsRestClient.class.getName(),
+                SheetValues.class.getName(),
+                UpdateValuesRequest.class.getName(),
+                UpdateValuesResponse.class.getName()
+        ).methods().fields().build();
+    }
+}

--- a/tools/qlawkus-tools-google-sheets/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/deployment/IsSheetsEnabled.java
+++ b/tools/qlawkus-tools-google-sheets/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/deployment/IsSheetsEnabled.java
@@ -1,0 +1,15 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets.deployment;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.util.function.BooleanSupplier;
+
+public class IsSheetsEnabled implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("qlawkus.google.sheets.enabled", Boolean.class)
+                .orElse(false);
+    }
+}

--- a/tools/qlawkus-tools-google-sheets/pom.xml
+++ b/tools/qlawkus-tools-google-sheets/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-sheets-parent</artifactId>
+    <name>Qlawkus Tools - Google Sheets - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/tools/qlawkus-tools-google-sheets/runtime/pom.xml
+++ b/tools/qlawkus-tools-google-sheets/runtime/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-sheets-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-sheets</artifactId>
+    <name>Qlawkus Tools - Google Sheets - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/GoogleSheetsConfig.java
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/GoogleSheetsConfig.java
@@ -1,0 +1,24 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "qlawkus.google.sheets")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface GoogleSheetsConfig {
+
+    /**
+     * Whether the Google Sheets tool is enabled.
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Default value input option for write operations.
+     * Valid values: RAW, USER_ENTERED. USER_ENTERED parses dates/formulas like the Sheets UI.
+     */
+    @WithDefault("USER_ENTERED")
+    String valueInputOption();
+}

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/GoogleSheetsRestClient.java
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/GoogleSheetsRestClient.java
@@ -1,0 +1,34 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.SheetValues;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.UpdateValuesRequest;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.UpdateValuesResponse;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/v4/spreadsheets")
+@RegisterRestClient(baseUri = "https://sheets.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleSheetsRestClient {
+
+    @GET
+    @Path("/{spreadsheetId}/values/{range}")
+    SheetValues getValues(
+            @PathParam("spreadsheetId") String spreadsheetId,
+            @PathParam("range") String range);
+
+    @PUT
+    @Path("/{spreadsheetId}/values/{range}")
+    UpdateValuesResponse updateValues(
+            @PathParam("spreadsheetId") String spreadsheetId,
+            @PathParam("range") String range,
+            @QueryParam("valueInputOption") String valueInputOption,
+            UpdateValuesRequest request);
+}

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/SheetsTool.java
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/SheetsTool.java
@@ -1,0 +1,113 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.SheetValues;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.UpdateValuesRequest;
+import dev.omatheusmesmo.qlawkus.tools.google.sheets.model.UpdateValuesResponse;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ClawTool
+@ApplicationScoped
+public class SheetsTool {
+
+    @Inject
+    GoogleSheetsConfig config;
+
+    @Inject
+    @RestClient
+    GoogleSheetsRestClient sheetsClient;
+
+    @Tool("Read data from a Google Sheets range. Provide spreadsheet ID and A1 notation range (e.g. 'Sheet1!A1:D10').")
+    public String readSheet(
+            @P("Spreadsheet ID from the Google Sheets URL") String spreadsheetId,
+            @P("Cell range in A1 notation, e.g. 'Sheet1!A1:D10'") String range) {
+
+        try {
+            SheetValues result = sheetsClient.getValues(spreadsheetId, range);
+
+            if (result.values() == null || result.values().isEmpty()) {
+                return "No data found in range " + range + ".";
+            }
+
+            StringBuilder output = new StringBuilder();
+            output.append("Range: ").append(result.range()).append("\n");
+
+            for (List<String> row : result.values()) {
+                output.append(row.stream().map(v -> v != null ? v : "").collect(Collectors.joining(" | ")));
+                output.append("\n");
+            }
+
+            return output.toString().trim();
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to read sheet %s range %s", spreadsheetId, range);
+            return "Error reading sheet: " + e.getMessage();
+        }
+    }
+
+    @Tool("Write data to a Google Sheets range. Provide spreadsheet ID, A1 notation range, and values as rows.")
+    public String writeSheet(
+            @P("Spreadsheet ID from the Google Sheets URL") String spreadsheetId,
+            @P("Target cell range in A1 notation, e.g. 'Sheet1!A1:D5'") String range,
+            @P("Data rows as comma-separated values, one row per line. E.g. 'Name,Age\\nAlice,30'") String values) {
+
+        try {
+            List<List<String>> rows = parseValues(values);
+            UpdateValuesRequest request = new UpdateValuesRequest(rows);
+
+            UpdateValuesResponse response = sheetsClient.updateValues(
+                    spreadsheetId, range, config.valueInputOption(), request);
+
+            return String.format("Updated %d cells across %d rows, %d columns.",
+                    response.updatedCells(), response.updatedRows(), response.updatedColumns());
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to write sheet %s range %s", spreadsheetId, range);
+            return "Error writing sheet: " + e.getMessage();
+        }
+    }
+
+    @Tool("Update a single cell in Google Sheets. Provide spreadsheet ID, cell reference (e.g. 'Sheet1!B2'), and the new value.")
+    public String updateCell(
+            @P("Spreadsheet ID from the Google Sheets URL") String spreadsheetId,
+            @P("Cell reference in A1 notation, e.g. 'Sheet1!B2'") String cell,
+            @P("New value for the cell") String value) {
+
+        try {
+            UpdateValuesRequest request = new UpdateValuesRequest(
+                    Collections.singletonList(Collections.singletonList(value)));
+
+            UpdateValuesResponse response = sheetsClient.updateValues(
+                    spreadsheetId, cell, config.valueInputOption(), request);
+
+            return String.format("Cell %s updated. %d cell changed.", cell, response.updatedCells());
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to update cell %s in sheet %s", cell, spreadsheetId);
+            return "Error updating cell: " + e.getMessage();
+        }
+    }
+
+    private List<List<String>> parseValues(String values) {
+        String[] lines = values.split("\\n");
+        List<List<String>> rows = new ArrayList<>();
+
+        for (String line : lines) {
+            String[] cells = line.split(",");
+            List<String> row = new ArrayList<>();
+            for (String cell : cells) {
+                row.add(cell.trim());
+            }
+            rows.add(row);
+        }
+
+        return rows;
+    }
+}

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/model/SheetValues.java
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/model/SheetValues.java
@@ -1,0 +1,13 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SheetValues(
+        String range,
+        String majorDimension,
+        List<List<String>> values
+) {
+}

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/model/UpdateValuesRequest.java
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/model/UpdateValuesRequest.java
@@ -1,0 +1,8 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets.model;
+
+import java.util.List;
+
+public record UpdateValuesRequest(
+        List<List<String>> values
+) {
+}

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/model/UpdateValuesResponse.java
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/sheets/model/UpdateValuesResponse.java
@@ -1,0 +1,11 @@
+package dev.omatheusmesmo.qlawkus.tools.google.sheets.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateValuesResponse(
+        int updatedCells,
+        int updatedRows,
+        int updatedColumns
+) {
+}

--- a/tools/qlawkus-tools-google-sheets/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/tools/qlawkus-tools-google-sheets/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+name: "Google Sheets"
+metadata:
+  keywords:
+    - "google"
+    - "sheets"
+    - "productivity"
+  categories:
+    - "productivity"
+  status: "experimental"


### PR DESCRIPTION
## Summary

- Scaffold complete Quarkus extension (`qlawkus-tools-google-sheets`) with runtime + deployment modules
- `SheetsTool` provides AI agent tools: `readSheet`, `writeSheet`, `updateCell` via Google Sheets API v4
- Uses MicroProfile REST Client with `GoogleAuthHeadersFilter` for auth
- Deployment processor registers beans conditionally (`IsSheetsEnabled`) and DTOs for native reflection
- Config: `qlawkus.google.sheets.enabled`, `valueInputOption` — all with `@WithDefault`

Closes #162