### PR TITLE
feat(google-storage): add StorageTool extension

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>qlawkus-tools-google-sheets</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-storage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -18,5 +18,6 @@
         <module>qlawkus-tools-google-gmail</module>
         <module>qlawkus-tools-google-drive</module>
         <module>qlawkus-tools-google-sheets</module>
+        <module>qlawkus-tools-google-storage</module>
     </modules>
 </project>

--- a/tools/qlawkus-tools-google-storage/deployment/pom.xml
+++ b/tools/qlawkus-tools-google-storage/deployment/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-storage-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-storage-deployment</artifactId>
+    <name>Qlawkus Tools - Google Storage - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-storage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-storage/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/deployment/GoogleStorageProcessor.java
+++ b/tools/qlawkus-tools-google-storage/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/deployment/GoogleStorageProcessor.java
@@ -1,0 +1,55 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage.deployment;
+
+import dev.omatheusmesmo.qlawkus.tools.google.storage.GoogleStorageConfig;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.GoogleStorageDownloadClient;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.GoogleStorageRestClient;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.StorageTool;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageBucket;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageBucketList;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageObject;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+class GoogleStorageProcessor {
+
+    private static final String FEATURE = "google-storage";
+    private static final String REST_CLIENT_CAPABILITY = "io.quarkus.rest-client.jackson";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIf = IsStorageEnabled.class)
+    AdditionalBeanBuildItem registerStorageBeans(Capabilities capabilities) {
+        if (capabilities.isMissing(REST_CLIENT_CAPABILITY)) {
+            throw new ConfigurationException(
+                    "Storage tool requires quarkus-rest-client-jackson. "
+                            + "Add the extension or disable storage with qlawkus.google.storage.enabled=false");
+        }
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(StorageTool.class)
+                .addBeanClass(GoogleStorageConfig.class)
+                .addBeanClass(GoogleStorageRestClient.class)
+                .addBeanClass(GoogleStorageDownloadClient.class)
+                .setRemovable()
+                .build();
+    }
+
+    @BuildStep(onlyIf = IsStorageEnabled.class)
+    ReflectiveClassBuildItem registerStorageReflection() {
+        return ReflectiveClassBuildItem.builder(
+                StorageTool.class.getName(),
+                GoogleStorageConfig.class.getName(),
+                GoogleStorageRestClient.class.getName(),
+                GoogleStorageDownloadClient.class.getName(),
+                StorageBucketList.class.getName(),
+                StorageBucket.class.getName(),
+                StorageObject.class.getName()
+        ).methods().fields().build();
+    }
+}

--- a/tools/qlawkus-tools-google-storage/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/deployment/IsStorageEnabled.java
+++ b/tools/qlawkus-tools-google-storage/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/deployment/IsStorageEnabled.java
@@ -1,0 +1,15 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage.deployment;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.util.function.BooleanSupplier;
+
+public class IsStorageEnabled implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("qlawkus.google.storage.enabled", Boolean.class)
+                .orElse(false);
+    }
+}

--- a/tools/qlawkus-tools-google-storage/pom.xml
+++ b/tools/qlawkus-tools-google-storage/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-storage-parent</artifactId>
+    <name>Qlawkus Tools - Google Storage - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/tools/qlawkus-tools-google-storage/runtime/pom.xml
+++ b/tools/qlawkus-tools-google-storage/runtime/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus-tools-google-storage-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qlawkus-tools-google-storage</artifactId>
+    <name>Qlawkus Tools - Google Storage - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-tools-google-auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.omatheusmesmo</groupId>
+            <artifactId>qlawkus-client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.platform.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/GoogleStorageConfig.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/GoogleStorageConfig.java
@@ -1,0 +1,25 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+import java.util.Optional;
+
+@ConfigMapping(prefix = "qlawkus.google.storage")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface GoogleStorageConfig {
+
+    /**
+     * Whether the Google Cloud Storage tool is enabled.
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Default Google Cloud project ID used for listing buckets.
+     * Required when using listBuckets without explicit projectId parameter.
+     */
+    Optional<String> projectId();
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/GoogleStorageDownloadClient.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/GoogleStorageDownloadClient.java
@@ -1,0 +1,23 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/storage/v1")
+@RegisterRestClient(baseUri = "https://storage.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleStorageDownloadClient {
+
+    @GET
+    @Path("/b/{bucket}/o/{object}")
+    String downloadObject(
+            @PathParam("bucket") String bucket,
+            @PathParam("object") String objectName,
+            @QueryParam("alt") String alt);
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/GoogleStorageRestClient.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/GoogleStorageRestClient.java
@@ -1,0 +1,39 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage;
+
+import dev.omatheusmesmo.qlawkus.tools.google.auth.GoogleAuthHeadersFilter;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageBucket;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageBucketList;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageObject;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/storage/v1")
+@RegisterRestClient(baseUri = "https://storage.googleapis.com")
+@RegisterProvider(GoogleAuthHeadersFilter.class)
+public interface GoogleStorageRestClient {
+
+    @GET
+    @Path("/b")
+    StorageBucketList listBuckets(
+            @QueryParam("project") String project);
+
+    @GET
+    @Path("/b/{bucket}/o/{object}")
+    StorageObject getObjectMetadata(
+            @PathParam("bucket") String bucket,
+            @PathParam("object") String objectName);
+
+    @POST
+    @Path("/b/{bucket}/o")
+    StorageObject uploadObject(
+            @PathParam("bucket") String bucket,
+            @QueryParam("uploadType") String uploadType,
+            @QueryParam("name") String name,
+            String content);
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/StorageTool.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/StorageTool.java
@@ -1,0 +1,104 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageBucket;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageBucketList;
+import dev.omatheusmesmo.qlawkus.tools.google.storage.model.StorageObject;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.Base64;
+import java.util.stream.Collectors;
+
+@ClawTool
+@ApplicationScoped
+public class StorageTool {
+
+    @Inject
+    GoogleStorageConfig config;
+
+    @Inject
+    @RestClient
+    GoogleStorageRestClient storageClient;
+
+    @Inject
+    @RestClient
+    GoogleStorageDownloadClient downloadClient;
+
+    @Tool("List Google Cloud Storage buckets for a project. Requires project ID.")
+    public String listBuckets(
+            @P(value = "Google Cloud project ID", required = false) String projectId) {
+
+        String project = projectId != null && !projectId.isBlank() ? projectId : config.projectId().orElse(null);
+
+        if (project == null || project.isBlank()) {
+            return "Error: projectId is required. Set qlawkus.google.storage.projectId or pass it as parameter.";
+        }
+
+        try {
+            StorageBucketList result = storageClient.listBuckets(project);
+
+            if (result.items() == null || result.items().isEmpty()) {
+                return "No buckets found for project " + project + ".";
+            }
+
+            return result.items().stream()
+                    .map(this::formatBucketSummary)
+                    .collect(Collectors.joining("\n---\n"));
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to list GCS buckets for project %s", project);
+            return "Error listing buckets: " + e.getMessage();
+        }
+    }
+
+    @Tool("Upload a text object to a Google Cloud Storage bucket. Provide bucket name, object name, and text content.")
+    public String uploadObject(
+            @P("GCS bucket name") String bucketName,
+            @P("Object name (key), e.g. 'reports/daily.txt'") String objectName,
+            @P("Text content to upload") String content) {
+
+        try {
+            String base64Content = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(content.getBytes());
+
+            StorageObject uploaded = storageClient.uploadObject(
+                    bucketName, "media", objectName, base64Content);
+
+            return "Object uploaded: " + uploaded.name() + " to bucket " + uploaded.bucket()
+                    + " (" + uploaded.size() + " bytes)";
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to upload object %s to bucket %s", objectName, bucketName);
+            return "Error uploading object: " + e.getMessage();
+        }
+    }
+
+    @Tool("Download a text object from a Google Cloud Storage bucket. Returns the object content.")
+    public String downloadObject(
+            @P("GCS bucket name") String bucketName,
+            @P("Object name (key) to download") String objectName) {
+
+        try {
+            StorageObject metadata = storageClient.getObjectMetadata(bucketName, objectName);
+            String content = downloadClient.downloadObject(bucketName, objectName, "media");
+
+            if (content == null || content.isBlank()) {
+                return "Object '" + objectName + "' appears to be empty or binary (cannot display as text).";
+            }
+
+            return "Object: " + metadata.name() + " | Bucket: " + metadata.bucket()
+                    + " | Size: " + metadata.size() + " bytes\n---\n" + content;
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to download object %s from bucket %s", objectName, bucketName);
+            return "Error downloading object: " + e.getMessage();
+        }
+    }
+
+    private String formatBucketSummary(StorageBucket bucket) {
+        return String.format("%s | Location: %s | Class: %s | Created: %s",
+                bucket.name(), bucket.location(), bucket.storageClass(), bucket.created());
+    }
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/model/StorageBucket.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/model/StorageBucket.java
@@ -1,0 +1,12 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record StorageBucket(
+        String name,
+        String location,
+        String storageClass,
+        String created
+) {
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/model/StorageBucketList.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/model/StorageBucketList.java
@@ -1,0 +1,11 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record StorageBucketList(
+        List<StorageBucket> items
+) {
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/model/StorageObject.java
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/google/storage/model/StorageObject.java
@@ -1,0 +1,13 @@
+package dev.omatheusmesmo.qlawkus.tools.google.storage.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record StorageObject(
+        String name,
+        String bucket,
+        String contentType,
+        Long size,
+        String updated
+) {
+}

--- a/tools/qlawkus-tools-google-storage/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/tools/qlawkus-tools-google-storage/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,10 @@
+name: "Google Storage"
+metadata:
+  keywords:
+    - "google"
+    - "storage"
+    - "gcs"
+    - "cloud"
+  categories:
+    - "cloud"
+  status: "experimental"


### PR DESCRIPTION
## Summary

- Add Google Cloud Storage tool extension (`qlawkus-tools-google-storage`) with `listBuckets`, `uploadObject`, `downloadObject`
- MicroProfile REST Client with separate `GoogleStorageDownloadClient` (avoids JAX-RS return type ambiguity like Drive)
- Deployment processor with `IsStorageEnabled` conditional build step + `ReflectiveClassBuildItem` for native image
- `quarkus-extension.yaml` metadata
- Register module in `tools/pom.xml` and add runtime dependency in `app/pom.xml`
- `projectId` is optional config — can be passed as parameter or set via `qlawkus.google.storage.project-id`

Closes #163