### PR TITLE
Migrate scattered config to @ConfigMapping; tidy docs, site and Docker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,39 @@ Create a CDI bean annotated with `@ClawTool` + `@ApplicationScoped`. Methods ann
 
 New tool modules must also be added as dependencies in `app/pom.xml`.
 
+## Extension Development
+
+Every module here (`client`, `tools/*`, `messaging/*`) is a full Quarkus extension: a `runtime/` + `deployment/` pair. Rules that keep that pattern correct:
+
+- **Dependency direction is one-way.** `deployment/` depends on `runtime/` (plus other extensions' `*-deployment` artifacts); `runtime/` must NEVER depend on any `deployment` artifact. The Maven plugin validates this and fails the build if a required deployment dependency is missing.
+- **Three bootstrap phases.** Build-time *augmentation* runs `@BuildStep` processors (e.g. `ClientProcessor`) - it reads the Jandex index, never loads app classes, and records bytecode. `@Record(STATIC_INIT)` bytecode runs in a static initializer (framework boot, bean wiring; do NOT open ports, start threads, or read runtime config here). `@Record(RUNTIME_INIT)` bytecode runs in `main` (ports, runtime config, service start). Push work to STATIC_INIT when possible.
+- **Build steps talk via build items, not fields.** A build-step class is instantiated per invocation and discarded; share state only through immutable `*BuildItem`s. Always produce a `FeatureBuildItem`. A step runs only if something consumes what it produces.
+- **Recorders bridge build to runtime.** `@Recorder` methods in `runtime/` are *recorded* (not executed) at build time; their calls replay at runtime. Parameters must be bytecode-serializable (primitives, strings, config objects, `RuntimeValue<T>`). Wrap complex objects in `RuntimeValue<T>`.
+- **Config is `@ConfigMapping` interfaces.** `@ConfigRoot(phase = RUN_TIME)` + `@ConfigMapping(prefix = "qlawkus...")`, JavaDoc on each accessor (it becomes the generated config-reference description), `@WithDefault` for defaults, `Optional<T>` for optional, `Map<String, X>` for keyed/dynamic config (see `MessagingConfig`). Choose phase by need: `BUILD_TIME` (build only), `BUILD_AND_RUN_TIME_FIXED` (read at build, immutable at runtime), `RUN_TIME` (re-read each run, overridable).
+- **CDI registration.** Register extension beans with `AdditionalBeanBuildItem`; use `@DefaultBean` for anything app code should be able to override; `SyntheticBeanBuildItem` for beans built through a recorder.
+- **Native image.** Reflection needs registration - `ClientProcessor` already registers `dev.omatheusmesmo.qlawkus.dto` records via `ReflectiveClassBuildItem`; new reflective types (DTOs, models) must be added the same way (or `@RegisterForReflection`). Use `NativeImageResourceBuildItem` to bundle resources. Verify with `mvn verify -Pnative`.
+- **Before inventing a build item, check the catalog**: [all build items](https://quarkus.io/guides/all-builditems).
+
+### Reference links
+
+Official Quarkus documentation:
+
+- [Writing Your Own Extension](https://quarkus.io/guides/writing-extensions) - canonical guide
+- [All build items reference](https://quarkus.io/guides/all-builditems) - the extension SPI
+- [Adding extensions to the Quarkus ecosystem / Quarkiverse](https://github.com/quarkusio/quarkus/wiki/Adding-extensions-to-the-Quarkus-ecosystem)
+
+Community tutorials and walkthroughs:
+
+- [Quarkus: Greener, Better, Faster, Stronger](https://jtama.github.io/posts/quarkus-greener-better-faster-stronger/) (Jérôme Tama) - Dev Services, annotation transform, recorders ([source](https://github.com/jtama/quarkus-extension-demo))
+- [How NOT to Create a Quarkus Extension](https://www.loicmathieu.fr/wordpress/informatique/quarkus-tip-comment-ne-pas-creer-une-extension-quarkus/) (Loïc Mathieu) - when a simple JAR + Jandex is enough instead
+- [Developing a Quarkus Extension](https://matheuscruz.dev/2024/01/12/developing-a-quarkus-extension/) (Matheus Cruz) - recorders, Gizmo, Jandex scanning ([source](https://github.com/mcruzdev/quarkus-useful))
+- [Creating a Quarkus Extension](https://blog.sebastian-daschner.com/entries/creating-a-quarkus-extension) (Sebastian Daschner) - video walkthrough ([source](https://github.com/sdaschner/blink-extension))
+- [How to Implement a Quarkus Extension](https://www.baeldung.com/quarkus-extension-java) (Baeldung) - Liquibase extension tutorial
+
+Resource collections:
+
+- [Quarkus Extensions Resources](https://hollycummins.com/quarkus-extensions-resources/) (Holly Cummins) - curated guides, talks, and posts
+
 ## Databases
 
 3 PostgreSQL databases, all managed by Flyway:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,39 @@ Please add meaningful tests (business logic, edge cases, integration points), no
 - **Commits**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, ...), small and atomic.
 - **Branches/merges**: feature branches; integrate by **rebase** (no merge commits).
 
+## Working on the extensions
+
+`client/`, `tools/*`, and `messaging/*` are full Quarkus extensions (a `runtime/` + `deployment/` pair each), not plain libraries. A few rules keep that pattern healthy:
+
+- `deployment/` may depend on `runtime/`; **`runtime/` must never depend on `deployment/`** (the build enforces this).
+- Build-time work (annotation scanning, bytecode generation) lives in `deployment/` `@BuildStep` processors and reads the Jandex index instead of loading classes. Keep runtime startup thin.
+- Anything reflective in native mode (DTOs, models) must be registered for reflection - `client`'s `ClientProcessor` already does this for `dev.omatheusmesmo.qlawkus.dto`; new reflective types follow the same path. Validate native builds with `mvn verify -Pnative`.
+- Before adding a custom build item, check whether one already exists: [all build items](https://quarkus.io/guides/all-builditems).
+
+If you only need to share CDI beans, typed `@ConfigMapping` config, or basic reflection and no build-time augmentation, a plain JAR with Jandex indexing may be enough - prefer that over a new full extension when it fits.
+
+`AGENTS.md` ("Extension Development") has the deeper rule set (bootstrap phases, recorders, build items, CDI registration).
+
+### Reference links
+
+Official Quarkus documentation:
+
+- [Writing Your Own Extension](https://quarkus.io/guides/writing-extensions) - canonical guide
+- [All build items reference](https://quarkus.io/guides/all-builditems) - the extension SPI
+- [Adding extensions to the Quarkus ecosystem / Quarkiverse](https://github.com/quarkusio/quarkus/wiki/Adding-extensions-to-the-Quarkus-ecosystem)
+
+Community tutorials and walkthroughs:
+
+- [Quarkus: Greener, Better, Faster, Stronger](https://jtama.github.io/posts/quarkus-greener-better-faster-stronger/) (Jérôme Tama) - Dev Services, annotation transform, recorders ([source](https://github.com/jtama/quarkus-extension-demo))
+- [How NOT to Create a Quarkus Extension](https://www.loicmathieu.fr/wordpress/informatique/quarkus-tip-comment-ne-pas-creer-une-extension-quarkus/) (Loïc Mathieu) - when a simple JAR + Jandex is enough instead
+- [Developing a Quarkus Extension](https://matheuscruz.dev/2024/01/12/developing-a-quarkus-extension/) (Matheus Cruz) - recorders, Gizmo, Jandex scanning ([source](https://github.com/mcruzdev/quarkus-useful))
+- [Creating a Quarkus Extension](https://blog.sebastian-daschner.com/entries/creating-a-quarkus-extension) (Sebastian Daschner) - video walkthrough ([source](https://github.com/sdaschner/blink-extension))
+- [How to Implement a Quarkus Extension](https://www.baeldung.com/quarkus-extension-java) (Baeldung) - Liquibase extension tutorial
+
+Resource collections:
+
+- [Quarkus Extensions Resources](https://hollycummins.com/quarkus-extensions-resources/) (Holly Cummins) - curated guides, talks, and posts
+
 ## Documentation
 
 User-facing docs live in `site/content/*.adoc`. The per-module configuration reference is generated from `@ConfigMapping` JavaDoc:

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
@@ -8,10 +8,10 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.MemorySource;
 import io.quarkus.arc.Arc;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -30,13 +30,11 @@ public class ActiveMemoryAugmentor implements Supplier<RetrievalAugmentor> {
 
   @Override
   public RetrievalAugmentor get() {
-    var config = ConfigProvider.getConfig();
-    boolean enabled = config.getOptionalValue("qlawkus.agent.active-memory.enabled", Boolean.class)
-        .orElse(true);
-    int maxResults = config.getOptionalValue("qlawkus.agent.active-memory.max-results", Integer.class)
-        .orElse(5);
-    double minScore = config.getOptionalValue("qlawkus.agent.active-memory.min-score", Double.class)
-        .orElse(0.7);
+    AgentConfig.ActiveMemory activeMemory =
+        Arc.container().instance(AgentConfig.class).get().activeMemory();
+    boolean enabled = activeMemory.enabled();
+    int maxResults = activeMemory.maxResults();
+    double minScore = activeMemory.minScore();
 
     ContentRetriever retriever;
     if (enabled) {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/MemoryCurationJob.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/MemoryCurationJob.java
@@ -1,13 +1,13 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.model.chat.ChatModel;
+import dev.omatheusmesmo.qlawkus.config.MemoryCurationConfig;
 import dev.omatheusmesmo.qlawkus.store.pg.EmbeddingRepository;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.List;
 
@@ -27,22 +27,19 @@ public class MemoryCurationJob {
   @Inject
   EmbeddingRepository embeddingRepository;
 
-  @ConfigProperty(name = "qlawkus.memory-curation.enabled", defaultValue = "true")
-  boolean enabled;
-
-  @ConfigProperty(name = "qlawkus.memory-curation.max-facts", defaultValue = "200")
-  int maxFacts;
+  @Inject
+  MemoryCurationConfig config;
 
   @Scheduled(cron = "{qlawkus.memory-curation.cron:0 45 3 * * ?}")
   void curate() {
-    if (enabled) {
+    if (config.enabled()) {
       curateProfile();
     }
   }
 
   @Transactional
   public boolean curateProfile() {
-    List<String> facts = embeddingRepository.listFactTexts(maxFacts);
+    List<String> facts = embeddingRepository.listFactTexts(config.maxFacts());
     if (facts.isEmpty()) {
       return false;
     }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/MemoryReviewJob.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/MemoryReviewJob.java
@@ -1,12 +1,12 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
+import dev.omatheusmesmo.qlawkus.config.MemoryReviewConfig;
 import dev.omatheusmesmo.qlawkus.store.pg.EmbeddingRepository;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Background self-review of long-term memory (inspired by Hermes' self-improvement loop). The
@@ -20,8 +20,8 @@ public class MemoryReviewJob {
   @Inject
   EmbeddingRepository embeddingRepository;
 
-  @ConfigProperty(name = "qlawkus.memory-review.similarity-threshold", defaultValue = "0.97")
-  double similarityThreshold;
+  @Inject
+  MemoryReviewConfig config;
 
   @Scheduled(cron = "{qlawkus.memory-review.cron:0 30 3 * * ?}")
   void review() {
@@ -30,6 +30,7 @@ public class MemoryReviewJob {
 
   @Transactional
   public long reviewNow() {
+    double similarityThreshold = config.similarityThreshold();
     double maxCosineDistance = 1.0 - similarityThreshold;
     long removed = embeddingRepository.deleteNearDuplicates(maxCosineDistance);
     if (removed > 0) {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SearchMemoriesTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SearchMemoriesTool.java
@@ -2,10 +2,10 @@ package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.FactStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.util.List;
 
 @ApplicationScoped
@@ -14,17 +14,14 @@ public class SearchMemoriesTool {
   @Inject
   FactStore factStore;
 
-  @ConfigProperty(name = "qlawkus.agent.memory.max-results", defaultValue = "10")
-  int maxResults;
-
-  @ConfigProperty(name = "qlawkus.agent.memory.min-score", defaultValue = "0.7")
-  double minScore;
+  @Inject
+  AgentConfig agentConfig;
 
   @Tool("Search your long-term memory for user preferences, past decisions, or personal context relevant to the conversation. Use this when the topic might relate to something the user told you before.")
   public List<String> searchMemories(
           @P("What to recall from long-term memory about the user, phrased as a search query "
                   + "(a topic, preference, fact, or question), e.g. \"user's GitHub handle\" "
                   + "or \"where the user works\".") String query) {
-        return factStore.search(query, maxResults, minScore);
+        return factStore.search(query, agentConfig.memory().maxResults(), agentConfig.memory().minScore());
   }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SearchTranscriptsTool.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SearchTranscriptsTool.java
@@ -2,11 +2,11 @@ package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.FactStore;
 import dev.omatheusmesmo.qlawkus.store.MemorySource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.List;
 
@@ -16,11 +16,8 @@ public class SearchTranscriptsTool {
   @Inject
   FactStore factStore;
 
-  @ConfigProperty(name = "qlawkus.agent.transcript-search.max-results", defaultValue = "5")
-  int maxResults;
-
-  @ConfigProperty(name = "qlawkus.agent.transcript-search.min-score", defaultValue = "0.7")
-  double minScore;
+  @Inject
+  AgentConfig agentConfig;
 
   @Tool("""
       Search what was actually said in past conversations (raw transcripts), to recall a specific \
@@ -29,6 +26,7 @@ public class SearchTranscriptsTool {
       grained than your long-term facts.""")
   public List<String> searchTranscripts(
       @P("What to find from past conversations, phrased as a search query") String query) {
-    return factStore.searchBySource(query, MemorySource.TRANSCRIPT.value(), maxResults, minScore);
+    return factStore.searchBySource(query, MemorySource.TRANSCRIPT.value(),
+        agentConfig.transcriptSearch().maxResults(), agentConfig.transcriptSearch().minScore());
   }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SoulEngine.java
@@ -1,6 +1,8 @@
 package dev.omatheusmesmo.qlawkus.cognition;
 
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkus.arc.Arc;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -16,8 +18,6 @@ public class SoulEngine implements SystemMessageProvider {
 
   private static final DateTimeFormatter NOW_FORMAT =
       DateTimeFormatter.ofPattern("EEEE, yyyy-MM-dd HH:mm:ss zzz (XXX)", Locale.ENGLISH);
-
-  private static final String DEFAULT_TIMEZONE = "America/Sao_Paulo";
 
   @Override
   @Transactional
@@ -64,9 +64,7 @@ public class SoulEngine implements SystemMessageProvider {
   }
 
   private String currentDateTimeContext() {
-    String timezone = ConfigProvider.getConfig()
-        .getOptionalValue("qlawkus.agent.timezone", String.class)
-        .orElse(DEFAULT_TIMEZONE);
+    String timezone = Arc.container().instance(AgentConfig.class).get().timezone();
     ZonedDateTime now = ZonedDateTime.now(ZoneId.of(timezone));
     return "\n\n## Current Date & Time\n\n"
         + "Right now it is **" + now.format(NOW_FORMAT) + "**.\n"

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/TranscriptArchiveObserver.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/TranscriptArchiveObserver.java
@@ -2,6 +2,7 @@ package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.FactStore;
 import dev.omatheusmesmo.qlawkus.store.MemorySource;
 import dev.omatheusmesmo.qlawkus.store.MessagesAppendedEvent;
@@ -9,7 +10,6 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.ObservesAsync;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.List;
 import java.util.Map;
@@ -26,11 +26,11 @@ public class TranscriptArchiveObserver {
   @Inject
   FactStore factStore;
 
-  @ConfigProperty(name = "qlawkus.agent.transcript-archive.enabled", defaultValue = "true")
-  boolean enabled;
+  @Inject
+  AgentConfig agentConfig;
 
   void onMessagesAppended(@ObservesAsync MessagesAppendedEvent event) {
-    if (!enabled) {
+    if (!agentConfig.transcriptArchive().enabled()) {
       return;
     }
     for (ChatMessage message : event.messages()) {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
@@ -1,0 +1,118 @@
+package dev.omatheusmesmo.qlawkus.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "qlawkus.agent")
+public interface AgentConfig {
+
+    /**
+     * IANA timezone used to render the current date and time injected into the system prompt,
+     * so the agent resolves relative expressions ("today", "tomorrow") against the owner's clock.
+     */
+    @WithDefault("America/Sao_Paulo")
+    String timezone();
+
+    /**
+     * Idle time-to-live, in minutes, for the single shared conversation context across all channels.
+     */
+    @WithDefault("60")
+    long contextTtlMinutes();
+
+    /**
+     * One shared conversation across every channel (the agent serves a single owner).
+     */
+    SharedContext sharedContext();
+
+    /**
+     * The {@code searchMemories} tool: explicit retrieval over long-term facts.
+     */
+    Memory memory();
+
+    /**
+     * Active memory: query-relevant facts injected before every reply, with no tool call needed.
+     */
+    ActiveMemory activeMemory();
+
+    /**
+     * Archival of each message as a searchable transcript embedding ({@code source=transcript}).
+     */
+    TranscriptArchive transcriptArchive();
+
+    /**
+     * The {@code searchTranscripts} tool: retrieval over archived raw transcripts.
+     */
+    TranscriptSearch transcriptSearch();
+
+    interface SharedContext {
+
+        /**
+         * Whether all channels share one conversation context. When false, each channel keeps its own.
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface Memory {
+
+        /**
+         * Maximum number of facts returned by the {@code searchMemories} tool.
+         */
+        @WithDefault("10")
+        int maxResults();
+
+        /**
+         * Minimum cosine score for a fact to be returned by the {@code searchMemories} tool.
+         */
+        @WithDefault("0.7")
+        double minScore();
+    }
+
+    interface ActiveMemory {
+
+        /**
+         * Whether to inject query-relevant facts into the prompt before each reply.
+         */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * Maximum number of facts injected per turn by active memory.
+         */
+        @WithDefault("5")
+        int maxResults();
+
+        /**
+         * Minimum cosine score for a fact to be injected by active memory.
+         */
+        @WithDefault("0.7")
+        double minScore();
+    }
+
+    interface TranscriptArchive {
+
+        /**
+         * Whether each user and AI message is archived as a searchable transcript embedding.
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface TranscriptSearch {
+
+        /**
+         * Maximum number of transcript excerpts returned by the {@code searchTranscripts} tool.
+         */
+        @WithDefault("5")
+        int maxResults();
+
+        /**
+         * Minimum cosine score for a transcript excerpt to be returned by the {@code searchTranscripts} tool.
+         */
+        @WithDefault("0.7")
+        double minScore();
+    }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/MemoryCurationConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/MemoryCurationConfig.java
@@ -1,0 +1,29 @@
+package dev.omatheusmesmo.qlawkus.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "qlawkus.memory-curation")
+public interface MemoryCurationConfig {
+
+    /**
+     * Whether the nightly curation job folds remembered facts into the owner profile.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * Maximum number of facts loaded from the store and fed to the model in a single curation pass.
+     */
+    @WithDefault("200")
+    int maxFacts();
+
+    /**
+     * Cron expression for the scheduled memory-curation job.
+     */
+    @WithDefault("0 45 3 * * ?")
+    String cron();
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/MemoryReviewConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/MemoryReviewConfig.java
@@ -1,0 +1,24 @@
+package dev.omatheusmesmo.qlawkus.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "qlawkus.memory-review")
+public interface MemoryReviewConfig {
+
+    /**
+     * Cosine similarity above which two facts are treated as near-duplicates and the redundant one
+     * is removed by the nightly memory-review job. Higher is stricter (removes fewer facts).
+     */
+    @WithDefault("0.97")
+    double similarityThreshold();
+
+    /**
+     * Cron expression for the scheduled memory-review job.
+     */
+    @WithDefault("0 30 3 * * ?")
+    String cron();
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/rest/ApiResource.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/rest/ApiResource.java
@@ -4,6 +4,7 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.omatheusmesmo.qlawkus.agent.AgentService;
 import dev.omatheusmesmo.qlawkus.agent.ConversationId;
 import dev.omatheusmesmo.qlawkus.cognition.ChatCompletedEvent;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.dto.ChatRequest;
 import dev.omatheusmesmo.qlawkus.store.WorkingMemoryStore;
 import io.quarkus.logging.Log;
@@ -11,7 +12,6 @@ import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -33,8 +33,8 @@ public class ApiResource {
     @Inject
     Event<ChatCompletedEvent> eventEmitter;
 
-    @ConfigProperty(name = "qlawkus.agent.shared-context.enabled", defaultValue = "true")
-    boolean sharedContextEnabled;
+    @Inject
+    AgentConfig agentConfig;
 
     @POST
     @Path("/chat/sync")
@@ -64,6 +64,6 @@ public class ApiResource {
     }
 
     private String conversationId() {
-        return sharedContextEnabled ? ConversationId.SHARED : ConversationId.REST;
+        return agentConfig.sharedContext().enabled() ? ConversationId.SHARED : ConversationId.REST;
     }
 }

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: app
       dockerfile: src/main/docker/Dockerfile.jvm
+    env_file:
+      - path: .env
+        required: false
     environment:
       - QUARKUS_PROFILE=prod
       - QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB:-qlawkus}
@@ -13,16 +16,8 @@ services:
       - QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODEL_NAME=${OLLAMA_MODEL:-gemma4:e2b}
       - QUARKUS_LANGCHAIN4J_OPENAI_EMBEDDING_MODEL_MODEL_NAME=${OLLAMA_EMBEDDING_MODEL:-mxbai-embed-large}
       - QUARKUS_LANGCHAIN4J_OPENAI_TIMEOUT=120s
-      # Memory tuning (defaults match application.properties; override to experiment)
-      - AGENT_MEMORY_MIN_SCORE=${AGENT_MEMORY_MIN_SCORE:-0.7}
-      - AGENT_ACTIVE_MEMORY=${AGENT_ACTIVE_MEMORY:-true}
-      - AGENT_ACTIVE_MEMORY_MAX_RESULTS=${AGENT_ACTIVE_MEMORY_MAX_RESULTS:-5}
-      - AGENT_ACTIVE_MEMORY_MIN_SCORE=${AGENT_ACTIVE_MEMORY_MIN_SCORE:-0.7}
-      - AGENT_TRANSCRIPT_ARCHIVE=${AGENT_TRANSCRIPT_ARCHIVE:-true}
-      - AGENT_TRANSCRIPT_MAX_RESULTS=${AGENT_TRANSCRIPT_MAX_RESULTS:-5}
-      - AGENT_TRANSCRIPT_MIN_SCORE=${AGENT_TRANSCRIPT_MIN_SCORE:-0.7}
-      - AGENT_MEMORY_REVIEW_SIMILARITY=${AGENT_MEMORY_REVIEW_SIMILARITY:-0.97}
-      - AGENT_MEMORY_CURATION=${AGENT_MEMORY_CURATION:-true}
+      # Memory tuning (AGENT_*) is read from .env via env_file above; unset keys use the
+      # extension defaults, so they are not repeated here.
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: app
       dockerfile: src/main/docker/Dockerfile.jvm
+    env_file:
+      - path: .env
+        required: false
     environment:
       - NVIDIA_AI_API_KEY=${NVIDIA_AI_API_KEY}
       - NVIDIA_CHAT_MODEL=${NVIDIA_CHAT_MODEL:-z-ai/glm-5.1}
@@ -38,22 +41,9 @@ services:
       - QUARKUS_DATASOURCE_BRAG_USERNAME=${POSTGRES_USER:-qlawkus}
       - QUARKUS_DATASOURCE_BRAG_PASSWORD=${POSTGRES_PASSWORD:-qlawkus}
       - QLAWKUS_WORKSPACE_ROOT=/tmp/qlawkus-workspace
-      - AGENT_SHARED_CONTEXT=${AGENT_SHARED_CONTEXT:-true}
-      - AGENT_CONTEXT_TTL_MINUTES=${AGENT_CONTEXT_TTL_MINUTES:-60}
-      - AGENT_MEMORY_MIN_SCORE=${AGENT_MEMORY_MIN_SCORE:-0.7}
-      - AGENT_MEMORY_MAX_RESULTS=${AGENT_MEMORY_MAX_RESULTS:-10}
-      - AGENT_MEMORY_MAX_MESSAGES=${AGENT_MEMORY_MAX_MESSAGES:-40}
-      # Active memory (query-relevant facts injected before each reply)
-      - AGENT_ACTIVE_MEMORY=${AGENT_ACTIVE_MEMORY:-true}
-      - AGENT_ACTIVE_MEMORY_MAX_RESULTS=${AGENT_ACTIVE_MEMORY_MAX_RESULTS:-5}
-      - AGENT_ACTIVE_MEMORY_MIN_SCORE=${AGENT_ACTIVE_MEMORY_MIN_SCORE:-0.7}
-      # Transcript archive + session search
-      - AGENT_TRANSCRIPT_ARCHIVE=${AGENT_TRANSCRIPT_ARCHIVE:-true}
-      - AGENT_TRANSCRIPT_MAX_RESULTS=${AGENT_TRANSCRIPT_MAX_RESULTS:-5}
-      - AGENT_TRANSCRIPT_MIN_SCORE=${AGENT_TRANSCRIPT_MIN_SCORE:-0.7}
-      # Background memory jobs (semantic dedup + profile curation)
-      - AGENT_MEMORY_REVIEW_SIMILARITY=${AGENT_MEMORY_REVIEW_SIMILARITY:-0.97}
-      - AGENT_MEMORY_CURATION=${AGENT_MEMORY_CURATION:-true}
+      # Memory tuning (AGENT_*, memory-review, memory-curation) is read from .env via env_file
+      # above; any key left unset falls back to the defaults baked into the extensions
+      # (see the config reference), so the defaults are not repeated here.
       - TTS_ENABLED=${TTS_ENABLED:-true}
       - TTS_DEFAULT_LANGUAGE=${TTS_DEFAULT_LANGUAGE:-en}
       - TTS_PT_KIND=${TTS_PT_KIND:-openai}
@@ -80,6 +70,9 @@ services:
       dockerfile: src/main/docker/Dockerfile.native-micro
     profiles:
       - native
+    env_file:
+      - path: .env
+        required: false
     environment:
       - NVIDIA_AI_API_KEY=${NVIDIA_AI_API_KEY}
       - NVIDIA_CHAT_MODEL=${NVIDIA_CHAT_MODEL:-z-ai/glm-5.1}

--- a/messaging/deployment/src/test/java/dev/omatheusmesmo/qlawkus/messaging/MessagingOrchestratorTest.java
+++ b/messaging/deployment/src/test/java/dev/omatheusmesmo/qlawkus/messaging/MessagingOrchestratorTest.java
@@ -5,7 +5,9 @@ import dev.omatheusmesmo.qlawkus.agent.AgentRunner;
 import dev.omatheusmesmo.qlawkus.agent.AgentService;
 import dev.omatheusmesmo.qlawkus.cognition.ConversationControl;
 import dev.omatheusmesmo.qlawkus.cognition.VoiceResponsePreference;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.messaging.auth.MessagingAuthService;
+import dev.omatheusmesmo.qlawkus.messaging.tts.TtsConfig;
 import dev.omatheusmesmo.qlawkus.messaging.tts.TtsRouter;
 import dev.omatheusmesmo.qlawkus.store.WorkingMemoryStore;
 import io.smallrye.mutiny.Uni;
@@ -43,6 +45,17 @@ class MessagingOrchestratorTest {
         orchestrator.conversationControl = conversationControl;
         orchestrator.workingMemoryStore = workingMemoryStore;
         orchestrator.ttsRouter = ttsRouter;
+
+        TtsConfig ttsConfig = Mockito.mock(TtsConfig.class);
+        when(ttsConfig.defaultLanguage()).thenReturn("en");
+        orchestrator.ttsConfig = ttsConfig;
+
+        AgentConfig agentConfig = Mockito.mock(AgentConfig.class);
+        AgentConfig.SharedContext sharedContext = Mockito.mock(AgentConfig.SharedContext.class);
+        when(sharedContext.enabled()).thenReturn(true);
+        when(agentConfig.sharedContext()).thenReturn(sharedContext);
+        when(agentConfig.contextTtlMinutes()).thenReturn(60L);
+        orchestrator.agentConfig = agentConfig;
 
         @SuppressWarnings("unchecked")
         Instance<AgentDeliveryContext> deliveryContextInstance = Mockito.mock(Instance.class);

--- a/messaging/runtime/src/main/java/dev/omatheusmesmo/qlawkus/messaging/MessagingOrchestrator.java
+++ b/messaging/runtime/src/main/java/dev/omatheusmesmo/qlawkus/messaging/MessagingOrchestrator.java
@@ -6,9 +6,11 @@ import dev.omatheusmesmo.qlawkus.agent.AgentService;
 import dev.omatheusmesmo.qlawkus.agent.ConversationId;
 import dev.omatheusmesmo.qlawkus.cognition.ConversationControl;
 import dev.omatheusmesmo.qlawkus.cognition.VoiceResponsePreference;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.WorkingMemoryStore;
 import dev.omatheusmesmo.qlawkus.messaging.auth.MessagingAuthService;
 import dev.omatheusmesmo.qlawkus.messaging.transcription.VoiceTranscriptionService;
+import dev.omatheusmesmo.qlawkus.messaging.tts.TtsConfig;
 import dev.omatheusmesmo.qlawkus.messaging.tts.TtsRouter;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
@@ -18,7 +20,6 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.text.Normalizer;
 import java.time.Duration;
@@ -64,14 +65,11 @@ public class MessagingOrchestrator {
     @Inject
     TtsRouter ttsRouter;
 
-    @ConfigProperty(name = "qlawkus.messaging.tts.default-language", defaultValue = "en")
-    String defaultTtsLanguage;
+    @Inject
+    TtsConfig ttsConfig;
 
-    @ConfigProperty(name = "qlawkus.agent.shared-context.enabled", defaultValue = "true")
-    boolean sharedContextEnabled;
-
-    @ConfigProperty(name = "qlawkus.agent.context-ttl-minutes", defaultValue = "60")
-    long contextTtlMinutes;
+    @Inject
+    AgentConfig agentConfig;
 
     public Uni<Void> process(MessagingMessage message) {
         Log.infof("MessagingOrchestrator: received provider=%s userId=%s chatId=%s textLen=%d hasAudio=%s",
@@ -180,6 +178,7 @@ public class MessagingOrchestrator {
     }
 
     private void expireIdleConversation(String conversationId) {
+        long contextTtlMinutes = agentConfig.contextTtlMinutes();
         if (contextTtlMinutes <= 0) {
             return;
         }
@@ -192,7 +191,7 @@ public class MessagingOrchestrator {
     }
 
     private String memoryId(MessagingMessage message) {
-        return sharedContextEnabled
+        return agentConfig.sharedContext().enabled()
                 ? ConversationId.SHARED
                 : message.providerId() + ":" + message.chatId();
     }
@@ -206,6 +205,7 @@ public class MessagingOrchestrator {
             activated = true;
         }
         if (detectVoiceIntent(text) && ttsRouter.enabled()) {
+            String defaultTtsLanguage = ttsConfig.defaultLanguage();
             voicePreference.request(defaultTtsLanguage);
             Log.infof("MessagingOrchestrator: auto-detected voice intent from user message, default language=%s (LLM may override)", defaultTtsLanguage);
         }

--- a/site/content/_includes/qlawkus-client_qlawkus.agent.adoc
+++ b/site/content/_includes/qlawkus-client_qlawkus.agent.adoc
@@ -1,0 +1,242 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a| [[qlawkus-client_qlawkus-agent-timezone]] [.property-path]##link:#qlawkus-client_qlawkus-agent-timezone[`+++qlawkus.agent.timezone+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.timezone+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+IANA timezone used to render the current date and time injected into the system prompt, so the agent resolves relative expressions ("today", "tomorrow") against the owner's clock.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_TIMEZONE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_TIMEZONE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++America/Sao_Paulo+++`
+
+a| [[qlawkus-client_qlawkus-agent-context-ttl-minutes]] [.property-path]##link:#qlawkus-client_qlawkus-agent-context-ttl-minutes[`+++qlawkus.agent.context-ttl-minutes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.context-ttl-minutes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Idle time-to-live, in minutes, for the single shared conversation context across all channels.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_CONTEXT_TTL_MINUTES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_CONTEXT_TTL_MINUTES+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++60+++`
+
+a| [[qlawkus-client_qlawkus-agent-shared-context-enabled]] [.property-path]##link:#qlawkus-client_qlawkus-agent-shared-context-enabled[`+++qlawkus.agent.shared-context.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.shared-context.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether all channels share one conversation context. When false, each channel keeps its own.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_SHARED_CONTEXT_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_SHARED_CONTEXT_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[qlawkus-client_qlawkus-agent-memory-max-results]] [.property-path]##link:#qlawkus-client_qlawkus-agent-memory-max-results[`+++qlawkus.agent.memory.max-results+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.memory.max-results+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of facts returned by the `searchMemories` tool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_MEMORY_MAX_RESULTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_MEMORY_MAX_RESULTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++10+++`
+
+a| [[qlawkus-client_qlawkus-agent-memory-min-score]] [.property-path]##link:#qlawkus-client_qlawkus-agent-memory-min-score[`+++qlawkus.agent.memory.min-score+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.memory.min-score+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Minimum cosine score for a fact to be returned by the `searchMemories` tool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_MEMORY_MIN_SCORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_MEMORY_MIN_SCORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`+++0.7+++`
+
+a| [[qlawkus-client_qlawkus-agent-active-memory-enabled]] [.property-path]##link:#qlawkus-client_qlawkus-agent-active-memory-enabled[`+++qlawkus.agent.active-memory.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.active-memory.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to inject query-relevant facts into the prompt before each reply.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_ACTIVE_MEMORY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_ACTIVE_MEMORY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[qlawkus-client_qlawkus-agent-active-memory-max-results]] [.property-path]##link:#qlawkus-client_qlawkus-agent-active-memory-max-results[`+++qlawkus.agent.active-memory.max-results+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.active-memory.max-results+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of facts injected per turn by active memory.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_ACTIVE_MEMORY_MAX_RESULTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_ACTIVE_MEMORY_MAX_RESULTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
+a| [[qlawkus-client_qlawkus-agent-active-memory-min-score]] [.property-path]##link:#qlawkus-client_qlawkus-agent-active-memory-min-score[`+++qlawkus.agent.active-memory.min-score+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.active-memory.min-score+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Minimum cosine score for a fact to be injected by active memory.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_ACTIVE_MEMORY_MIN_SCORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_ACTIVE_MEMORY_MIN_SCORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`+++0.7+++`
+
+a| [[qlawkus-client_qlawkus-agent-transcript-archive-enabled]] [.property-path]##link:#qlawkus-client_qlawkus-agent-transcript-archive-enabled[`+++qlawkus.agent.transcript-archive.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.transcript-archive.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether each user and AI message is archived as a searchable transcript embedding.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_TRANSCRIPT_ARCHIVE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_TRANSCRIPT_ARCHIVE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[qlawkus-client_qlawkus-agent-transcript-search-max-results]] [.property-path]##link:#qlawkus-client_qlawkus-agent-transcript-search-max-results[`+++qlawkus.agent.transcript-search.max-results+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.transcript-search.max-results+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of transcript excerpts returned by the `searchTranscripts` tool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_TRANSCRIPT_SEARCH_MAX_RESULTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_TRANSCRIPT_SEARCH_MAX_RESULTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
+a| [[qlawkus-client_qlawkus-agent-transcript-search-min-score]] [.property-path]##link:#qlawkus-client_qlawkus-agent-transcript-search-min-score[`+++qlawkus.agent.transcript-search.min-score+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.transcript-search.min-score+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Minimum cosine score for a transcript excerpt to be returned by the `searchTranscripts` tool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_TRANSCRIPT_SEARCH_MIN_SCORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_TRANSCRIPT_SEARCH_MIN_SCORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`+++0.7+++`
+
+|===
+

--- a/site/content/_includes/qlawkus-client_qlawkus.memory-curation.adoc
+++ b/site/content/_includes/qlawkus-client_qlawkus.memory-curation.adoc
@@ -1,0 +1,74 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a| [[qlawkus-client_qlawkus-memory-curation-enabled]] [.property-path]##link:#qlawkus-client_qlawkus-memory-curation-enabled[`+++qlawkus.memory-curation.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.memory-curation.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the nightly curation job folds remembered facts into the owner profile.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_MEMORY_CURATION_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_MEMORY_CURATION_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[qlawkus-client_qlawkus-memory-curation-max-facts]] [.property-path]##link:#qlawkus-client_qlawkus-memory-curation-max-facts[`+++qlawkus.memory-curation.max-facts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.memory-curation.max-facts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Maximum number of facts loaded from the store and fed to the model in a single curation pass.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_MEMORY_CURATION_MAX_FACTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_MEMORY_CURATION_MAX_FACTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++200+++`
+
+a| [[qlawkus-client_qlawkus-memory-curation-cron]] [.property-path]##link:#qlawkus-client_qlawkus-memory-curation-cron[`+++qlawkus.memory-curation.cron+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.memory-curation.cron+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Cron expression for the scheduled memory-curation job.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_MEMORY_CURATION_CRON+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_MEMORY_CURATION_CRON+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++0 45 3 * * ?+++`
+
+|===
+

--- a/site/content/_includes/qlawkus-client_qlawkus.memory-review.adoc
+++ b/site/content/_includes/qlawkus-client_qlawkus.memory-review.adoc
@@ -1,0 +1,53 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a| [[qlawkus-client_qlawkus-memory-review-similarity-threshold]] [.property-path]##link:#qlawkus-client_qlawkus-memory-review-similarity-threshold[`+++qlawkus.memory-review.similarity-threshold+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.memory-review.similarity-threshold+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Cosine similarity above which two facts are treated as near-duplicates and the redundant one is removed by the nightly memory-review job. Higher is stricter (removes fewer facts).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_MEMORY_REVIEW_SIMILARITY_THRESHOLD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_MEMORY_REVIEW_SIMILARITY_THRESHOLD+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`+++0.97+++`
+
+a| [[qlawkus-client_qlawkus-memory-review-cron]] [.property-path]##link:#qlawkus-client_qlawkus-memory-review-cron[`+++qlawkus.memory-review.cron+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.memory-review.cron+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Cron expression for the scheduled memory-review job.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_MEMORY_REVIEW_CRON+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_MEMORY_REVIEW_CRON+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++0 30 3 * * ?+++`
+
+|===
+

--- a/site/content/config-reference.adoc
+++ b/site/content/config-reference.adoc
@@ -4,6 +4,15 @@ This page is generated from each module's `@ConfigMapping` classes and their Jav
 
 == Core agent (qlawkus-client)
 
+=== Agent
+include::_includes/qlawkus-client_qlawkus.agent.adoc[]
+
+=== Memory review
+include::_includes/qlawkus-client_qlawkus.memory-review.adoc[]
+
+=== Memory curation
+include::_includes/qlawkus-client_qlawkus.memory-curation.adoc[]
+
 === Shell
 include::_includes/qlawkus-client_qlawkus.shell.adoc[]
 

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <circle cx="16" cy="19" r="12" fill="#f5821f"/>
+  <ellipse cx="11.5" cy="14.5" rx="3.6" ry="2.3" fill="#ffffff" opacity="0.22"/>
+  <path d="M15.6 8 l-0.4 -4.2" stroke="#6b4a2b" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M16 7 c 0.6 -3.4 3.8 -4.5 6.1 -3.6 c -0.5 3.1 -3.3 4.4 -6.1 3.6 z" fill="#43a35f"/>
+</svg>

--- a/site/templates/layouts/default.html
+++ b/site/templates/layouts/default.html
@@ -37,9 +37,14 @@
         <a href="{site.url.resolve('architecture')}"{#if page.title == 'Architecture'} aria-current="page"{/if}>Architecture</a>
         <a href="{site.url.resolve('configuration')}"{#if page.title == 'Configuration Reference'} aria-current="page"{/if}>Configuration</a>
         <a href="{site.url.resolve('config-reference')}"{#if page.title == 'Configuration Reference (all modules)'} aria-current="page"{/if}>Config Reference</a>
+        <a class="nav-external" href="https://github.com/omatheusmesmo/Qlawkus" target="_blank" rel="noopener">
+          <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
+        </a>
       </nav>
       <div class="sidebar-foot">
-        Build your own agent on Quarkus.
+        <a class="foot-link" href="https://github.com/omatheusmesmo/Qlawkus" target="_blank" rel="noopener">View source on GitHub</a>
+        <p class="foot-tag">Build your own agent on Quarkus.</p>
       </div>
     </aside>
     <label for="nav-toggle" class="nav-burger" aria-label="Toggle navigation">&#9776;</label>

--- a/site/templates/layouts/default.html
+++ b/site/templates/layouts/default.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   {#seo page site/}
   {#favicon site/}
+  <link rel="icon" type="image/svg+xml" href="{site.url.resolve('favicon.svg')}">
   {#bundle /}
   {/insert}
   {#insert head /}

--- a/site/web/app.css
+++ b/site/web/app.css
@@ -93,6 +93,15 @@ body {
   color: #fff;
   box-shadow: inset 2px 0 0 var(--accent);
 }
+.nav a.nav-external {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 8px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+.nav a.nav-external svg { flex: 0 0 auto; }
 
 .sidebar-foot {
   margin-top: auto;
@@ -101,6 +110,13 @@ body {
   border-top: 1px solid rgba(255, 255, 255, 0.07);
   padding-top: 16px;
 }
+.sidebar-foot .foot-link {
+  color: #d8d4dd;
+  text-decoration: none;
+  font-weight: 600;
+}
+.sidebar-foot .foot-link:hover { color: #fff; }
+.sidebar-foot .foot-tag { margin: 8px 0 0; }
 
 /* ---------- Content ---------- */
 .content {

--- a/site/web/app.css
+++ b/site/web/app.css
@@ -245,10 +245,11 @@ table.configuration-reference code { white-space: normal; word-break: break-word
 table.configuration-reference td > .content { margin: 0; }
 table.configuration-reference td > p, table.configuration-reference th > p { margin: 0; }
 table.configuration-reference .property-path { font-weight: 600; }
-table.configuration-reference td .content > .paragraph { margin: 0 0 10px; }
+table.configuration-reference td .content > .paragraph { margin: 0; }
 table.configuration-reference .description { margin: 0; padding-top: 10px; border-top: 1px dashed var(--border); }
 table.configuration-reference .description p { margin: 0; }
-table.configuration-reference .description p + p { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--border); }
+table.configuration-reference .description .content > .paragraph + .paragraph { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--border); }
+table.configuration-reference .description .content > .paragraph:last-child { font-size: 12.5px; color: var(--muted); }
 .configuration-legend { font-size: 12.5px; color: var(--muted); margin: 1.2rem 0 0.5rem; }
 .configuration-legend i, .configuration-legend .icon { display: none; }
 .doc-body .header-title { font-weight: 650; }

--- a/site/web/app.css
+++ b/site/web/app.css
@@ -240,15 +240,19 @@ table.tableblock tbody tr:hover { background: #fcfaf8; }
 /* Generated config reference: keep the 3-column table; stack ONLY the first cell's
    content (property path -> description -> environment variable) with separators. */
 table.configuration-reference { table-layout: fixed; }
+table.configuration-reference col:first-child { width: 72% !important; }
+table.configuration-reference col:nth-child(2),
+table.configuration-reference col:nth-child(3) { width: 14% !important; }
 table.configuration-reference td, table.configuration-reference th { overflow-wrap: anywhere; vertical-align: top; }
+table.configuration-reference td:nth-child(2), table.configuration-reference td:nth-child(3) { vertical-align: middle; }
 table.configuration-reference code { white-space: normal; word-break: break-word; }
-table.configuration-reference td > .content { margin: 0; }
+table.configuration-reference td .content { display: block; margin: 0; padding: 0; }
 table.configuration-reference td > p, table.configuration-reference th > p { margin: 0; }
 table.configuration-reference .property-path { font-weight: 600; }
 table.configuration-reference td .content > .paragraph { margin: 0; }
-table.configuration-reference .description { margin: 0; padding-top: 10px; border-top: 1px dashed var(--border); }
+table.configuration-reference .description { margin: 12px 0 0; }
 table.configuration-reference .description p { margin: 0; }
-table.configuration-reference .description .content > .paragraph + .paragraph { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--border); }
+table.configuration-reference .description .content > .paragraph + .paragraph { margin-top: 12px; }
 table.configuration-reference .description .content > .paragraph:last-child { font-size: 12.5px; color: var(--muted); }
 .configuration-legend { font-size: 12.5px; color: var(--muted); margin: 1.2rem 0 0.5rem; }
 .configuration-legend i, .configuration-legend .icon { display: none; }


### PR DESCRIPTION
## Summary

Moves the remaining ad-hoc config reads onto typed `@ConfigMapping` interfaces (the Quarkiverse idiom already used elsewhere in the project) so configuration is documented from JavaDoc, and tidies up the docs, site and Docker files around it. Behaviour is preserved: property names and defaults are unchanged, so existing env-var overrides keep working.

## Config migration
- New `AgentConfig` (`qlawkus.agent`), `MemoryReviewConfig` (`qlawkus.memory-review`) and `MemoryCurationConfig` (`qlawkus.memory-curation`) interfaces.
- Replaced `@ConfigProperty` / `ConfigProvider` lookups in the cognition, REST and messaging beans with injected mappings; non-CDI suppliers (`SoulEngine`, `ActiveMemoryAugmentor`) resolve the mapping via Arc.
- The JavaDoc now feeds the generated configuration reference (new `agent` / `memory-review` / `memory-curation` includes wired into `config-reference.adoc`).
- `client/deployment` and `messaging/deployment` test suites pass.

## Docs
- `AGENTS.md` / `CONTRIBUTING.md`: extension-development guidance plus a shared set of Quarkus extension reference links.

## Site
- Repository link in the docs sidebar (nav + footer).
- Orange favicon matching the brand mark.
- Config-reference table: first column now stacks property / description / env var (the previous selector never matched), env var rendered as muted metadata.

## Docker
- `docker-compose.yml` / `docker-compose.local.yml` now use `env_file` and drop the `AGENT_*` entries that only repeated the application defaults, reducing noise while keeping overrides, container-specific values and intentional Docker-only defaults.