### PR TITLE
Run passive memory extraction on every channel, not just REST

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,9 @@ Scheduled background jobs, each with a manual `POST /api/admin/memory/*` trigger
 
 - `MemoryReviewJob` - semantic dedup of near-duplicate facts (`/review`).
 - `MemoryCurationJob` - folds facts into the owner profile, reconciling contradictions; leaves facts untouched (`/curate`).
-- `SemanticExtractorObserver` - extracts facts from a conversation on `ChatCompletedEvent`. **Only the REST SSE path fires this event; the messaging path does not** - so passive fact extraction does not happen over Discord/Telegram (explicit `rememberFact` and the profile tool still work).
+- `SemanticExtractorObserver` - extracts facts from a conversation on `ChatCompletedEvent`. The event is emitted channel-agnostically by `ChatCompletionEmitter`, which observes the store-level `MessagesAppendedEvent` and fires once per turn (when a final assistant message - one without tool-execution requests - is appended). **Passive fact extraction works on every channel** (REST, Discord, Telegram); gate it with `qlawkus.agent.semantic-extractor.enabled` (default `true`). The same event also drives the Brag `AchievementProcessor`, so both run on all channels.
 
-Config knobs: `qlawkus.agent.memory.*`, `qlawkus.agent.active-memory.*`, `qlawkus.agent.transcript-*`, `qlawkus.memory-review.*`, `qlawkus.memory-curation.*`. Admin REST: `GET/DELETE /api/admin/memory` (summary / purge), `POST /api/admin/memory/{review,curate}`. End-to-end check: `scripts/memory-benchmark.sh` (needs a running instance + real LLM).
+Config knobs: `qlawkus.agent.memory.*`, `qlawkus.agent.active-memory.*`, `qlawkus.agent.transcript-*`, `qlawkus.agent.semantic-extractor.*`, `qlawkus.memory-review.*`, `qlawkus.memory-curation.*`. Admin REST: `GET/DELETE /api/admin/memory` (summary / purge), `POST /api/admin/memory/{review,curate}`. End-to-end check: `scripts/memory-benchmark.sh` (needs a running instance + real LLM).
 
 Gotcha when testing recall: working memory and the system prompt are both sources, so to prove a fact came from the vector store, `TRUNCATE chat_message_entity` first. The embedding model (`nvidia/nv-embedqa-e5-v5`) is retrieval-tuned and scores relevant pairs high, so a cosine `min-score` of 0.9 is not as strict as it looks - `0.7` is the default margin.
 

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/cognition/ChatCompletionEmitterTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/cognition/ChatCompletionEmitterTest.java
@@ -1,0 +1,49 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Turn-completion detection: a turn is complete only when a final (text) assistant message is
+ * appended, so passive post-turn work fires once per user turn rather than once per tool round.
+ */
+class ChatCompletionEmitterTest {
+
+  @Test
+  void finalAssistantMessageCompletesTheTurn() {
+    assertTrue(ChatCompletionEmitter.isTurnComplete(List.of(
+        AiMessage.from("Here is your answer."))));
+  }
+
+  @Test
+  void userMessageAloneDoesNotCompleteTheTurn() {
+    assertFalse(ChatCompletionEmitter.isTurnComplete(List.of(
+        new UserMessage("what's the weather?"))));
+  }
+
+  @Test
+  void toolRequestingAssistantMessageDoesNotCompleteTheTurn() {
+    AiMessage toolCall = AiMessage.from(ToolExecutionRequest.builder()
+        .id("1").name("getWeather").arguments("{}").build());
+    assertFalse(ChatCompletionEmitter.isTurnComplete(List.of(toolCall)));
+  }
+
+  @Test
+  void toolResultWithoutFinalAnswerDoesNotCompleteTheTurn() {
+    assertFalse(ChatCompletionEmitter.isTurnComplete(List.of(
+        ToolExecutionResultMessage.from("1", "getWeather", "sunny"))));
+  }
+
+  @Test
+  void emptyBatchDoesNotCompleteTheTurn() {
+    assertFalse(ChatCompletionEmitter.isTurnComplete(List.<ChatMessage>of()));
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatCompletionEmitter.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ChatCompletionEmitter.java
@@ -1,0 +1,50 @@
+package dev.omatheusmesmo.qlawkus.cognition;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.omatheusmesmo.qlawkus.store.MessagesAppendedEvent;
+import dev.omatheusmesmo.qlawkus.store.WorkingMemoryStore;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.inject.Inject;
+import java.util.List;
+
+/**
+ * Bridges the store-level {@link MessagesAppendedEvent} (fired on every channel) to the
+ * turn-level {@link ChatCompletedEvent}, so post-turn consumers (semantic extraction, brag
+ * achievements) run regardless of entry point - REST, Discord or Telegram. Replaces the
+ * previous REST-only emission that depended on the SSE stream completing.
+ *
+ * <p>A turn is considered complete when a final assistant message is appended. Intermediate
+ * assistant messages that carry tool-execution requests are skipped, so the event fires once
+ * per user turn rather than once per tool round.
+ */
+@ApplicationScoped
+public class ChatCompletionEmitter {
+
+  @Inject
+  WorkingMemoryStore workingMemoryStore;
+
+  @Inject
+  Event<ChatCompletedEvent> chatCompleted;
+
+  void onMessagesAppended(@ObservesAsync MessagesAppendedEvent event) {
+    if (!isTurnComplete(event.messages())) {
+      return;
+    }
+    List<ChatMessage> window = workingMemoryStore.getMessages(event.memoryId());
+    if (window.isEmpty()) {
+      return;
+    }
+    Log.infof("Firing ChatCompletedEvent with %d messages from memoryId=%s",
+        window.size(), event.memoryId());
+    chatCompleted.fireAsync(new ChatCompletedEvent(window));
+  }
+
+  static boolean isTurnComplete(List<ChatMessage> appended) {
+    return appended.stream().anyMatch(message ->
+        message instanceof AiMessage ai && !ai.hasToolExecutionRequests());
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserver.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/SemanticExtractorObserver.java
@@ -2,6 +2,7 @@ package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.FactStore;
 import dev.omatheusmesmo.qlawkus.store.MemorySource;
 import io.quarkus.logging.Log;
@@ -19,7 +20,11 @@ public class SemanticExtractorObserver {
   @Inject
   FactStore factStore;
 
+  @Inject
+  AgentConfig agentConfig;
+
   void onChatCompleted(@ObservesAsync ChatCompletedEvent event) {
+    if (!agentConfig.semanticExtractor().enabled()) return;
     if (event.messages().isEmpty()) return;
 
     extractAndStore(event.messages());

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
@@ -47,6 +47,12 @@ public interface AgentConfig {
      */
     TranscriptSearch transcriptSearch();
 
+    /**
+     * Passive fact extraction: after each completed turn, mine durable facts from the
+     * conversation and store them ({@code source=semantic-extractor}), on every channel.
+     */
+    SemanticExtractor semanticExtractor();
+
     interface SharedContext {
 
         /**
@@ -96,6 +102,15 @@ public interface AgentConfig {
 
         /**
          * Whether each user and AI message is archived as a searchable transcript embedding.
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface SemanticExtractor {
+
+        /**
+         * Whether to mine durable facts from each completed conversation turn.
          */
         @WithDefault("true")
         boolean enabled();

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/rest/ApiResource.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/rest/ApiResource.java
@@ -1,16 +1,11 @@
 package dev.omatheusmesmo.qlawkus.rest;
 
-import dev.langchain4j.data.message.ChatMessage;
 import dev.omatheusmesmo.qlawkus.agent.AgentService;
 import dev.omatheusmesmo.qlawkus.agent.ConversationId;
-import dev.omatheusmesmo.qlawkus.cognition.ChatCompletedEvent;
 import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.dto.ChatRequest;
-import dev.omatheusmesmo.qlawkus.store.WorkingMemoryStore;
-import io.quarkus.logging.Log;
 import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Multi;
-import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.POST;
@@ -18,7 +13,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import java.util.List;
 
 @Path("/api")
 @Authenticated
@@ -26,12 +20,6 @@ public class ApiResource {
 
     @Inject
     AgentService agentService;
-
-    @Inject
-    WorkingMemoryStore memoryStore;
-
-    @Inject
-    Event<ChatCompletedEvent> eventEmitter;
 
     @Inject
     AgentConfig agentConfig;
@@ -49,18 +37,7 @@ public class ApiResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Multi<String> chat(@Valid ChatRequest request) {
-        String conversationId = conversationId();
-        return agentService.chat(conversationId, request.message())
-            .onCompletion().invoke(() -> {
-                try {
-                    List<ChatMessage> messages = memoryStore.getMessages(conversationId);
-                    Log.infof("Firing ChatCompletedEvent with %d messages from memoryId=%s",
-                            messages.size(), conversationId);
-                    eventEmitter.fireAsync(new ChatCompletedEvent(messages));
-                } catch (Exception e) {
-                    Log.errorf(e, "Failed to fire ChatCompletedEvent");
-                }
-            });
+        return agentService.chat(conversationId(), request.message());
     }
 
     private String conversationId() {

--- a/site/content/_includes/qlawkus-client_qlawkus.agent.adoc
+++ b/site/content/_includes/qlawkus-client_qlawkus.agent.adoc
@@ -238,5 +238,26 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0.7+++`
 
+a| [[qlawkus-client_qlawkus-agent-semantic-extractor-enabled]] [.property-path]##link:#qlawkus-client_qlawkus-agent-semantic-extractor-enabled[`+++qlawkus.agent.semantic-extractor.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.semantic-extractor.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to mine durable facts from each completed conversation turn.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_SEMANTIC_EXTRACTOR_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_SEMANTIC_EXTRACTOR_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 |===
 


### PR DESCRIPTION
## What

Passive memory now works on every channel (REST, Discord, Telegram), not just the REST SSE path.

## Why

`ChatCompletedEvent` was emitted only by the REST SSE completion hook, so passive semantic fact extraction (and brag achievement detection) never ran over Discord/Telegram. Recall already worked everywhere; only the write side was channel-bound.

## How

- New `ChatCompletionEmitter` bridges the store-level `MessagesAppendedEvent` (fired on any channel) to `ChatCompletedEvent`, firing once per completed turn (on the final assistant message, skipping tool-call rounds).
- Removed the REST-only emission from `ApiResource`.
- Both existing consumers (`SemanticExtractorObserver`, brag `AchievementProcessor`) now run on all channels with no change to them.
- New `qlawkus.agent.semantic-extractor.enabled` flag (default `true`) gates the extractor; config reference regenerated.
- Added `ChatCompletionEmitterTest` covering the once-per-turn detection.

## Verification

- `client` + `app` build green; `client/deployment` suite (304) and the new test pass.