### PR TITLE
feat(brag): add BragTool with addAchievement, generateMarkdownReport, deleteAchievement

### DIFF
--- a/tools/qlawkus-tools-brag/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/deployment/BragProcessor.java
+++ b/tools/qlawkus-tools-brag/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/deployment/BragProcessor.java
@@ -3,6 +3,8 @@ package dev.omatheusmesmo.qlawkus.tools.brag.deployment;
 import dev.omatheusmesmo.qlawkus.tools.brag.AchievementProcessor;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragConfig;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragEntry;
+import dev.omatheusmesmo.qlawkus.tools.brag.BragTool;
+import dev.omatheusmesmo.qlawkus.tools.brag.ImpactTranslator;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -25,12 +27,14 @@ class BragProcessor {
         if (capabilities.isMissing(HIBERNATE_PANACHE_CAPABILITY)) {
             throw new ConfigurationException(
                     "Brag tool requires quarkus-hibernate-orm-panache. "
-                            + "Add the extension or disable the brag tool with qlawkus.brag.enabled=false");
+                    + "Add the extension or disable the brag tool with qlawkus.brag.enabled=false");
         }
         return AdditionalBeanBuildItem.builder()
-                .addBeanClass(BragEntry.class)
-                .addBeanClass(BragConfig.class)
                 .addBeanClass(AchievementProcessor.class)
+                .addBeanClass(BragConfig.class)
+                .addBeanClass(BragEntry.class)
+                .addBeanClass(BragTool.class)
+                .addBeanClass(ImpactTranslator.class)
                 .setRemovable()
                 .build();
     }
@@ -39,8 +43,10 @@ class BragProcessor {
     ReflectiveClassBuildItem registerBragReflection() {
         return ReflectiveClassBuildItem.builder(
                 AchievementProcessor.class.getName(),
+                BragConfig.class.getName(),
                 BragEntry.class.getName(),
-                BragConfig.class.getName()
+                BragTool.class.getName(),
+                ImpactTranslator.class.getName()
         ).methods().fields().build();
     }
 }

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragEntry.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragEntry.java
@@ -10,6 +10,7 @@ import jakarta.persistence.PrePersist;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 public class BragEntry extends PanacheEntityBase {
@@ -36,8 +37,17 @@ public class BragEntry extends PanacheEntityBase {
     @Column(nullable = false)
     public Instant createdAt;
 
+    public static BragEntry findById(long id) {
+        return (BragEntry) PanacheEntityBase.findById(id);
+    }
+
     public static BragEntry findDuplicate(LocalDate date, String achievement, String repo) {
         return find("date = ?1 and achievement = ?2 and repo = ?3 and deleted = false", date, achievement, repo)
                 .firstResult();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<BragEntry> findActiveByDateRange(LocalDate from, LocalDate to) {
+        return find("date >= ?1 and date <= ?2 and deleted = false order by date desc", from, to).list();
     }
 }

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragTool.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragTool.java
@@ -1,0 +1,110 @@
+package dev.omatheusmesmo.qlawkus.tools.brag;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.tool.ClawTool;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.stream.Collectors;
+
+@ClawTool
+@ApplicationScoped
+public class BragTool {
+
+    @Inject
+    BragConfig config;
+
+    @Inject
+    ImpactTranslator impactTranslator;
+
+    @Tool("Record a career achievement or accomplishment. Provide a description of what was done, optionally the date and the repository it relates to.")
+    @Transactional
+    public String addAchievement(
+            @P("Description of the achievement or accomplishment") String achievement,
+            @P(value = "Date of the achievement in ISO-8601 format, e.g. 2026-05-07. Defaults to today.", required = false) String date,
+            @P(value = "Repository name this achievement relates to, e.g. my-project", required = false) String repo) {
+        LocalDate entryDate = (date != null && !date.isBlank()) ? LocalDate.parse(date) : LocalDate.now(ZoneOffset.UTC);
+
+        BragEntry existing = BragEntry.findDuplicate(entryDate, achievement, repo);
+        if (existing != null) {
+            return "Duplicate achievement already recorded for " + entryDate + ".";
+        }
+
+        BragEntry entry = new BragEntry();
+        entry.date = entryDate;
+        entry.achievement = achievement;
+        entry.repo = repo;
+        entry.deleted = false;
+
+        if (config.impactTranslationEnabled()) {
+            try {
+                entry.impact = impactTranslator.translate(achievement);
+            } catch (Exception e) {
+                Log.warnf(e, "Impact translation failed, storing achievement without impact");
+                entry.impact = null;
+            }
+        }
+
+        entry.persist();
+        String result = "Achievement recorded for " + entryDate + ".";
+        if (entry.impact != null) {
+            result += " Business impact: " + entry.impact;
+        }
+        return result;
+    }
+
+    @Tool("Generate a Markdown brag document summarizing recorded achievements within a date range. Useful for performance reviews, status updates, or self-reflection.")
+    public String generateMarkdownReport(
+            @P(value = "Start date in ISO-8601 format, e.g. 2026-01-01. Defaults to 30 days ago.", required = false) String startDate,
+            @P(value = "End date in ISO-8601 format, e.g. 2026-05-07. Defaults to today.", required = false) String endDate) {
+        LocalDate from = (startDate != null && !startDate.isBlank())
+                ? LocalDate.parse(startDate)
+                : LocalDate.now(ZoneOffset.UTC).minusDays(30);
+        LocalDate to = (endDate != null && !endDate.isBlank())
+                ? LocalDate.parse(endDate)
+                : LocalDate.now(ZoneOffset.UTC);
+
+        var entries = BragEntry.findActiveByDateRange(from, to);
+
+        if (entries.isEmpty()) {
+            return "No achievements found between " + from + " and " + to + ".";
+        }
+
+        StringBuilder markdown = new StringBuilder();
+        markdown.append("# Brag Document\n\n");
+        markdown.append("Period: ").append(from).append(" to ").append(to).append("\n\n");
+        markdown.append("## Achievements\n\n");
+
+        for (BragEntry entry : entries) {
+            markdown.append("- **").append(entry.date).append("** — ").append(entry.achievement);
+            if (entry.impact != null && !entry.impact.isBlank()) {
+                markdown.append(" _(Impact: ").append(entry.impact).append(")_");
+            }
+            if (entry.repo != null && !entry.repo.isBlank()) {
+                markdown.append(" [").append(entry.repo).append("]");
+            }
+            markdown.append("\n");
+        }
+
+        markdown.append("\n---\n_Total: ").append(entries.size()).append(" achievements._\n");
+        return markdown.toString();
+    }
+
+    @Tool("Soft-delete a recorded achievement by its ID. The entry will be marked as deleted and excluded from reports.")
+    @Transactional
+    public String deleteAchievement(@P("ID of the achievement to delete") long id) {
+        BragEntry entry = BragEntry.findById(id);
+        if (entry == null) {
+            return "Achievement with ID " + id + " not found.";
+        }
+        if (entry.deleted) {
+            return "Achievement with ID " + id + " is already deleted.";
+        }
+        entry.deleted = true;
+        return "Achievement " + id + " marked as deleted.";
+    }
+}

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/ImpactTranslator.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/ImpactTranslator.java
@@ -1,0 +1,36 @@
+package dev.omatheusmesmo.qlawkus.tools.brag;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class ImpactTranslator {
+
+    @Inject
+    ChatModel chatModel;
+
+    public String translate(String achievement) {
+        String prompt = """
+                You are a career impact translator. Convert the following technical achievement \
+                into a concise business-impact statement. Focus on outcomes, value delivered, \
+                and relevance to stakeholders — not technical implementation details.
+
+                Rules:
+                - Write one or two sentences maximum.
+                - Use active voice and business language.
+                - If the achievement is purely technical with no clear business impact, \
+                reframe it in terms of reliability, efficiency, or risk reduction.
+                - Do not add information that is not implied by the achievement.
+
+                Achievement: %s""".formatted(achievement);
+
+        try {
+            return chatModel.chat(prompt);
+        } catch (Exception e) {
+            Log.warnf(e, "Impact translation LLM call failed for: %s", achievement);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `BragTool` with `@ClawTool` auto-discovery and three `@Tool` methods: `addAchievement`, `generateMarkdownReport`, `deleteAchievement`
- `ImpactTranslator` service using `ChatModel` for business-impact translation
- `BragEntry.findById` and `findActiveByDateRange` typed wrappers (no raw casts at call sites)
- `BragProcessor` updated to register `BragTool` and `ImpactTranslator` beans + reflection

Closes #53