### PR TITLE
feat(brag): add GET /api/brag/export endpoint

### DIFF
--- a/tools/qlawkus-tools-brag/deployment/pom.xml
+++ b/tools/qlawkus-tools-brag/deployment/pom.xml
@@ -52,11 +52,21 @@
             <artifactId>quarkus-flyway</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-flyway-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>

--- a/tools/qlawkus-tools-brag/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/deployment/BragProcessor.java
+++ b/tools/qlawkus-tools-brag/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/deployment/BragProcessor.java
@@ -3,6 +3,7 @@ package dev.omatheusmesmo.qlawkus.tools.brag.deployment;
 import dev.omatheusmesmo.qlawkus.tools.brag.AchievementProcessor;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragConfig;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragEntry;
+import dev.omatheusmesmo.qlawkus.tools.brag.BragExportResource;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragTool;
 import dev.omatheusmesmo.qlawkus.tools.brag.ImpactTranslator;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -16,6 +17,7 @@ class BragProcessor {
 
     private static final String FEATURE = "brag";
     private static final String HIBERNATE_PANACHE_CAPABILITY = "io.quarkus.hibernate-orm-panache";
+    private static final String REST_CAPABILITY = "io.quarkus.rest";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -40,11 +42,23 @@ class BragProcessor {
     }
 
     @BuildStep(onlyIf = IsBragEnabled.class)
+    AdditionalBeanBuildItem registerBragExportResource(Capabilities capabilities) {
+        if (capabilities.isMissing(REST_CAPABILITY)) {
+            return null;
+        }
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(BragExportResource.class)
+                .setRemovable()
+                .build();
+    }
+
+    @BuildStep(onlyIf = IsBragEnabled.class)
     ReflectiveClassBuildItem registerBragReflection() {
         return ReflectiveClassBuildItem.builder(
                 AchievementProcessor.class.getName(),
                 BragConfig.class.getName(),
                 BragEntry.class.getName(),
+                BragExportResource.class.getName(),
                 BragTool.class.getName(),
                 ImpactTranslator.class.getName()
         ).methods().fields().build();

--- a/tools/qlawkus-tools-brag/runtime/pom.xml
+++ b/tools/qlawkus-tools-brag/runtime/pom.xml
@@ -43,11 +43,16 @@
             <artifactId>quarkus-flyway</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-scheduler</artifactId>
-            <optional>true</optional>
-        </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+      <optional>true</optional>
+    </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragExportResource.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragExportResource.java
@@ -1,0 +1,29 @@
+package dev.omatheusmesmo.qlawkus.tools.brag;
+
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Path("/api/brag")
+@Authenticated
+public class BragExportResource {
+
+    @Inject
+    BragTool bragTool;
+
+    @GET
+    @Path("/export")
+    @Produces("text/markdown")
+    public String export(
+            @QueryParam("startDate") String startDate,
+            @QueryParam("endDate") String endDate) {
+        return bragTool.generateMarkdownReport(startDate, endDate);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BragExportResource` JAX-RS resource at `GET /api/brag/export`
- Accepts optional `startDate`/`endDate` query params (ISO-8601)
- Returns Markdown brag document (`text/markdown`)
- Delegates to `BragTool.generateMarkdownReport()`
- `quarkus-rest` optional dependency in brag runtime
- `BragExportResource` registered in `BragProcessor` with REST capability check
- Requires authentication (`@Authenticated`)

Closes #56