### PR TITLE
feat(brag): add scheduled cleanup job for deleted/duplicate entries

### DIFF
--- a/tools/qlawkus-tools-brag/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/deployment/BragProcessor.java
+++ b/tools/qlawkus-tools-brag/deployment/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/deployment/BragProcessor.java
@@ -1,6 +1,7 @@
 package dev.omatheusmesmo.qlawkus.tools.brag.deployment;
 
 import dev.omatheusmesmo.qlawkus.tools.brag.AchievementProcessor;
+import dev.omatheusmesmo.qlawkus.tools.brag.BragCleanupJob;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragConfig;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragEntry;
 import dev.omatheusmesmo.qlawkus.tools.brag.BragExportResource;
@@ -33,6 +34,7 @@ class BragProcessor {
         }
         return AdditionalBeanBuildItem.builder()
                 .addBeanClass(AchievementProcessor.class)
+                .addBeanClass(BragCleanupJob.class)
                 .addBeanClass(BragConfig.class)
                 .addBeanClass(BragEntry.class)
                 .addBeanClass(BragTool.class)
@@ -56,6 +58,7 @@ class BragProcessor {
     ReflectiveClassBuildItem registerBragReflection() {
         return ReflectiveClassBuildItem.builder(
                 AchievementProcessor.class.getName(),
+                BragCleanupJob.class.getName(),
                 BragConfig.class.getName(),
                 BragEntry.class.getName(),
                 BragExportResource.class.getName(),

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragCleanupJob.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragCleanupJob.java
@@ -1,0 +1,55 @@
+package dev.omatheusmesmo.qlawkus.tools.brag;
+
+import io.quarkus.logging.Log;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@ApplicationScoped
+public class BragCleanupJob {
+
+    @Inject
+    BragConfig config;
+
+    @Scheduled(cron = "{qlawkus.brag.cleanup-cron}")
+    @Transactional
+    void purgeExpiredEntries() {
+        Instant cutoff = Instant.now().minus(config.cleanupAgeDays(), ChronoUnit.DAYS);
+
+        long deleted = BragEntry.delete("deleted = true and createdAt < ?1", cutoff);
+        if (deleted > 0) {
+            Log.infof("Purged %d soft-deleted brag entries older than %d days", deleted, config.cleanupAgeDays());
+        }
+
+        long duplicates = removeDuplicates();
+        if (duplicates > 0) {
+            Log.infof("Removed %d duplicate brag entries", duplicates);
+        }
+    }
+
+    private long removeDuplicates() {
+        var entries = BragEntry.listAllActiveByDateAsc();
+
+        long removed = 0;
+        for (int i = 0; i < entries.size(); i++) {
+            BragEntry current = entries.get(i);
+            for (int j = i + 1; j < entries.size(); j++) {
+                BragEntry other = entries.get(j);
+                if (isDuplicate(current, other)) {
+                    other.deleted = true;
+                    removed++;
+                }
+            }
+        }
+        return removed;
+    }
+
+    private boolean isDuplicate(BragEntry a, BragEntry b) {
+        return a.date.equals(b.date)
+                && a.achievement != null && a.achievement.equals(b.achievement)
+                && (a.repo == null ? b.repo == null : a.repo.equals(b.repo));
+    }
+}

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragConfig.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragConfig.java
@@ -27,4 +27,11 @@ public interface BragConfig {
      */
     @WithDefault("7")
     int cleanupAgeDays();
+
+    /**
+     * Cron expression for the cleanup job schedule.
+     * Defaults to daily at 03:00 UTC.
+     */
+    @WithDefault("0 3 * * *")
+    String cleanupCron();
 }

--- a/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragEntry.java
+++ b/tools/qlawkus-tools-brag/runtime/src/main/java/dev/omatheusmesmo/qlawkus/tools/brag/BragEntry.java
@@ -50,4 +50,9 @@ public class BragEntry extends PanacheEntityBase {
     public static List<BragEntry> findActiveByDateRange(LocalDate from, LocalDate to) {
         return find("date >= ?1 and date <= ?2 and deleted = false order by date desc", from, to).list();
     }
+
+    @SuppressWarnings("unchecked")
+    public static List<BragEntry> listAllActiveByDateAsc() {
+        return find("deleted = false order by date asc, createdAt asc").list();
+    }
 }


### PR DESCRIPTION
## Summary
- Add `BragCleanupJob` with `@Scheduled` cron (default daily at 03:00 UTC)
- Purges soft-deleted entries older than `cleanupAgeDays` (default 7)
- Detects and soft-deletes duplicate entries (same date + achievement + repo)
- `cleanupCron` config added to `BragConfig` for custom schedule
- `BragEntry.listAllActiveByDateAsc()` typed query method added
- Registered in `BragProcessor` with conditional build step + reflection

Closes #58