### PR TITLE
Pluggable fact store backends: markdown, pgvector, and hybrid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,13 @@ Gotcha when testing recall: working memory and the system prompt are both source
 
 Skills are the agent's **procedural** memory (how to do a recurring task), complementing the declarative memory above. Each skill is a `SKILL.md` file (YAML frontmatter `name` + `description` + Markdown body). Same discipline as memory: the index is **injected, not searched** - `SoulEngine` adds a `## Skills` block (name + description only, via `SkillIndexRenderer`, capped by `qlawkus.skills.max-injected`) every turn; the full body is loaded on demand with the `viewSkill` tool (progressive disclosure).
 
-- **SPI**: `skill.SkillStore` (interface) with `Skill`/`SkillSummary` records and `SkillFrontmatter`. The backend is selected at **build time** via `@IfBuildProperty` on `qlawkus.cognition.backend` (`markdown` | `pgvector` | `hybrid`): `MarkdownSkillStore` (`@DefaultBean`, no DB, shared file logic in `MarkdownSkillFiles`), `store.pg.PgSkillStore` (the `skill` table, `V6` migration), `store.pg.HybridSkillStore` (files source-of-truth + pg mirror). Reads from all `qlawkus.skills.roots` (first wins); writes only to the first, owned root (default `~/.qlawkus/skills`).
+- **SPI**: `skill.SkillStore` (interface) with `Skill`/`SkillSummary` records. SKILL.md **parsing is delegated to the upstream `dev.langchain4j.skills` loaders** (`FileSystemSkillLoader`, agentskills.io spec, BOM-managed `dev.langchain4j:langchain4j-skills`); `SkillFrontmatter` owns only the **write** side (rendering a `Skill` back to frontmatter + body), which upstream does not provide. The backend is selected at **build time** via `@IfBuildProperty` on `qlawkus.cognition.backend` (`markdown` | `pgvector` | `hybrid`): `MarkdownSkillStore` (`@DefaultBean`, no DB, shared file logic in `MarkdownSkillFiles`), `store.pg.PgSkillStore` (the `skill` table, `V6` migration), `store.pg.HybridSkillStore` (files source-of-truth + pg mirror). Reads from all `qlawkus.skills.roots` (first wins); writes only to the first, owned root (default `~/.qlawkus/skills`).
 - **Tools** (in `AgentService`): `ViewSkillTool` (load body), `ManageSkillTool` (`createOrUpdateSkill` / `deleteSkill`).
 - **Auto-distill**: `SkillExtractorObserver` mines a reusable skill from each `ChatCompletedEvent` (gate `qlawkus.skills.extractor.enabled`), mirroring `SemanticExtractorObserver`.
 - **Curation**: `SkillCurationJob` removes redundant skills (scheduled + `POST /api/admin/skills/curate`).
 - **Lifecycle**: `viewSkill` calls `recordUse`; `SkillLifecycleJob` ages unused skills `ACTIVE -> STALE -> ARCHIVED` (config `qlawkus.skills.lifecycle.*`, scheduled + `POST /api/admin/skills/lifecycle`). Archived skills leave the injected index but stay loadable; pinned skills (`POST /api/admin/skills/{name}/pin`) never transition. Telemetry: pg columns (migration `V7`) for pgvector/hybrid, a `.qlawkus-usage.json` sidecar for markdown.
 - **Admin REST**: `GET/DELETE /api/admin/skills`, `GET /api/admin/skills/{name}`, `POST /api/admin/skills/{curate,lifecycle}`, `POST /api/admin/skills/{name}/pin`.
-- **Bundled skills (build-time)**: extensions/apps ship read-only skills as classpath resources under `META-INF/qlawkus-skills/<name>/SKILL.md`. `ClientProcessor.bundledSkills` (a `@BuildStep` + `SkillsRecorder`) scans and parses them at **augmentation** and bakes them into the synthetic `BundledSkills` bean - no runtime classpath scanning. Stores merge bundled (read-only) with owned skills; owned wins on a name clash.
+- **Bundled skills (build-time)**: extensions/apps ship read-only skills as classpath resources under `META-INF/qlawkus-skills/<name>/SKILL.md`. `ClientProcessor.bundledSkills` (a `@BuildStep` + `SkillsRecorder`) scans and parses them (via the same `FileSystemSkillLoader`) at **augmentation** and bakes them into the synthetic `BundledSkills` bean - no runtime classpath scanning. Stores merge bundled (read-only) with owned skills; owned wins on a name clash.
 
 Config knobs: `qlawkus.cognition.backend`, `qlawkus.skills.*`. The broader plan (making facts/episodic/working memory pluggable too, plus a `SkillHub` capability backed by jskills/skills.sh) lives outside the repo in the owner's notes.
 
@@ -166,6 +166,21 @@ Dev mode: Dev Services auto-provisions Ollama (no `.env` needed).
 Prod: Requires `LLM_API_KEY` in `.env`.
 
 Embedding dimension is hardcoded to 1024 via `EMBEDDING_DIMENSION` - must match the model output.
+
+### Dependency versions (do NOT conflate the two langchain4j namespaces)
+
+| What | Version | Where set |
+|------|---------|-----------|
+| Quarkus platform | `3.33.2` | `quarkus.platform.version` in root `pom.xml` |
+| quarkus-langchain4j (Quarkiverse extension + BOM) | `1.11.2` | `quarkus-langchain4j.version` in root `pom.xml` |
+| Upstream `dev.langchain4j` core (transitive) | `1.16.2` | managed by `quarkus-langchain4j-bom:1.11.2` - do not set |
+| Upstream beta modules (`langchain4j-skills`, `langchain4j-pgvector`, `langchain4j-agentic`) | `1.16.2-beta26` | same BOM - do not set |
+
+The Quarkiverse **extension** version (`1.11.2`) and the upstream **library** version (`1.16.2`) are different namespaces: `1.11.2` is NOT a langchain4j-core version. `quarkus-langchain4j-bom` transitively imports the `langchain4j-bom`, which pins every `dev.langchain4j:*` artifact. So when adding an upstream module (e.g. `langchain4j-skills`, or `dev.langchain4j:langchain4j` for `InMemoryEmbeddingStore`), add it with **no `<version>`** - the BOM resolves it. Re-verify any time with:
+
+```bash
+mvn dependency:tree -pl client/runtime -Dincludes='dev.langchain4j'
+```
 
 ## Key Entry Points
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,17 @@ Thanks for your interest in Qlawkus. It is a multi-module Quarkus project: a set
 - Docker (for Dev Services in dev mode, and for the container run modes)
 - An `NVIDIA_AI_API_KEY` only if you want to run against a real LLM (dev mode and local Docker use Ollama)
 
+## Versions
+
+| What | Version |
+|------|---------|
+| Java | 25 |
+| Quarkus platform | 3.33.2 |
+| quarkus-langchain4j (Quarkiverse extension + BOM) | 1.11.2 |
+| Upstream `dev.langchain4j` (transitive, BOM-managed) | 1.16.2 (beta modules `langchain4j-skills`/`-pgvector`/`-agentic`: 1.16.2-beta26) |
+
+The Quarkiverse **extension** version (`1.11.2`) and the upstream **library** version (`1.16.2`) are **different namespaces** - they are not the same number by coincidence; they track separately. The platform and extension versions are set in the root `pom.xml` (`quarkus.platform.version`, `quarkus-langchain4j.version`); the upstream `dev.langchain4j:*` versions are managed transitively by `quarkus-langchain4j-bom`, so add those dependencies **without** a `<version>`. Verify with `mvn dependency:tree -pl client/runtime -Dincludes='dev.langchain4j'`.
+
 ## Project layout
 
 | Module | Role |

--- a/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
+++ b/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.logging.Log;
 import dev.omatheusmesmo.qlawkus.model.LlmKindConfigBuilder;
 import jakarta.inject.Singleton;
@@ -97,6 +98,17 @@ class ClientProcessor {
         } catch (RuntimeException e) {
             Log.warnf(e, "Failed to read bundled skill %s", file);
         }
+    }
+
+    /**
+     * {@code ActiveMemoryAugmentor} holds a static {@code ContentInjector} whose prompt template is
+     * not native-image safe to construct at image build time. Initialize the class at runtime so its
+     * static initializer runs in the running image instead of failing the build.
+     */
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitActiveMemoryAugmentor() {
+        return new RuntimeInitializedClassBuildItem(
+                "dev.omatheusmesmo.qlawkus.cognition.ActiveMemoryAugmentor");
     }
 
     @BuildStep

--- a/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
+++ b/client/deployment/src/main/java/dev/omatheusmesmo/qlawkus/deployment/ClientProcessor.java
@@ -1,7 +1,8 @@
 package dev.omatheusmesmo.qlawkus.deployment;
 
+import dev.langchain4j.skills.FileSystemSkill;
+import dev.langchain4j.skills.FileSystemSkillLoader;
 import dev.omatheusmesmo.qlawkus.skill.BundledSkills;
-import dev.omatheusmesmo.qlawkus.skill.SkillFrontmatter;
 import dev.omatheusmesmo.qlawkus.skill.SkillsRecorder;
 import dev.omatheusmesmo.qlawkus.tool.QlawTool;
 import dev.omatheusmesmo.qlawkus.tool.QlawToolProvider;
@@ -28,7 +29,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -87,13 +87,14 @@ class ClientProcessor {
     private static void readBundledSkill(Path file, List<String> names, List<String> descriptions,
             List<String> bodies) {
         try {
-            SkillFrontmatter.Parsed parsed =
-                    SkillFrontmatter.parse(Files.readString(file, StandardCharsets.UTF_8));
-            String name = parsed.name().orElseGet(() -> file.getParent().getFileName().toString());
+            FileSystemSkill parsed = FileSystemSkillLoader.loadSkill(file.getParent());
+            String name = (parsed.name() == null || parsed.name().isBlank())
+                    ? file.getParent().getFileName().toString()
+                    : parsed.name();
             names.add(name);
-            descriptions.add(parsed.description().orElse(""));
-            bodies.add(parsed.body());
-        } catch (IOException e) {
+            descriptions.add(parsed.description() == null ? "" : parsed.description());
+            bodies.add(parsed.content());
+        } catch (RuntimeException e) {
             Log.warnf(e, "Failed to read bundled skill %s", file);
         }
     }

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactStoreTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactStoreTest.java
@@ -1,0 +1,151 @@
+package dev.omatheusmesmo.qlawkus.store.markdown;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.omatheusmesmo.qlawkus.store.MemorySource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit test for the markdown fact backend: files are the source of truth, an in-process embedding
+ * store gives query-relevant top-K retrieval, and a JSON cache avoids re-embedding on reload. Uses
+ * a deterministic fake {@link EmbeddingModel} (same text yields the same vector) so an exact match
+ * scores 1.0 - no real LLM needed.
+ */
+class MarkdownFactStoreTest {
+
+  @TempDir
+  Path tempDir;
+
+  private static Map<String, Object> source(MemorySource source) {
+    return Map.of("source", source.value());
+  }
+
+  private MarkdownFactStore freshStore(EmbeddingModel model) {
+    MarkdownFactStore store = new MarkdownFactStore(tempDir.toString(), model);
+    store.load();
+    return store;
+  }
+
+  private long markdownFileCount() throws IOException {
+    try (Stream<Path> files = Files.list(tempDir)) {
+      return files.filter(p -> p.getFileName().toString().endsWith(".md")).count();
+    }
+  }
+
+  @Test
+  void storesFactAsFileAndRetrievesItByRelevance() {
+    MarkdownFactStore store = freshStore(new FakeEmbeddingModel());
+    store.store("the sky is blue", source(MemorySource.REMEMBER_TOOL));
+    store.store("cats enjoy fish", source(MemorySource.REMEMBER_TOOL));
+
+    List<String> hits = store.search("the sky is blue", 1, 0.0);
+
+    assertEquals(1, hits.size());
+    assertEquals("the sky is blue", hits.get(0));
+  }
+
+  @Test
+  void deduplicatesIdenticalContent() throws IOException {
+    MarkdownFactStore store = freshStore(new FakeEmbeddingModel());
+    store.store("the sky is blue", source(MemorySource.REMEMBER_TOOL));
+    store.store("the sky is blue", source(MemorySource.REMEMBER_TOOL));
+
+    assertEquals(1, markdownFileCount());
+  }
+
+  @Test
+  void searchBySourceFiltersOutOtherSources() {
+    MarkdownFactStore store = freshStore(new FakeEmbeddingModel());
+    store.store("curated fact", source(MemorySource.REMEMBER_TOOL));
+    store.store("raw transcript line", source(MemorySource.TRANSCRIPT));
+
+    List<String> transcripts = store.searchBySource("curated fact", MemorySource.TRANSCRIPT.value(), 10, 0.0);
+
+    assertFalse(transcripts.contains("curated fact"));
+    assertTrue(transcripts.contains("raw transcript line"));
+  }
+
+  @Test
+  void purgeBySourceRemovesOnlyThatSource() {
+    MarkdownFactStore store = freshStore(new FakeEmbeddingModel());
+    store.store("curated fact", source(MemorySource.REMEMBER_TOOL));
+    store.store("raw transcript line", source(MemorySource.TRANSCRIPT));
+
+    long purged = store.purgeBySource(MemorySource.TRANSCRIPT.value());
+
+    assertEquals(1, purged);
+    assertEquals(List.of(MemorySource.REMEMBER_TOOL.value()), store.listSources());
+    assertEquals(List.of("curated fact"), store.search("curated fact", 1, 0.0));
+  }
+
+  @Test
+  void purgeAllClearsFactsAndFiles() throws IOException {
+    MarkdownFactStore store = freshStore(new FakeEmbeddingModel());
+    store.store("one", source(MemorySource.REMEMBER_TOOL));
+    store.store("two", source(MemorySource.REMEMBER_TOOL));
+
+    long purged = store.purgeAll();
+
+    assertEquals(2, purged);
+    assertEquals(0, markdownFileCount());
+    assertTrue(store.search("one", 5, 0.0).isEmpty());
+  }
+
+  @Test
+  void reloadUsesEmbeddingCacheAndDoesNotReembed() {
+    FakeEmbeddingModel writer = new FakeEmbeddingModel();
+    MarkdownFactStore first = freshStore(writer);
+    first.store("the sky is blue", source(MemorySource.REMEMBER_TOOL));
+
+    FakeEmbeddingModel reader = new FakeEmbeddingModel();
+    MarkdownFactStore second = freshStore(reader);
+
+    assertEquals(0, reader.embedCalls, "reload must hit the cache, not re-embed stored facts");
+    assertEquals(List.of("the sky is blue"), second.search("the sky is blue", 1, 0.0));
+  }
+
+  /** Deterministic, offline embedding model: same text always yields the same vector. */
+  private static final class FakeEmbeddingModel implements EmbeddingModel {
+
+    int embedCalls = 0;
+
+    @Override
+    public Response<List<Embedding>> embedAll(List<TextSegment> segments) {
+      embedCalls += segments.size();
+      List<Embedding> embeddings = new ArrayList<>();
+      for (TextSegment segment : segments) {
+        embeddings.add(vectorFor(segment.text()));
+      }
+      return Response.from(embeddings);
+    }
+
+    @Override
+    public int dimension() {
+      return 32;
+    }
+
+    private static Embedding vectorFor(String text) {
+      Random random = new Random(text.hashCode());
+      float[] vector = new float[32];
+      for (int i = 0; i < vector.length; i++) {
+        vector[i] = random.nextFloat() * 2 - 1;
+      }
+      return Embedding.from(vector);
+    }
+  }
+}

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/pg/HybridFactStoreTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/pg/HybridFactStoreTest.java
@@ -1,0 +1,149 @@
+package dev.omatheusmesmo.qlawkus.store.pg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
+import dev.omatheusmesmo.qlawkus.store.MemorySource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit test for the hybrid fact backend: every write must land in the {@code .md} files (the source
+ * of truth) AND be mirrored into the vector store. Uses a real {@link InMemoryEmbeddingStore} as the
+ * mirror, a deterministic fake embedding model, and a fake {@link EmbeddingRepository} (no
+ * database), so the file/mirror logic is exercised without Postgres.
+ */
+class HybridFactStoreTest {
+
+  @TempDir
+  Path tempDir;
+
+  private static Map<String, Object> source(MemorySource source) {
+    return Map.of("source", source.value());
+  }
+
+  private HybridFactStore store(FakeRepo repo) {
+    return new HybridFactStore(tempDir.toString(), new FakeEmbeddingModel(),
+        new InMemoryEmbeddingStore<>(), repo);
+  }
+
+  private long markdownFileCount() throws IOException {
+    try (Stream<Path> files = Files.list(tempDir)) {
+      return files.filter(p -> p.getFileName().toString().endsWith(".md")).count();
+    }
+  }
+
+  @Test
+  void storeWritesFileAndMirrorsToVectorStore() throws IOException {
+    HybridFactStore store = store(new FakeRepo());
+
+    store.store("user prefers dark theme", source(MemorySource.REMEMBER_TOOL));
+
+    assertEquals(1, markdownFileCount());
+    assertEquals(List.of("user prefers dark theme"),
+        store.search("user prefers dark theme", 1, 0.0));
+  }
+
+  @Test
+  void storeDeduplicatesViaRepository() throws IOException {
+    FakeRepo repo = new FakeRepo();
+    repo.exists = true;
+    HybridFactStore store = store(repo);
+
+    store.store("already known", source(MemorySource.REMEMBER_TOOL));
+
+    assertEquals(0, markdownFileCount());
+  }
+
+  @Test
+  void purgeAllDeletesFilesAndDelegatesToRepository() throws IOException {
+    FakeRepo repo = new FakeRepo();
+    HybridFactStore store = store(repo);
+    store.store("one", source(MemorySource.REMEMBER_TOOL));
+    store.store("two", source(MemorySource.REMEMBER_TOOL));
+
+    long purged = store.purgeAll();
+
+    assertEquals(2, purged);
+    assertEquals(1, repo.deleteAllCalls);
+    assertEquals(0, markdownFileCount());
+  }
+
+  @Test
+  void purgeBySourceDeletesMatchingFilesAndDelegates() throws IOException {
+    FakeRepo repo = new FakeRepo();
+    HybridFactStore store = store(repo);
+    store.store("curated", source(MemorySource.REMEMBER_TOOL));
+    store.store("transcript line", source(MemorySource.TRANSCRIPT));
+
+    store.purgeBySource(MemorySource.TRANSCRIPT.value());
+
+    assertEquals(MemorySource.TRANSCRIPT.value(), repo.deletedSource);
+    assertEquals(1, markdownFileCount());
+  }
+
+  /** Fake repository: in-memory flags, no EntityManager, overrides only what the store calls. */
+  private static final class FakeRepo extends EmbeddingRepository {
+
+    boolean exists = false;
+    int deleteAllCalls = 0;
+    String deletedSource = null;
+
+    @Override
+    public boolean existsByContentHash(String hash) {
+      return exists;
+    }
+
+    @Override
+    public long deleteAll() {
+      deleteAllCalls++;
+      return 2;
+    }
+
+    @Override
+    public long deleteBySource(String source) {
+      deletedSource = source;
+      return 1;
+    }
+
+    @Override
+    public List<String> listSources() {
+      return List.of();
+    }
+  }
+
+  /** Deterministic, offline embedding model: same text always yields the same vector. */
+  private static final class FakeEmbeddingModel implements EmbeddingModel {
+
+    @Override
+    public Response<List<Embedding>> embedAll(List<TextSegment> segments) {
+      List<Embedding> embeddings = new ArrayList<>();
+      for (TextSegment segment : segments) {
+        Random random = new Random(segment.text().hashCode());
+        float[] vector = new float[32];
+        for (int i = 0; i < vector.length; i++) {
+          vector[i] = random.nextFloat() * 2 - 1;
+        }
+        embeddings.add(Embedding.from(vector));
+      }
+      return Response.from(embeddings);
+    }
+
+    @Override
+    public int dimension() {
+      return 32;
+    }
+  }
+}

--- a/client/runtime/pom.xml
+++ b/client/runtime/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>quarkus-langchain4j-pgvector</artifactId>
     </dependency>
     <dependency>
+      <groupId>dev.langchain4j</groupId>
+      <artifactId>langchain4j-skills</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-scheduler</artifactId>
     </dependency>

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
@@ -10,7 +10,9 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import dev.omatheusmesmo.qlawkus.config.AgentConfig;
 import dev.omatheusmesmo.qlawkus.store.MemorySource;
+import dev.omatheusmesmo.qlawkus.store.markdown.MarkdownFactStore;
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.List;
@@ -38,8 +40,7 @@ public class ActiveMemoryAugmentor implements Supplier<RetrievalAugmentor> {
 
     ContentRetriever retriever;
     if (enabled) {
-      @SuppressWarnings("unchecked")
-      EmbeddingStore<TextSegment> store = Arc.container().instance(EmbeddingStore.class).get();
+      EmbeddingStore<TextSegment> store = resolveEmbeddingStore();
       EmbeddingModel model = Arc.container().instance(EmbeddingModel.class).get();
       retriever = EmbeddingStoreContentRetriever.builder()
           .embeddingStore(store)
@@ -52,5 +53,20 @@ public class ActiveMemoryAugmentor implements Supplier<RetrievalAugmentor> {
       retriever = query -> List.of();
     }
     return DefaultRetrievalAugmentor.builder().contentRetriever(retriever).build();
+  }
+
+  /**
+   * The embedding store to retrieve facts from, chosen by the active cognition backend. In markdown
+   * mode the {@link MarkdownFactStore} bean is present and owns an in-process index (no database);
+   * otherwise the Postgres-backed {@code EmbeddingStore} (pgvector / hybrid) is used. Both flow
+   * through the same {@code EmbeddingStoreContentRetriever}.
+   */
+  @SuppressWarnings("unchecked")
+  private EmbeddingStore<TextSegment> resolveEmbeddingStore() {
+    InstanceHandle<MarkdownFactStore> markdown = Arc.container().instance(MarkdownFactStore.class);
+    if (markdown.isAvailable()) {
+      return markdown.get().embeddingStore();
+    }
+    return Arc.container().instance(EmbeddingStore.class).get();
   }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
@@ -37,6 +37,10 @@ public class ActiveMemoryAugmentor implements Supplier<RetrievalAugmentor> {
    * Frames retrieved facts in the user message and surfaces each fact's {@code source} as
    * provenance, so the model knows these are recalled memories (not the user's words) and where
    * they came from. Empty retrieval is a no-op, so this is safe to apply unconditionally.
+   *
+   * <p>The injector's prompt template is not native-image safe to build at image build time, so
+   * {@code ClientProcessor} marks this class for runtime class initialization
+   * ({@code RuntimeInitializedClassBuildItem}); the field is then initialized at runtime.
    */
   private static final ContentInjector MEMORY_INJECTOR = DefaultContentInjector.builder()
       .promptTemplate(PromptTemplate.from("{{userMessage}}\n\n"

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/cognition/ActiveMemoryAugmentor.java
@@ -2,8 +2,11 @@ package dev.omatheusmesmo.qlawkus.cognition;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.RetrievalAugmentor;
+import dev.langchain4j.rag.content.injector.ContentInjector;
+import dev.langchain4j.rag.content.injector.DefaultContentInjector;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
@@ -30,6 +33,18 @@ import java.util.function.Supplier;
 @ApplicationScoped
 public class ActiveMemoryAugmentor implements Supplier<RetrievalAugmentor> {
 
+  /**
+   * Frames retrieved facts in the user message and surfaces each fact's {@code source} as
+   * provenance, so the model knows these are recalled memories (not the user's words) and where
+   * they came from. Empty retrieval is a no-op, so this is safe to apply unconditionally.
+   */
+  private static final ContentInjector MEMORY_INJECTOR = DefaultContentInjector.builder()
+      .promptTemplate(PromptTemplate.from("{{userMessage}}\n\n"
+          + "Relevant things you remember (each item is a stored memory, with its source):\n"
+          + "{{contents}}"))
+      .metadataKeysToInclude(List.of("source"))
+      .build();
+
   @Override
   public RetrievalAugmentor get() {
     AgentConfig.ActiveMemory activeMemory =
@@ -52,7 +67,10 @@ public class ActiveMemoryAugmentor implements Supplier<RetrievalAugmentor> {
     } else {
       retriever = query -> List.of();
     }
-    return DefaultRetrievalAugmentor.builder().contentRetriever(retriever).build();
+    return DefaultRetrievalAugmentor.builder()
+        .contentRetriever(retriever)
+        .contentInjector(MEMORY_INJECTOR)
+        .build();
   }
 
   /**

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
@@ -53,6 +53,23 @@ public interface AgentConfig {
      */
     SemanticExtractor semanticExtractor();
 
+    /**
+     * Markdown fact backend: where the agent's {@code .md} fact files and their embedding cache
+     * live. Used only when {@code qlawkus.cognition.backend=markdown}.
+     */
+    Facts facts();
+
+    interface Facts {
+
+        /**
+         * Directory holding the markdown fact files and the sibling embedding cache
+         * ({@code .embeddings.json}). Defaults to a qlawkus-owned folder, keeping facts editable
+         * and git-versionable.
+         */
+        @WithDefault("${user.home}/.qlawkus/facts")
+        String root();
+    }
+
     interface SharedContext {
 
         /**

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/skill/MarkdownSkillFiles.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/skill/MarkdownSkillFiles.java
@@ -2,6 +2,8 @@ package dev.omatheusmesmo.qlawkus.skill;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.skills.FileSystemSkill;
+import dev.langchain4j.skills.FileSystemSkillLoader;
 import io.quarkus.logging.Log;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -171,14 +173,17 @@ public class MarkdownSkillFiles {
       return;
     }
     try {
-      SkillFrontmatter.Parsed parsed =
-          SkillFrontmatter.parse(Files.readString(file, StandardCharsets.UTF_8));
-      String name = parsed.name().orElse(dir.getFileName().toString());
-      byName.putIfAbsent(name,
-          new Loaded(new Skill(name, parsed.description().orElse(""), parsed.body()), file));
-    } catch (IOException e) {
+      FileSystemSkill parsed = FileSystemSkillLoader.loadSkill(dir);
+      String name = isBlank(parsed.name()) ? dir.getFileName().toString() : parsed.name();
+      String description = parsed.description() == null ? "" : parsed.description();
+      byName.putIfAbsent(name, new Loaded(new Skill(name, description, parsed.content()), file));
+    } catch (RuntimeException e) {
       Log.warnf(e, "Failed to read skill at %s", file);
     }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
   }
 
   private Map<String, SkillUsage> readUsage() {

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/skill/SkillFrontmatter.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/skill/SkillFrontmatter.java
@@ -1,54 +1,16 @@
 package dev.omatheusmesmo.qlawkus.skill;
 
-import java.util.Optional;
-
 /**
- * Minimal reader/writer for SKILL.md files: a YAML frontmatter block delimited by {@code ---}
- * lines, followed by the Markdown body. Only the {@code name} and {@code description} keys are
- * read (the keys that form the injected index); other frontmatter keys are ignored. Avoids a
- * YAML dependency for what is, in practice, a couple of flat string keys.
+ * Writer for SKILL.md files: renders a {@link Skill} into a {@code ---}-delimited YAML frontmatter
+ * block ({@code name} + {@code description}) followed by the Markdown body. Reading/parsing is
+ * delegated to the upstream {@code dev.langchain4j.skills} loaders (agentskills.io spec); this
+ * class only owns the write side, which upstream does not provide.
  */
 public final class SkillFrontmatter {
 
   private static final String DELIMITER = "---";
 
   private SkillFrontmatter() {
-  }
-
-  public record Parsed(Optional<String> name, Optional<String> description, String body) {
-  }
-
-  public static Parsed parse(String content) {
-    if (content == null) {
-      return new Parsed(Optional.empty(), Optional.empty(), "");
-    }
-    String normalized = content.stripLeading();
-    if (!normalized.startsWith(DELIMITER)) {
-      return new Parsed(Optional.empty(), Optional.empty(), content.strip());
-    }
-    int firstBreak = normalized.indexOf('\n');
-    if (firstBreak < 0) {
-      return new Parsed(Optional.empty(), Optional.empty(), "");
-    }
-    int closing = normalized.indexOf("\n" + DELIMITER, firstBreak);
-    if (closing < 0) {
-      return new Parsed(Optional.empty(), Optional.empty(), content.strip());
-    }
-    String frontmatter = normalized.substring(firstBreak + 1, closing);
-    int bodyStart = normalized.indexOf('\n', closing + 1);
-    String body = bodyStart < 0 ? "" : normalized.substring(bodyStart + 1).strip();
-
-    String name = null;
-    String description = null;
-    for (String line : frontmatter.split("\n")) {
-      String trimmed = line.strip();
-      if (trimmed.startsWith("name:")) {
-        name = unquote(trimmed.substring("name:".length()).strip());
-      } else if (trimmed.startsWith("description:")) {
-        description = unquote(trimmed.substring("description:".length()).strip());
-      }
-    }
-    return new Parsed(blankToEmpty(name), blankToEmpty(description), body);
   }
 
   static String render(Skill skill) {
@@ -68,18 +30,5 @@ public final class SkillFrontmatter {
       return "";
     }
     return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ");
-  }
-
-  private static String unquote(String value) {
-    if (value.length() >= 2
-        && ((value.startsWith("\"") && value.endsWith("\""))
-            || (value.startsWith("'") && value.endsWith("'")))) {
-      return value.substring(1, value.length() - 1);
-    }
-    return value;
-  }
-
-  private static Optional<String> blankToEmpty(String value) {
-    return value == null || value.isBlank() ? Optional.empty() : Optional.of(value);
   }
 }

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactFiles.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactFiles.java
@@ -1,0 +1,174 @@
+package dev.omatheusmesmo.qlawkus.store.markdown;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.logging.Log;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+/**
+ * File operations for the markdown fact backend. Each fact is a {@code <root>/<id>.md} file with a
+ * small YAML frontmatter ({@code source}, {@code createdAt}, ...) followed by the fact text as the
+ * body. The id is the MD5 of the content, so identical facts deduplicate. A sibling
+ * {@code .embeddings.json} caches the embedding vector per id, so restarts re-embed only changed
+ * facts. The files are the source of truth; the cache is derived and safe to delete.
+ */
+public class MarkdownFactFiles {
+
+  private static final String CACHE_FILE = ".embeddings.json";
+  private static final String DELIMITER = "---";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Path root;
+
+  public MarkdownFactFiles(Path root) {
+    this.root = root;
+  }
+
+  public record FactRecord(String id, String content, Map<String, String> metadata) {
+  }
+
+  public List<FactRecord> loadAll() {
+    if (!Files.isDirectory(root)) {
+      return List.of();
+    }
+    List<FactRecord> facts = new ArrayList<>();
+    try (Stream<Path> files = Files.list(root)) {
+      files.filter(p -> p.getFileName().toString().endsWith(".md"))
+          .forEach(p -> readFact(p, facts));
+    } catch (IOException e) {
+      Log.warnf(e, "Failed to list fact root %s", root);
+    }
+    return facts;
+  }
+
+  private void readFact(Path file, List<FactRecord> out) {
+    try {
+      Parsed parsed = parse(Files.readString(file, StandardCharsets.UTF_8));
+      String id = file.getFileName().toString().replaceFirst("\\.md$", "");
+      out.add(new FactRecord(id, parsed.body(), parsed.frontmatter()));
+    } catch (IOException e) {
+      Log.warnf(e, "Failed to read fact %s", file);
+    }
+  }
+
+  public boolean exists(String id) {
+    return Files.isRegularFile(root.resolve(id + ".md"));
+  }
+
+  public void write(String id, String content, Map<String, String> metadata) {
+    try {
+      Files.createDirectories(root);
+      Files.writeString(root.resolve(id + ".md"), render(content, metadata),
+          StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to write fact " + id, e);
+    }
+  }
+
+  public boolean delete(String id) {
+    try {
+      return Files.deleteIfExists(root.resolve(id + ".md"));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to delete fact " + id, e);
+    }
+  }
+
+  public List<String> listSources() {
+    TreeSet<String> sources = new TreeSet<>();
+    for (FactRecord fact : loadAll()) {
+      String source = fact.metadata().get("source");
+      if (source != null && !source.isBlank()) {
+        sources.add(source);
+      }
+    }
+    return new ArrayList<>(sources);
+  }
+
+  public Map<String, float[]> loadCache() {
+    Path file = root.resolve(CACHE_FILE);
+    if (!Files.isRegularFile(file)) {
+      return new LinkedHashMap<>();
+    }
+    try {
+      Map<String, float[]> cache = MAPPER.readValue(Files.readString(file, StandardCharsets.UTF_8),
+          new TypeReference<LinkedHashMap<String, float[]>>() {});
+      return cache == null ? new LinkedHashMap<>() : cache;
+    } catch (IOException e) {
+      Log.warnf(e, "Failed to read embedding cache %s; will re-embed", file);
+      return new LinkedHashMap<>();
+    }
+  }
+
+  public void saveCache(Map<String, float[]> cache) {
+    try {
+      Files.createDirectories(root);
+      Files.writeString(root.resolve(CACHE_FILE), MAPPER.writeValueAsString(cache),
+          StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      Log.warnf(e, "Failed to write embedding cache");
+    }
+  }
+
+  public static String md5(String content) {
+    try {
+      byte[] digest = MessageDigest.getInstance("MD5")
+          .digest(content.getBytes(StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder(digest.length * 2);
+      for (byte b : digest) {
+        sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("MD5 not available", e);
+    }
+  }
+
+  private String render(String content, Map<String, String> metadata) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(DELIMITER).append('\n');
+    Map<String, String> frontmatter = new LinkedHashMap<>(metadata);
+    frontmatter.putIfAbsent("createdAt", Instant.now().toString());
+    frontmatter.forEach((key, value) ->
+        sb.append(key).append(": ").append(value == null ? "" : value).append('\n'));
+    sb.append(DELIMITER).append("\n\n");
+    sb.append(content == null ? "" : content.strip()).append('\n');
+    return sb.toString();
+  }
+
+  private record Parsed(Map<String, String> frontmatter, String body) {
+  }
+
+  private Parsed parse(String raw) {
+    Map<String, String> frontmatter = new LinkedHashMap<>();
+    String text = raw.strip();
+    if (!text.startsWith(DELIMITER)) {
+      return new Parsed(frontmatter, text);
+    }
+    int end = text.indexOf("\n" + DELIMITER, DELIMITER.length());
+    if (end < 0) {
+      return new Parsed(frontmatter, text);
+    }
+    String header = text.substring(DELIMITER.length(), end).strip();
+    String body = text.substring(end + ("\n" + DELIMITER).length()).strip();
+    for (String line : header.split("\n")) {
+      int colon = line.indexOf(':');
+      if (colon > 0) {
+        frontmatter.put(line.substring(0, colon).strip(), line.substring(colon + 1).strip());
+      }
+    }
+    return new Parsed(frontmatter, body);
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactStore.java
@@ -44,13 +44,18 @@ public class MarkdownFactStore implements FactStore {
     this(config.facts().root(), embeddingModel);
   }
 
-  MarkdownFactStore(String root, EmbeddingModel embeddingModel) {
+  public MarkdownFactStore(String root, EmbeddingModel embeddingModel) {
     this.files = new MarkdownFactFiles(Path.of(root));
     this.embeddingModel = embeddingModel;
   }
 
+  /**
+   * Rebuilds the in-process embedding index from the {@code .md} files, re-embedding only facts
+   * absent from the JSON cache. Runs automatically as the CDI {@code @PostConstruct}; also callable
+   * directly when the store is constructed outside the container (tests).
+   */
   @PostConstruct
-  void load() {
+  public void load() {
     Map<String, float[]> cache = files.loadCache();
     Map<String, float[]> refreshed = new LinkedHashMap<>();
     boolean changed = false;

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownFactStore.java
@@ -1,0 +1,163 @@
+package dev.omatheusmesmo.qlawkus.store.markdown;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
+import dev.omatheusmesmo.qlawkus.store.FactStore;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Markdown-backed {@link FactStore}, active when {@code qlawkus.cognition.backend=markdown}. Facts
+ * are {@code .md} files (the source of truth) under {@code qlawkus.agent.facts.root}; an in-process
+ * {@link InMemoryEmbeddingStore} holds their embeddings for query-relevant retrieval (top-K), with
+ * a sibling JSON cache so restarts only re-embed changed facts. No database is used. The same
+ * embedding store is read by {@code ActiveMemoryAugmentor}, so recall stays on the RAG seam exactly
+ * like the pgvector backend - retrieved, not dumped.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "markdown")
+public class MarkdownFactStore implements FactStore {
+
+  private final MarkdownFactFiles files;
+  private final EmbeddingModel embeddingModel;
+  private final InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+
+  @Inject
+  public MarkdownFactStore(AgentConfig config, EmbeddingModel embeddingModel) {
+    this(config.facts().root(), embeddingModel);
+  }
+
+  MarkdownFactStore(String root, EmbeddingModel embeddingModel) {
+    this.files = new MarkdownFactFiles(Path.of(root));
+    this.embeddingModel = embeddingModel;
+  }
+
+  @PostConstruct
+  void load() {
+    Map<String, float[]> cache = files.loadCache();
+    Map<String, float[]> refreshed = new LinkedHashMap<>();
+    boolean changed = false;
+    for (MarkdownFactFiles.FactRecord fact : files.loadAll()) {
+      float[] vector = cache.get(fact.id());
+      Embedding embedding;
+      if (vector != null) {
+        embedding = Embedding.from(vector);
+      } else {
+        embedding = embeddingModel.embed(fact.content()).content();
+        changed = true;
+      }
+      refreshed.put(fact.id(), embedding.vector());
+      store.add(fact.id(), embedding, segment(fact.content(), fact.metadata()));
+    }
+    if (changed || refreshed.size() != cache.size()) {
+      files.saveCache(refreshed);
+    }
+    Log.infof("Markdown fact store loaded %d facts", refreshed.size());
+  }
+
+  @Override
+  public void store(String content, Map<String, Object> metadata) {
+    String id = MarkdownFactFiles.md5(content);
+    if (files.exists(id)) {
+      Log.debugf("Fact already exists, skipping: %s", id);
+      return;
+    }
+    Map<String, String> stringMetadata = stringify(metadata);
+    files.write(id, content, stringMetadata);
+    Embedding embedding = embeddingModel.embed(content).content();
+    store.add(id, embedding, segment(content, stringMetadata));
+    Map<String, float[]> cache = files.loadCache();
+    cache.put(id, embedding.vector());
+    files.saveCache(cache);
+  }
+
+  @Override
+  public List<String> search(String query, int maxResults, double minScore) {
+    return texts(EmbeddingSearchRequest.builder()
+        .queryEmbedding(embeddingModel.embed(query).content())
+        .maxResults(maxResults)
+        .minScore(minScore)
+        .build());
+  }
+
+  @Override
+  public List<String> searchBySource(String query, String source, int maxResults, double minScore) {
+    return texts(EmbeddingSearchRequest.builder()
+        .queryEmbedding(embeddingModel.embed(query).content())
+        .maxResults(maxResults)
+        .minScore(minScore)
+        .filter(metadataKey("source").isEqualTo(source))
+        .build());
+  }
+
+  @Override
+  public List<String> listSources() {
+    return files.listSources();
+  }
+
+  @Override
+  public long purgeBySource(String source) {
+    List<String> ids = new ArrayList<>();
+    for (MarkdownFactFiles.FactRecord fact : files.loadAll()) {
+      if (source.equals(fact.metadata().get("source"))) {
+        ids.add(fact.id());
+      }
+    }
+    ids.forEach(files::delete);
+    if (!ids.isEmpty()) {
+      store.removeAll(ids);
+      Map<String, float[]> cache = files.loadCache();
+      ids.forEach(cache::remove);
+      files.saveCache(cache);
+    }
+    return ids.size();
+  }
+
+  @Override
+  public long purgeAll() {
+    List<MarkdownFactFiles.FactRecord> all = files.loadAll();
+    all.forEach(fact -> files.delete(fact.id()));
+    store.removeAll();
+    files.saveCache(new LinkedHashMap<>());
+    return all.size();
+  }
+
+  /** The in-process embedding store backing this fact store; read by the active-memory augmentor. */
+  public EmbeddingStore<TextSegment> embeddingStore() {
+    return store;
+  }
+
+  private List<String> texts(EmbeddingSearchRequest request) {
+    EmbeddingSearchResult<TextSegment> result = store.search(request);
+    return result.matches().stream().map(EmbeddingMatch::embedded).map(TextSegment::text).toList();
+  }
+
+  private static TextSegment segment(String content, Map<String, String> metadata) {
+    Metadata segmentMetadata = new Metadata();
+    metadata.forEach(segmentMetadata::put);
+    return TextSegment.from(content, segmentMetadata);
+  }
+
+  private static Map<String, String> stringify(Map<String, Object> metadata) {
+    Map<String, String> out = new LinkedHashMap<>();
+    metadata.forEach((key, value) -> out.put(key, value == null ? "" : value.toString()));
+    return out;
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/HybridFactStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/HybridFactStore.java
@@ -14,7 +14,6 @@ import dev.omatheusmesmo.qlawkus.store.FactStore;
 import dev.omatheusmesmo.qlawkus.store.markdown.MarkdownFactFiles;
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.logging.Log;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.nio.file.Path;
@@ -32,23 +31,23 @@ import java.util.Map;
 @IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "hybrid")
 public class HybridFactStore implements FactStore {
 
-  @Inject
-  AgentConfig config;
+  private final MarkdownFactFiles files;
+  private final EmbeddingModel embeddingModel;
+  private final EmbeddingStore<TextSegment> embeddingStore;
+  private final EmbeddingRepository embeddingRepository;
 
   @Inject
-  EmbeddingModel embeddingModel;
+  public HybridFactStore(AgentConfig config, EmbeddingModel embeddingModel,
+      EmbeddingStore<TextSegment> embeddingStore, EmbeddingRepository embeddingRepository) {
+    this(config.facts().root(), embeddingModel, embeddingStore, embeddingRepository);
+  }
 
-  @Inject
-  EmbeddingStore<TextSegment> embeddingStore;
-
-  @Inject
-  EmbeddingRepository embeddingRepository;
-
-  private MarkdownFactFiles files;
-
-  @PostConstruct
-  void init() {
-    files = new MarkdownFactFiles(Path.of(config.facts().root()));
+  HybridFactStore(String root, EmbeddingModel embeddingModel,
+      EmbeddingStore<TextSegment> embeddingStore, EmbeddingRepository embeddingRepository) {
+    this.files = new MarkdownFactFiles(Path.of(root));
+    this.embeddingModel = embeddingModel;
+    this.embeddingStore = embeddingStore;
+    this.embeddingRepository = embeddingRepository;
   }
 
   @Override

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/HybridFactStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/HybridFactStore.java
@@ -1,0 +1,116 @@
+package dev.omatheusmesmo.qlawkus.store.pg;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
+import dev.omatheusmesmo.qlawkus.store.FactStore;
+import dev.omatheusmesmo.qlawkus.store.markdown.MarkdownFactFiles;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hybrid {@link FactStore}, active when {@code qlawkus.cognition.backend=hybrid}. Facts are written
+ * to {@code .md} files (the editable, git-versionable source of truth) and mirrored into pgvector;
+ * retrieval runs against pgvector so it scales and persists. Selected at build time via
+ * {@link IfBuildProperty}.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "hybrid")
+public class HybridFactStore implements FactStore {
+
+  @Inject
+  AgentConfig config;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @Inject
+  EmbeddingStore<TextSegment> embeddingStore;
+
+  @Inject
+  EmbeddingRepository embeddingRepository;
+
+  private MarkdownFactFiles files;
+
+  @PostConstruct
+  void init() {
+    files = new MarkdownFactFiles(Path.of(config.facts().root()));
+  }
+
+  @Override
+  public void store(String content, Map<String, Object> metadata) {
+    String id = EmbeddingRepository.md5(content);
+    if (embeddingRepository.existsByContentHash(id)) {
+      Log.debugf("Fact already exists, skipping: %s", id);
+      return;
+    }
+    files.write(id, content, stringify(metadata));
+    Metadata segmentMetadata = new Metadata();
+    metadata.forEach((key, value) -> segmentMetadata.put(key, value == null ? "" : value.toString()));
+    Embedding embedding = embeddingModel.embed(content).content();
+    embeddingStore.add(embedding, TextSegment.from(content, segmentMetadata));
+  }
+
+  @Override
+  public List<String> search(String query, int maxResults, double minScore) {
+    return texts(EmbeddingSearchRequest.builder()
+        .queryEmbedding(embeddingModel.embed(query).content())
+        .maxResults(maxResults)
+        .minScore(minScore)
+        .build());
+  }
+
+  @Override
+  public List<String> searchBySource(String query, String source, int maxResults, double minScore) {
+    return texts(EmbeddingSearchRequest.builder()
+        .queryEmbedding(embeddingModel.embed(query).content())
+        .maxResults(maxResults)
+        .minScore(minScore)
+        .filter(metadataKey("source").isEqualTo(source))
+        .build());
+  }
+
+  @Override
+  public List<String> listSources() {
+    return embeddingRepository.listSources();
+  }
+
+  @Override
+  public long purgeBySource(String source) {
+    files.loadAll().stream()
+        .filter(fact -> source.equals(fact.metadata().get("source")))
+        .forEach(fact -> files.delete(fact.id()));
+    return embeddingRepository.deleteBySource(source);
+  }
+
+  @Override
+  public long purgeAll() {
+    files.loadAll().forEach(fact -> files.delete(fact.id()));
+    return embeddingRepository.deleteAll();
+  }
+
+  private List<String> texts(EmbeddingSearchRequest request) {
+    EmbeddingSearchResult<TextSegment> result = embeddingStore.search(request);
+    return result.matches().stream().map(EmbeddingMatch::embedded).map(TextSegment::text).toList();
+  }
+
+  private static Map<String, String> stringify(Map<String, Object> metadata) {
+    Map<String, String> out = new LinkedHashMap<>();
+    metadata.forEach((key, value) -> out.put(key, value == null ? "" : value.toString()));
+    return out;
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/PgFactStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/PgFactStore.java
@@ -10,13 +10,20 @@ import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import dev.omatheusmesmo.qlawkus.store.FactStore;
+import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Postgres/pgvector-backed {@link FactStore}, active when {@code qlawkus.cognition.backend=pgvector}
+ * (the default). Selected at build time via {@link IfBuildProperty}, so other backends do not wire
+ * it at all.
+ */
 @ApplicationScoped
+@IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "pgvector", enableIfMissing = true)
 public class PgFactStore implements FactStore {
 
   @Inject

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -7,6 +7,7 @@
 .Architecture
 
 * xref:architecture.adoc[Architecture Overview]
+* xref:memory.adoc[Memory]
 * xref:skills.adoc[Skills]
 
 [.list-top-item]

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -81,7 +81,7 @@ See xref:memory.adoc[Memory] for the full treatment of this approach.
 <div class="mermaid">
 graph LR
     subgraph Write["Write paths"]
-        RT[RememberFactTool] --> FS[pgvector Fact Store]
+        RT[RememberFactTool] --> FS["Fact Store (markdown / pgvector / hybrid)"]
         SE[SemanticExtractor] --> FS
         EC[EpisodicConsolidator] --> FS
         TA[TranscriptArchive] --> TS[Transcript Store]
@@ -102,7 +102,7 @@ graph LR
 
 * *Persona* - the agent's own `Soul` (mood, focus, identity), rendered into the system prompt.
 * *Owner profile* - a `UserProfile` (the single person served) injected on every turn. Maintained by the `updateUserProfile` tool and refreshed nightly by the curation job.
-* *Facts* - long-term facts in pgvector, each tagged with a source (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`).
+* *Facts* - long-term facts, each tagged with a source (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`). The store backend is selectable via `qlawkus.cognition.backend`: `pgvector` (default), `markdown` (files plus an in-process embedding index, no database), or `hybrid` (files mirrored into pgvector). All three retrieve query-relevant top-K through the same RAG path.
 * *Active memory* - before each reply, relevant facts are retrieved and injected (transcripts excluded to keep it clean).
 * *Transcripts (session search)* - every message is archived and semantically searchable via the `searchTranscripts` tool, distinct from curated facts.
 * *Episodic journals* - a nightly job summarizes each day; summaries are embedded and surfaced by active memory.

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -70,7 +70,12 @@ sequenceDiagram
 
 == Memory
 
-The defining idea: *memory is injected into the prompt, not searched*. The agent does not have to decide to look things up.
+The defining idea is two deliberate choices that set Qlawkus apart from agents that paste their whole memory into the system prompt:
+
+* *Injected, not tool-called.* Relevant memory is retrieved and added automatically before every reply, so recall never depends on the model choosing to call a search tool.
+* *Retrieved, not dumped.* Active memory uses Retrieval-Augmented Generation (RAG): only the facts relevant to the current turn are injected (query-relevant top-K), never the entire store. The prompt stays small and the per-turn cost stays roughly constant as memory grows.
+
+See xref:memory.adoc[Memory] for the full treatment of this approach.
 
 ++++
 <div class="mermaid">

--- a/docs/modules/ROOT/pages/includes/qlawkus-client_qlawkus.agent.adoc
+++ b/docs/modules/ROOT/pages/includes/qlawkus-client_qlawkus.agent.adoc
@@ -259,5 +259,26 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a| [[qlawkus-client_qlawkus-agent-facts-root]] [.property-path]##link:#qlawkus-client_qlawkus-agent-facts-root[`+++qlawkus.agent.facts.root+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.facts.root+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Directory holding the markdown fact files and the sibling embedding cache (`.embeddings.json`). Defaults to a qlawkus-owned folder, keeping facts editable and git-versionable.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_FACTS_ROOT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_FACTS_ROOT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++${user.home}/.qlawkus/facts+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/memory.adoc
+++ b/docs/modules/ROOT/pages/memory.adoc
@@ -54,4 +54,19 @@ The agent maintains its own memory so it does not rot:
 * `DELETE /api/admin/memory` - purge (all, or by source).
 * `POST /api/admin/memory/review` and `POST /api/admin/memory/curate` - trigger the curation jobs manually.
 
+== Storage backends
+
+The fact store backend is selected at build time with `qlawkus.cognition.backend`:
+
+[cols="1,3",options="header"]
+|===
+|Backend |Behavior
+
+|`pgvector` (default) |Embeddings in Postgres. Scales and is shared across instances.
+|`markdown` |Facts are `.md` files (editable, git-versionable) plus an in-process embedding index cached to JSON. No database; single-node.
+|`hybrid` |`.md` files are the source of truth, mirrored into pgvector for retrieval.
+|===
+
+Whichever backend is active, retrieval is the same query-relevant top-K RAG path described above - the choice trades off persistence and scale, never the recall model.
+
 See xref:architecture.adoc#_memory[Architecture > Memory] for the write/read data-flow diagram, and the xref:config-reference.adoc[configuration reference] for every `qlawkus.agent.*` memory knob.

--- a/docs/modules/ROOT/pages/memory.adoc
+++ b/docs/modules/ROOT/pages/memory.adoc
@@ -1,0 +1,57 @@
+= Memory
+:page-title: Memory
+:page-description: Declarative memory the agent retrieves with RAG and injects automatically, never a prompt dump
+
+Memory is Qlawkus's *declarative* memory: *what the agent knows* about its owner and the world. It complements the *procedural* memory described in xref:skills.adoc[Skills] (*how* the agent does recurring things). Where skills are how-to procedures, memory is facts, history, and the owner's profile.
+
+== Injected, not searched - and retrieved, not dumped
+
+Most agents handle long-term memory in one of two weak ways: they make the model *call a search tool* (so recall depends on the model deciding to look), or they *paste the entire memory* into the system prompt every turn (which balloons the prompt and stops scaling). Qlawkus rejects both. Two deliberate choices define the approach:
+
+* *Injected, not tool-called.* Relevant memory is retrieved and added to the prompt automatically before every reply. Recall never depends on the model choosing to call a search tool - reactive recall is unreliable, and the most important memory is the kind the model does not know it should look for.
+* *Retrieved, not wholesale.* Active memory uses Retrieval-Augmented Generation (RAG): each turn, only the facts relevant to the current message are selected (query-relevant top-K) and injected. The full store is never dumped into the prompt, so the per-turn token cost stays roughly constant as memory grows.
+
+The result is recall that is both *reliable* (always runs) and *bounded* (only what is relevant), instead of trading one off against the other.
+
+== What is injected each turn
+
+[cols="1,3",options="header"]
+|===
+|Layer |What it is
+
+|*Persona* |The agent's own `Soul` (identity, mood, focus), rendered into the system prompt by `SoulEngine`. Framing, not retrieval.
+|*Owner profile* |A single `UserProfile` describing the person served, injected on every turn by `SoulEngine`. Stable framing maintained by the `updateUserProfile` tool and refreshed nightly.
+|*Active memory (facts)* |Query-relevant facts retrieved before each reply by the `ActiveMemoryAugmentor` (a RAG retrieval augmentor) and injected into the prompt. This is the RAG path described above.
+|===
+
+Persona and owner profile are *stable framing* and live in the system prompt. Facts are *retrieved knowledge* and flow through the RAG augmentor - the two are kept separate on purpose.
+
+== Where facts come from
+
+Facts are written from several sources, each tagged so producers and purges never drift:
+
+* `remember-tool` - the agent explicitly records something with the `rememberFact` tool.
+* `semantic-extractor` - facts are distilled passively from each completed turn, on every channel (REST, Discord, Telegram).
+* `episodic-consolidator` - a nightly job summarizes each day into a journal.
+* `transcript` - every message is archived for full-text recall; transcripts are excluded from active memory so curated facts stay clean, and are searched on demand with the `searchTranscripts` tool.
+
+== Background curation
+
+The agent maintains its own memory so it does not rot:
+
+[cols="2,1,3",options="header"]
+|===
+|Job |Schedule |What it does
+
+|Episodic consolidation |nightly |Summarizes the day into a journal that active memory can surface.
+|Memory review |nightly (`POST /api/admin/memory/review`) |Removes semantic near-duplicate facts.
+|Profile curation |nightly (`POST /api/admin/memory/curate`) |Folds facts into the owner profile, reconciling contradictions. Facts themselves are left untouched.
+|===
+
+== Administration
+
+* `GET /api/admin/memory` - summary of what is stored.
+* `DELETE /api/admin/memory` - purge (all, or by source).
+* `POST /api/admin/memory/review` and `POST /api/admin/memory/curate` - trigger the curation jobs manually.
+
+See xref:architecture.adoc#_memory[Architecture > Memory] for the write/read data-flow diagram, and the xref:config-reference.adoc[configuration reference] for every `qlawkus.agent.*` memory knob.

--- a/docs/modules/ROOT/pages/skills.adoc
+++ b/docs/modules/ROOT/pages/skills.adoc
@@ -10,7 +10,7 @@ See xref:architecture.adoc#_skills_procedural_memory[Architecture > Skills] for 
 
 == Anatomy of a skill
 
-A skill is a single `SKILL.md` file: YAML frontmatter with a `name` and `description`, followed by a Markdown body.
+A skill is a single `SKILL.md` file: YAML frontmatter with a `name` and `description`, followed by a Markdown body. The file follows the https://agentskills.io[agentskills.io] spec and is parsed by the upstream langchain4j skill loaders, so a `SKILL.md` written for Qlawkus is portable to any other agent that speaks the same format.
 
 [source,markdown]
 ----

--- a/integration-tests/cognition/src/test/java/dev/omatheusmesmo/qlawkus/it/cognition/MarkdownFactBackendTest.java
+++ b/integration-tests/cognition/src/test/java/dev/omatheusmesmo/qlawkus/it/cognition/MarkdownFactBackendTest.java
@@ -1,0 +1,62 @@
+package dev.omatheusmesmo.qlawkus.it.cognition;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.omatheusmesmo.qlawkus.store.markdown.MarkdownFactStore;
+import dev.omatheusmesmo.qlawkus.testing.QlawkusWireMockStubs;
+import io.quarkiverse.wiremock.devservice.ConnectWireMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration test for the markdown fact backend against the module's real {@link EmbeddingModel}
+ * bean (WireMock-backed in tests). The store is instantiated directly with a temp root (mirroring
+ * {@code HybridSkillStoreTest}), so no separate markdown-pinned module is needed: a fact is written
+ * as a {@code .md} file and then retrieved through the actual embedding pipeline. Stubs are
+ * registered per test so the suite passes in isolation, not only when another test seeds them first.
+ */
+@QuarkusTest
+@ConnectWireMock
+class MarkdownFactBackendTest {
+
+  WireMock wiremock;
+
+  @Inject
+  EmbeddingModel embeddingModel;
+
+  @TempDir
+  Path factsRoot;
+
+  @BeforeEach
+  void setupStubs() {
+    QlawkusWireMockStubs.registerOpenAiStubs(wiremock);
+  }
+
+  @Test
+  void storesFactAsFileAndRetrievesThroughEmbeddingPipeline() throws IOException {
+    MarkdownFactStore store = new MarkdownFactStore(factsRoot.toString(), embeddingModel);
+    store.load();
+
+    store.store("User prefers dark theme in IDE", Map.of("source", "semantic-extractor"));
+
+    try (Stream<Path> files = Files.list(factsRoot)) {
+      assertTrue(files.anyMatch(p -> p.getFileName().toString().endsWith(".md")),
+          "fact should be persisted as a .md file");
+    }
+
+    List<String> facts = store.search("IDE theme preference", 5, 0.0);
+    assertTrue(facts.stream().anyMatch(f -> f.toLowerCase().contains("dark theme")),
+        "stored fact should be retrievable through the embedding store");
+  }
+}

--- a/site/content/architecture.adoc
+++ b/site/content/architecture.adoc
@@ -81,7 +81,7 @@ See xref:memory.adoc[Memory] for the full treatment of this approach.
 <div class="mermaid">
 graph LR
     subgraph Write["Write paths"]
-        RT[RememberFactTool] --> FS[pgvector Fact Store]
+        RT[RememberFactTool] --> FS["Fact Store (markdown / pgvector / hybrid)"]
         SE[SemanticExtractor] --> FS
         EC[EpisodicConsolidator] --> FS
         TA[TranscriptArchive] --> TS[Transcript Store]
@@ -102,7 +102,7 @@ graph LR
 
 * *Persona* - the agent's own `Soul` (mood, focus, identity), rendered into the system prompt.
 * *Owner profile* - a `UserProfile` (the single person served) injected on every turn. Maintained by the `updateUserProfile` tool and refreshed nightly by the curation job.
-* *Facts* - long-term facts in pgvector, each tagged with a source (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`).
+* *Facts* - long-term facts, each tagged with a source (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`). The store backend is selectable via `qlawkus.cognition.backend`: `pgvector` (default), `markdown` (files plus an in-process embedding index, no database), or `hybrid` (files mirrored into pgvector). All three retrieve query-relevant top-K through the same RAG path.
 * *Active memory* - before each reply, relevant facts are retrieved and injected (transcripts excluded to keep it clean).
 * *Transcripts (session search)* - every message is archived and semantically searchable via the `searchTranscripts` tool, distinct from curated facts.
 * *Episodic journals* - a nightly job summarizes each day; summaries are embedded and surfaced by active memory.

--- a/site/content/architecture.adoc
+++ b/site/content/architecture.adoc
@@ -70,7 +70,12 @@ sequenceDiagram
 
 == Memory
 
-The defining idea: *memory is injected into the prompt, not searched*. The agent does not have to decide to look things up.
+The defining idea is two deliberate choices that set Qlawkus apart from agents that paste their whole memory into the system prompt:
+
+* *Injected, not tool-called.* Relevant memory is retrieved and added automatically before every reply, so recall never depends on the model choosing to call a search tool.
+* *Retrieved, not dumped.* Active memory uses Retrieval-Augmented Generation (RAG): only the facts relevant to the current turn are injected (query-relevant top-K), never the entire store. The prompt stays small and the per-turn cost stays roughly constant as memory grows.
+
+See xref:memory.adoc[Memory] for the full treatment of this approach.
 
 ++++
 <div class="mermaid">

--- a/site/content/includes/qlawkus-client_qlawkus.agent.adoc
+++ b/site/content/includes/qlawkus-client_qlawkus.agent.adoc
@@ -259,5 +259,26 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a| [[qlawkus-client_qlawkus-agent-facts-root]] [.property-path]##link:#qlawkus-client_qlawkus-agent-facts-root[`+++qlawkus.agent.facts.root+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.facts.root+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Directory holding the markdown fact files and the sibling embedding cache (`.embeddings.json`). Defaults to a qlawkus-owned folder, keeping facts editable and git-versionable.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_FACTS_ROOT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_FACTS_ROOT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++${user.home}/.qlawkus/facts+++`
+
 |===
 

--- a/site/content/memory.adoc
+++ b/site/content/memory.adoc
@@ -54,4 +54,19 @@ The agent maintains its own memory so it does not rot:
 * `DELETE /api/admin/memory` - purge (all, or by source).
 * `POST /api/admin/memory/review` and `POST /api/admin/memory/curate` - trigger the curation jobs manually.
 
+== Storage backends
+
+The fact store backend is selected at build time with `qlawkus.cognition.backend`:
+
+[cols="1,3",options="header"]
+|===
+|Backend |Behavior
+
+|`pgvector` (default) |Embeddings in Postgres. Scales and is shared across instances.
+|`markdown` |Facts are `.md` files (editable, git-versionable) plus an in-process embedding index cached to JSON. No database; single-node.
+|`hybrid` |`.md` files are the source of truth, mirrored into pgvector for retrieval.
+|===
+
+Whichever backend is active, retrieval is the same query-relevant top-K RAG path described above - the choice trades off persistence and scale, never the recall model.
+
 See xref:architecture.adoc#_memory[Architecture > Memory] for the write/read data-flow diagram, and the xref:config-reference.adoc[configuration reference] for every `qlawkus.agent.*` memory knob.

--- a/site/content/memory.adoc
+++ b/site/content/memory.adoc
@@ -1,0 +1,57 @@
+= Memory
+:page-title: Memory
+:page-description: Declarative memory the agent retrieves with RAG and injects automatically, never a prompt dump
+
+Memory is Qlawkus's *declarative* memory: *what the agent knows* about its owner and the world. It complements the *procedural* memory described in xref:skills.adoc[Skills] (*how* the agent does recurring things). Where skills are how-to procedures, memory is facts, history, and the owner's profile.
+
+== Injected, not searched - and retrieved, not dumped
+
+Most agents handle long-term memory in one of two weak ways: they make the model *call a search tool* (so recall depends on the model deciding to look), or they *paste the entire memory* into the system prompt every turn (which balloons the prompt and stops scaling). Qlawkus rejects both. Two deliberate choices define the approach:
+
+* *Injected, not tool-called.* Relevant memory is retrieved and added to the prompt automatically before every reply. Recall never depends on the model choosing to call a search tool - reactive recall is unreliable, and the most important memory is the kind the model does not know it should look for.
+* *Retrieved, not wholesale.* Active memory uses Retrieval-Augmented Generation (RAG): each turn, only the facts relevant to the current message are selected (query-relevant top-K) and injected. The full store is never dumped into the prompt, so the per-turn token cost stays roughly constant as memory grows.
+
+The result is recall that is both *reliable* (always runs) and *bounded* (only what is relevant), instead of trading one off against the other.
+
+== What is injected each turn
+
+[cols="1,3",options="header"]
+|===
+|Layer |What it is
+
+|*Persona* |The agent's own `Soul` (identity, mood, focus), rendered into the system prompt by `SoulEngine`. Framing, not retrieval.
+|*Owner profile* |A single `UserProfile` describing the person served, injected on every turn by `SoulEngine`. Stable framing maintained by the `updateUserProfile` tool and refreshed nightly.
+|*Active memory (facts)* |Query-relevant facts retrieved before each reply by the `ActiveMemoryAugmentor` (a RAG retrieval augmentor) and injected into the prompt. This is the RAG path described above.
+|===
+
+Persona and owner profile are *stable framing* and live in the system prompt. Facts are *retrieved knowledge* and flow through the RAG augmentor - the two are kept separate on purpose.
+
+== Where facts come from
+
+Facts are written from several sources, each tagged so producers and purges never drift:
+
+* `remember-tool` - the agent explicitly records something with the `rememberFact` tool.
+* `semantic-extractor` - facts are distilled passively from each completed turn, on every channel (REST, Discord, Telegram).
+* `episodic-consolidator` - a nightly job summarizes each day into a journal.
+* `transcript` - every message is archived for full-text recall; transcripts are excluded from active memory so curated facts stay clean, and are searched on demand with the `searchTranscripts` tool.
+
+== Background curation
+
+The agent maintains its own memory so it does not rot:
+
+[cols="2,1,3",options="header"]
+|===
+|Job |Schedule |What it does
+
+|Episodic consolidation |nightly |Summarizes the day into a journal that active memory can surface.
+|Memory review |nightly (`POST /api/admin/memory/review`) |Removes semantic near-duplicate facts.
+|Profile curation |nightly (`POST /api/admin/memory/curate`) |Folds facts into the owner profile, reconciling contradictions. Facts themselves are left untouched.
+|===
+
+== Administration
+
+* `GET /api/admin/memory` - summary of what is stored.
+* `DELETE /api/admin/memory` - purge (all, or by source).
+* `POST /api/admin/memory/review` and `POST /api/admin/memory/curate` - trigger the curation jobs manually.
+
+See xref:architecture.adoc#_memory[Architecture > Memory] for the write/read data-flow diagram, and the xref:config-reference.adoc[configuration reference] for every `qlawkus.agent.*` memory knob.

--- a/site/content/skills.adoc
+++ b/site/content/skills.adoc
@@ -10,7 +10,7 @@ See xref:architecture.adoc#_skills_procedural_memory[Architecture > Skills] for 
 
 == Anatomy of a skill
 
-A skill is a single `SKILL.md` file: YAML frontmatter with a `name` and `description`, followed by a Markdown body.
+A skill is a single `SKILL.md` file: YAML frontmatter with a `name` and `description`, followed by a Markdown body. The file follows the https://agentskills.io[agentskills.io] spec and is parsed by the upstream langchain4j skill loaders, so a `SKILL.md` written for Qlawkus is portable to any other agent that speaks the same format.
 
 [source,markdown]
 ----

--- a/site/templates/layouts/default.html
+++ b/site/templates/layouts/default.html
@@ -35,6 +35,7 @@
       <nav class="nav" aria-label="Documentation">
         <a href="{site.url.resolve('quickstart')}"{#if page.title == 'Quick Start'} aria-current="page"{/if}>Quick Start</a>
         <a href="{site.url.resolve('architecture')}"{#if page.title == 'Architecture'} aria-current="page"{/if}>Architecture</a>
+        <a href="{site.url.resolve('memory')}"{#if page.title == 'Memory'} aria-current="page"{/if}>Memory</a>
         <a href="{site.url.resolve('skills')}"{#if page.title == 'Skills'} aria-current="page"{/if}>Skills</a>
         <a href="{site.url.resolve('google-workspace')}"{#if page.title == 'Google Workspace Setup'} aria-current="page"{/if}>Google Workspace</a>
         <a href="{site.url.resolve('messaging')}"{#if page.title == 'Messaging Setup'} aria-current="page"{/if}>Messaging</a>


### PR DESCRIPTION
## Summary

Makes the `FactStore` backend pluggable, selected at **build time** via `qlawkus.cognition.backend`:

- **`markdown`** - facts are `.md` files (source of truth) under `qlawkus.agent.facts.root` + an in-process `InMemoryEmbeddingStore` (incremental JSON embedding cache keyed by content hash). No database. Recall flows through the **same** `EmbeddingStoreContentRetriever` as pgvector, so it stays on the RAG seam (retrieved, not dumped).
- **`pgvector`** (default) - existing `PgFactStore`, now gated with `@IfBuildProperty(..., enableIfMissing=true)`.
- **`hybrid`** - `.md` files as the editable, git-versionable source of truth + a pgvector mirror that retrieval runs against.

`ActiveMemoryAugmentor` is backend-aware (picks the `EmbeddingStore` by the presence of the `MarkdownFactStore` bean) and now frames retrieved facts with provenance: a custom `DefaultContentInjector` presents them as recalled memories in the user message, each item tagged with its `source` (no-op on empty retrieval).

## Design note

The markdown backend deliberately uses top-K retrieval through the existing RAG augmentor rather than wholesale-injecting every fact into the system prompt (the approach some competitors take for lack of a RAG framework). Facts are **retrieved, not dumped**; **injected, not tool-called**.

## Changes

- `MarkdownFactStore` + `MarkdownFactFiles` (file IO, hash-keyed `.embeddings.json` cache, re-embeds only changed facts on reload)
- `HybridFactStore` (files + pgvector mirror), constructor-injected for testability
- `@IfBuildProperty` gating across the three backends; `AgentConfig.Facts.root()`
- `ActiveMemoryAugmentor`: backend-aware store resolution + provenance `ContentInjector`
- Docs: dedicated Memory page, RAG-approach framing in architecture, regenerated config reference, pinned quarkus-langchain4j/langchain4j version namespaces
- Refactor: adopt the upstream langchain4j skill parser

## Testing

- `client/deployment` suite green: **345** tests, 0 failures, 0 errors (2 skipped)
- `MarkdownFactStoreTest` (6): store / search / dedup / source filter / purge / cache reuse on reload
- `HybridFactStoreTest` (4): file + mirror write, dedup, purgeAll, purgeBySource (in-memory mirror + fake repo, no Postgres)
- `MarkdownFactBackendTest` (cognition IT): markdown backend through the real WireMock-backed embedding pipeline; registers its own stubs so it passes in isolation

Native verification deferred to CI.