### PR TITLE
Pluggable episodic journal backends: markdown, pgvector, and hybrid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,14 @@ Three layers, all injected each turn via `SoulEngine` (the agent's `systemMessag
 
 - **Persona** - `Soul` (singleton entity) rendered into the system message by `SoulEngine`.
 - **Owner** - `UserProfile` (singleton; the single user this agent serves) injected every turn by `SoulEngine`. Maintained by `UpdateUserProfileTool`, refreshed by `MemoryCurationJob`.
-- **Facts** - `FactStore` / `PgFactStore` (pgvector). Every embedding is tagged with a `MemorySource` (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`) - the enum exists so producers and purges never drift.
+- **Facts** - `FactStore` SPI, backend selected at **build time** via `@IfBuildProperty` on `qlawkus.cognition.backend` (`markdown` | `pgvector` | `hybrid`): `store.pg.PgFactStore` (pgvector, default), `store.markdown.MarkdownFactStore` (`.md` files + in-process `InMemoryEmbeddingStore` with a JSON embedding cache, no DB; shared file logic in `MarkdownFactFiles`), `store.pg.HybridFactStore` (files source-of-truth + pg mirror). Root: `qlawkus.agent.facts.root` (default `~/.qlawkus/facts`). Every embedding is tagged with a `MemorySource` (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`) - the enum exists so producers and purges never drift.
 
 Stores & retrieval:
 
 - **Active Memory** - `ActiveMemoryAugmentor` is the AiService `retrievalAugmentor`; it runs an `EmbeddingStoreContentRetriever` before each reply and injects query-relevant facts. It filters OUT `source=transcript` so curated facts stay clean.
 - **Working memory** - `PgWorkingMemoryStore` (a langchain4j `ChatMemoryStore`), windowed to 40 messages. `updateMessages` is append-only (preserves `createdAt`; never reset it) and fires `MessagesAppendedEvent` for every new message on any channel.
 - **Transcripts (session_search)** - `TranscriptArchiveObserver` embeds each message as `source=transcript`; `SearchTranscriptsTool` searches only those.
-- **Episodic** - `EpisodicConsolidatorJob` (nightly) summarizes each day into journals (also embedded).
+- **Episodic** - `EpisodicConsolidatorJob` (nightly) summarizes each day into journals (also embedded through the `FactStore` as `source=episodic-consolidator`). The journal record is an `EpisodicStore` SPI, backend selected at build time by the same `qlawkus.cognition.backend`: `store.pg.PgEpisodicStore` (the `Journal` table, default), `store.markdown.MarkdownEpisodicStore` (dated `<date>.md` files, one per day, no DB; file logic in `MarkdownEpisodicFiles`), `store.pg.HybridEpisodicStore` (files source-of-truth + pg mirror). Pg/hybrid share Panache access via `JournalRepository`. Root: `qlawkus.agent.episodic.root` (default `~/.qlawkus/journals`).
 
 Scheduled background jobs, each with a manual `POST /api/admin/memory/*` trigger:
 
@@ -61,7 +61,7 @@ Skills are the agent's **procedural** memory (how to do a recurring task), compl
 - **Admin REST**: `GET/DELETE /api/admin/skills`, `GET /api/admin/skills/{name}`, `POST /api/admin/skills/{curate,lifecycle}`, `POST /api/admin/skills/{name}/pin`.
 - **Bundled skills (build-time)**: extensions/apps ship read-only skills as classpath resources under `META-INF/qlawkus-skills/<name>/SKILL.md`. `ClientProcessor.bundledSkills` (a `@BuildStep` + `SkillsRecorder`) scans and parses them (via the same `FileSystemSkillLoader`) at **augmentation** and bakes them into the synthetic `BundledSkills` bean - no runtime classpath scanning. Stores merge bundled (read-only) with owned skills; owned wins on a name clash.
 
-Config knobs: `qlawkus.cognition.backend`, `qlawkus.skills.*`. The broader plan (making facts/episodic/working memory pluggable too, plus a `SkillHub` capability backed by jskills/skills.sh) lives outside the repo in the owner's notes.
+Config knobs: `qlawkus.cognition.backend`, `qlawkus.skills.*`. Facts and episodic journals are already pluggable on this same switch; the broader plan (making working memory pluggable too and fully gating the datasource for a markdown-only distribution, plus a `SkillHub` capability backed by jskills/skills.sh) lives outside the repo in the owner's notes.
 
 ## Testing
 

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownEpisodicStoreTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownEpisodicStoreTest.java
@@ -1,0 +1,102 @@
+package dev.omatheusmesmo.qlawkus.store.markdown;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit test for the markdown episodic backend: journals are dated {@code <date>.md} files, one per
+ * day, with no database. Verifies write/read/dedup-by-date/count/purge and that a re-consolidation of
+ * the same day is a no-op.
+ */
+class MarkdownEpisodicStoreTest {
+
+  @TempDir
+  Path tempDir;
+
+  private MarkdownEpisodicStore store() {
+    return new MarkdownEpisodicStore(tempDir.toString());
+  }
+
+  private long markdownFileCount() throws IOException {
+    try (Stream<Path> files = Files.list(tempDir)) {
+      return files.filter(p -> p.getFileName().toString().endsWith(".md")).count();
+    }
+  }
+
+  @Test
+  void storesJournalAsDatedFileAndReadsItBack() throws IOException {
+    MarkdownEpisodicStore store = store();
+    LocalDate date = LocalDate.of(2026, 6, 19);
+
+    store.storeEpisode(date, "Discussed pluggable cognition backends.", 12);
+
+    assertEquals(1, markdownFileCount());
+    assertTrue(Files.isRegularFile(tempDir.resolve("2026-06-19.md")));
+    List<JournalSummary> journals = store.listJournals();
+    assertEquals(1, journals.size());
+    JournalSummary journal = journals.get(0);
+    assertEquals(date, journal.date());
+    assertEquals("Discussed pluggable cognition backends.", journal.summary());
+    assertEquals(12, journal.messageCount());
+  }
+
+  @Test
+  void existsForDateReflectsStoredJournals() {
+    MarkdownEpisodicStore store = store();
+    LocalDate date = LocalDate.of(2026, 6, 19);
+
+    assertFalse(store.existsForDate(date));
+    store.storeEpisode(date, "summary", 1);
+    assertTrue(store.existsForDate(date));
+  }
+
+  @Test
+  void secondConsolidationOfSameDayIsNoOp() throws IOException {
+    MarkdownEpisodicStore store = store();
+    LocalDate date = LocalDate.of(2026, 6, 19);
+
+    store.storeEpisode(date, "first", 1);
+    store.storeEpisode(date, "second wins nothing", 99);
+
+    assertEquals(1, markdownFileCount());
+    assertEquals("first", store.listJournals().get(0).summary());
+  }
+
+  @Test
+  void listJournalsReturnsAllDaysSortedByDate() {
+    MarkdownEpisodicStore store = store();
+    store.storeEpisode(LocalDate.of(2026, 6, 20), "tuesday", 2);
+    store.storeEpisode(LocalDate.of(2026, 6, 18), "sunday", 4);
+    store.storeEpisode(LocalDate.of(2026, 6, 19), "monday", 3);
+
+    List<LocalDate> dates = store.listJournals().stream().map(JournalSummary::date).toList();
+
+    assertEquals(List.of(
+        LocalDate.of(2026, 6, 18), LocalDate.of(2026, 6, 19), LocalDate.of(2026, 6, 20)), dates);
+    assertEquals(3, store.count());
+  }
+
+  @Test
+  void purgeAllRemovesEveryJournalFile() throws IOException {
+    MarkdownEpisodicStore store = store();
+    store.storeEpisode(LocalDate.of(2026, 6, 18), "one", 1);
+    store.storeEpisode(LocalDate.of(2026, 6, 19), "two", 1);
+
+    long purged = store.purgeAll();
+
+    assertEquals(2, purged);
+    assertEquals(0, markdownFileCount());
+    assertEquals(0, store.count());
+  }
+}

--- a/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/pg/HybridEpisodicStoreTest.java
+++ b/client/deployment/src/test/java/dev/omatheusmesmo/qlawkus/store/pg/HybridEpisodicStoreTest.java
@@ -1,0 +1,130 @@
+package dev.omatheusmesmo.qlawkus.store.pg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit test for the hybrid episodic backend: every write must land in the dated {@code .md} files
+ * (the source of truth) AND be mirrored into the {@code Journal} table, while reads go through the
+ * table. Uses a fake {@link JournalRepository} (in-memory, no database), so the file/mirror logic is
+ * exercised without Postgres.
+ */
+class HybridEpisodicStoreTest {
+
+  @TempDir
+  Path tempDir;
+
+  private HybridEpisodicStore store(FakeJournals journals) {
+    return new HybridEpisodicStore(tempDir.toString(), journals);
+  }
+
+  private long markdownFileCount() throws IOException {
+    try (Stream<Path> files = Files.list(tempDir)) {
+      return files.filter(p -> p.getFileName().toString().endsWith(".md")).count();
+    }
+  }
+
+  @Test
+  void storeWritesFileAndMirrorsToTable() throws IOException {
+    FakeJournals journals = new FakeJournals();
+    HybridEpisodicStore store = store(journals);
+    LocalDate date = LocalDate.of(2026, 6, 19);
+
+    store.storeEpisode(date, "Discussed episodic backends.", 8);
+
+    assertEquals(1, markdownFileCount());
+    assertTrue(Files.isRegularFile(tempDir.resolve("2026-06-19.md")));
+    assertEquals(1, journals.count());
+    assertEquals(date, journals.listJournals().get(0).date());
+  }
+
+  @Test
+  void storeSkipsWhenDayAlreadyMirrored() throws IOException {
+    FakeJournals journals = new FakeJournals();
+    journals.store(LocalDate.of(2026, 6, 19), "already there", 1);
+    HybridEpisodicStore store = store(journals);
+
+    store.storeEpisode(LocalDate.of(2026, 6, 19), "should be skipped", 2);
+
+    assertEquals(0, markdownFileCount());
+    assertEquals(1, journals.count());
+  }
+
+  @Test
+  void readsGoThroughTableAndCarryDatabaseIds() {
+    FakeJournals journals = new FakeJournals();
+    HybridEpisodicStore store = store(journals);
+
+    store.storeEpisode(LocalDate.of(2026, 6, 19), "monday", 3);
+
+    JournalSummary summary = store.listJournals().get(0);
+    assertEquals(1L, summary.id());
+    assertEquals(1, store.count());
+    assertTrue(store.existsForDate(LocalDate.of(2026, 6, 19)));
+    assertFalse(store.existsForDate(LocalDate.of(2026, 6, 20)));
+  }
+
+  @Test
+  void purgeAllDeletesFilesAndDelegatesToTable() throws IOException {
+    FakeJournals journals = new FakeJournals();
+    HybridEpisodicStore store = store(journals);
+    store.storeEpisode(LocalDate.of(2026, 6, 18), "one", 1);
+    store.storeEpisode(LocalDate.of(2026, 6, 19), "two", 1);
+
+    long purged = store.purgeAll();
+
+    assertEquals(2, purged);
+    assertEquals(0, markdownFileCount());
+    assertEquals(0, journals.count());
+  }
+
+  /** Fake repository: in-memory journals keyed by date, no EntityManager or Panache. */
+  private static final class FakeJournals extends JournalRepository {
+
+    private final List<JournalSummary> rows = new ArrayList<>();
+    private long sequence = 0;
+
+    @Override
+    public boolean existsForDate(LocalDate date) {
+      return rows.stream().anyMatch(j -> j.date().equals(date));
+    }
+
+    @Override
+    public void store(LocalDate date, String summary, int messageCount) {
+      if (existsForDate(date)) {
+        return;
+      }
+      rows.add(new JournalSummary(++sequence, date, summary, messageCount, Instant.now()));
+    }
+
+    @Override
+    public List<JournalSummary> listJournals() {
+      return List.copyOf(rows);
+    }
+
+    @Override
+    public long count() {
+      return rows.size();
+    }
+
+    @Override
+    public long deleteAll() {
+      long n = rows.size();
+      rows.clear();
+      return n;
+    }
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/AgentConfig.java
@@ -59,6 +59,12 @@ public interface AgentConfig {
      */
     Facts facts();
 
+    /**
+     * Markdown episodic backend: where the agent's dated journal {@code .md} files live. Used only
+     * when {@code qlawkus.cognition.backend=markdown} or {@code hybrid}.
+     */
+    Episodic episodic();
+
     interface Facts {
 
         /**
@@ -67,6 +73,16 @@ public interface AgentConfig {
          * and git-versionable.
          */
         @WithDefault("${user.home}/.qlawkus/facts")
+        String root();
+    }
+
+    interface Episodic {
+
+        /**
+         * Directory holding the dated journal markdown files (one per day, {@code <date>.md}).
+         * Defaults to a qlawkus-owned folder, keeping journals editable and git-versionable.
+         */
+        @WithDefault("${user.home}/.qlawkus/journals")
         String root();
     }
 

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownEpisodicFiles.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownEpisodicFiles.java
@@ -1,0 +1,156 @@
+package dev.omatheusmesmo.qlawkus.store.markdown;
+
+import io.quarkus.logging.Log;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * File operations for the markdown episodic backend. Each journal is a {@code <root>/<date>.md} file
+ * with a small YAML frontmatter ({@code date}, {@code messageCount}, {@code createdAt}) followed by
+ * the day's summary as the body. The date is the filename, so there is naturally one journal per day
+ * and a second consolidation of the same day is a no-op. Unlike the fact backend there is no
+ * embedding cache here: the journal text is embedded through the {@code FactStore}
+ * ({@code source=episodic-consolidator}), which owns its own index.
+ */
+public class MarkdownEpisodicFiles {
+
+  private static final String DELIMITER = "---";
+
+  private final Path root;
+
+  public MarkdownEpisodicFiles(Path root) {
+    this.root = root;
+  }
+
+  public record JournalRecord(LocalDate date, String summary, int messageCount, Instant createdAt) {
+  }
+
+  public boolean exists(LocalDate date) {
+    return Files.isRegularFile(root.resolve(date + ".md"));
+  }
+
+  public void write(LocalDate date, String summary, int messageCount) {
+    try {
+      Files.createDirectories(root);
+      Files.writeString(root.resolve(date + ".md"), render(date, summary, messageCount),
+          StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to write journal " + date, e);
+    }
+  }
+
+  public List<JournalRecord> loadAll() {
+    if (!Files.isDirectory(root)) {
+      return List.of();
+    }
+    List<JournalRecord> journals = new ArrayList<>();
+    try (Stream<Path> files = Files.list(root)) {
+      files.filter(p -> p.getFileName().toString().endsWith(".md"))
+          .forEach(p -> readJournal(p, journals));
+    } catch (IOException e) {
+      Log.warnf(e, "Failed to list journal root %s", root);
+    }
+    journals.sort((a, b) -> a.date().compareTo(b.date()));
+    return journals;
+  }
+
+  public long count() {
+    return loadAll().size();
+  }
+
+  public long deleteAll() {
+    List<JournalRecord> all = loadAll();
+    for (JournalRecord journal : all) {
+      try {
+        Files.deleteIfExists(root.resolve(journal.date() + ".md"));
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to delete journal " + journal.date(), e);
+      }
+    }
+    return all.size();
+  }
+
+  private void readJournal(Path file, List<JournalRecord> out) {
+    try {
+      Parsed parsed = parse(Files.readString(file, StandardCharsets.UTF_8));
+      String name = file.getFileName().toString().replaceFirst("\\.md$", "");
+      LocalDate date = parseDate(parsed.frontmatter().get("date"), name);
+      int messageCount = parseInt(parsed.frontmatter().get("messageCount"));
+      Instant createdAt = parseInstant(parsed.frontmatter().get("createdAt"));
+      out.add(new JournalRecord(date, parsed.body(), messageCount, createdAt));
+    } catch (IOException e) {
+      Log.warnf(e, "Failed to read journal %s", file);
+    }
+  }
+
+  private String render(LocalDate date, String summary, int messageCount) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(DELIMITER).append('\n');
+    Map<String, String> frontmatter = new LinkedHashMap<>();
+    frontmatter.put("date", date.toString());
+    frontmatter.put("messageCount", Integer.toString(messageCount));
+    frontmatter.put("createdAt", Instant.now().toString());
+    frontmatter.forEach((key, value) -> sb.append(key).append(": ").append(value).append('\n'));
+    sb.append(DELIMITER).append("\n\n");
+    sb.append(summary == null ? "" : summary.strip()).append('\n');
+    return sb.toString();
+  }
+
+  private record Parsed(Map<String, String> frontmatter, String body) {
+  }
+
+  private Parsed parse(String raw) {
+    Map<String, String> frontmatter = new LinkedHashMap<>();
+    String text = raw.strip();
+    if (!text.startsWith(DELIMITER)) {
+      return new Parsed(frontmatter, text);
+    }
+    int end = text.indexOf("\n" + DELIMITER, DELIMITER.length());
+    if (end < 0) {
+      return new Parsed(frontmatter, text);
+    }
+    String header = text.substring(DELIMITER.length(), end).strip();
+    String body = text.substring(end + ("\n" + DELIMITER).length()).strip();
+    for (String line : header.split("\n")) {
+      int colon = line.indexOf(':');
+      if (colon > 0) {
+        frontmatter.put(line.substring(0, colon).strip(), line.substring(colon + 1).strip());
+      }
+    }
+    return new Parsed(frontmatter, body);
+  }
+
+  private static LocalDate parseDate(String value, String fallback) {
+    try {
+      return LocalDate.parse(value == null || value.isBlank() ? fallback : value);
+    } catch (RuntimeException e) {
+      return LocalDate.parse(fallback);
+    }
+  }
+
+  private static int parseInt(String value) {
+    try {
+      return value == null || value.isBlank() ? 0 : Integer.parseInt(value.strip());
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  private static Instant parseInstant(String value) {
+    try {
+      return value == null || value.isBlank() ? null : Instant.parse(value.strip());
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownEpisodicStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/markdown/MarkdownEpisodicStore.java
@@ -1,0 +1,66 @@
+package dev.omatheusmesmo.qlawkus.store.markdown;
+
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import dev.omatheusmesmo.qlawkus.store.EpisodicStore;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Markdown-backed {@link EpisodicStore}, active when {@code qlawkus.cognition.backend=markdown}.
+ * Each daily journal is a {@code <root>/<date>.md} file under {@code qlawkus.agent.episodic.root};
+ * the date is the filename, so there is one journal per day and a repeated consolidation is a no-op.
+ * No database is used. The journal text is still embedded for recall through the markdown
+ * {@code FactStore} ({@code source=episodic-consolidator}), which owns its own index.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "markdown")
+public class MarkdownEpisodicStore implements EpisodicStore {
+
+  private final MarkdownEpisodicFiles files;
+
+  @Inject
+  public MarkdownEpisodicStore(AgentConfig config) {
+    this(config.episodic().root());
+  }
+
+  public MarkdownEpisodicStore(String root) {
+    this.files = new MarkdownEpisodicFiles(Path.of(root));
+  }
+
+  @Override
+  public boolean existsForDate(LocalDate date) {
+    return files.exists(date);
+  }
+
+  @Override
+  public void storeEpisode(LocalDate date, String summary, int messageCount) {
+    if (files.exists(date)) {
+      Log.debugf("Journal already exists for %s, skipping", date);
+      return;
+    }
+    files.write(date, summary, messageCount);
+  }
+
+  @Override
+  public List<JournalSummary> listJournals() {
+    return files.loadAll().stream()
+        .map(j -> new JournalSummary(null, j.date(), j.summary(), j.messageCount(), j.createdAt()))
+        .toList();
+  }
+
+  @Override
+  public long count() {
+    return files.count();
+  }
+
+  @Override
+  public long purgeAll() {
+    return files.deleteAll();
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/HybridEpisodicStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/HybridEpisodicStore.java
@@ -1,0 +1,68 @@
+package dev.omatheusmesmo.qlawkus.store.pg;
+
+import dev.omatheusmesmo.qlawkus.config.AgentConfig;
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import dev.omatheusmesmo.qlawkus.store.EpisodicStore;
+import dev.omatheusmesmo.qlawkus.store.markdown.MarkdownEpisodicFiles;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Hybrid {@link EpisodicStore}, active when {@code qlawkus.cognition.backend=hybrid}. Journals are
+ * written to dated {@code <date>.md} files (the editable, git-versionable source of truth) and
+ * mirrored into the {@code Journal} table; reads run against the table so summaries carry real
+ * database ids. Selected at build time via {@link IfBuildProperty}.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "hybrid")
+public class HybridEpisodicStore implements EpisodicStore {
+
+  private final MarkdownEpisodicFiles files;
+  private final JournalRepository journals;
+
+  @Inject
+  public HybridEpisodicStore(AgentConfig config, JournalRepository journals) {
+    this(config.episodic().root(), journals);
+  }
+
+  HybridEpisodicStore(String root, JournalRepository journals) {
+    this.files = new MarkdownEpisodicFiles(Path.of(root));
+    this.journals = journals;
+  }
+
+  @Override
+  public boolean existsForDate(LocalDate date) {
+    return journals.existsForDate(date);
+  }
+
+  @Override
+  public void storeEpisode(LocalDate date, String summary, int messageCount) {
+    if (journals.existsForDate(date)) {
+      Log.debugf("Journal already exists for %s, skipping", date);
+      return;
+    }
+    files.write(date, summary, messageCount);
+    journals.store(date, summary, messageCount);
+  }
+
+  @Override
+  public List<JournalSummary> listJournals() {
+    return journals.listJournals();
+  }
+
+  @Override
+  public long count() {
+    return journals.count();
+  }
+
+  @Override
+  public long purgeAll() {
+    files.deleteAll();
+    return journals.deleteAll();
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/JournalRepository.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/JournalRepository.java
@@ -1,0 +1,50 @@
+package dev.omatheusmesmo.qlawkus.store.pg;
+
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Panache access to the {@code Journal} entity, wrapping its static calls behind instance methods so
+ * the episodic stores (pg + hybrid) share one transactional seam and tests can fake it without a
+ * database. Mirrors {@link EmbeddingRepository}.
+ */
+@ApplicationScoped
+public class JournalRepository {
+
+  @Transactional
+  public boolean existsForDate(LocalDate date) {
+    return Journal.existsForDate(date);
+  }
+
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public void store(LocalDate date, String summary, int messageCount) {
+    if (Journal.existsForDate(date)) {
+      return;
+    }
+    Journal journal = new Journal();
+    journal.date = date;
+    journal.summary = summary;
+    journal.messageCount = messageCount;
+    journal.persist();
+  }
+
+  @Transactional
+  public List<JournalSummary> listJournals() {
+    return Journal.<Journal>listAll().stream()
+        .map(j -> new JournalSummary(j.id, j.date, j.summary, j.messageCount, j.createdAt))
+        .toList();
+  }
+
+  @Transactional
+  public long count() {
+    return Journal.count();
+  }
+
+  @Transactional
+  public long deleteAll() {
+    return Journal.deleteAll();
+  }
+}

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/PgEpisodicStore.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/store/pg/PgEpisodicStore.java
@@ -2,49 +2,46 @@ package dev.omatheusmesmo.qlawkus.store.pg;
 
 import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
 import dev.omatheusmesmo.qlawkus.store.EpisodicStore;
+import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
+import jakarta.inject.Inject;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * Postgres-backed {@link EpisodicStore}, active when {@code qlawkus.cognition.backend=pgvector} (the
+ * default). Journals are rows in the {@code Journal} table; selected at build time via
+ * {@link IfBuildProperty}, so other backends do not wire it at all.
+ */
 @ApplicationScoped
+@IfBuildProperty(name = "qlawkus.cognition.backend", stringValue = "pgvector", enableIfMissing = true)
 public class PgEpisodicStore implements EpisodicStore {
 
+  @Inject
+  JournalRepository journals;
+
   @Override
-  @Transactional
   public boolean existsForDate(LocalDate date) {
-    return Journal.existsForDate(date);
+    return journals.existsForDate(date);
   }
 
   @Override
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public void storeEpisode(LocalDate date, String summary, int messageCount) {
-    if (Journal.existsForDate(date)) return;
-    Journal journal = new Journal();
-    journal.date = date;
-    journal.summary = summary;
-    journal.messageCount = messageCount;
-    journal.persist();
+    journals.store(date, summary, messageCount);
   }
 
   @Override
-  @Transactional
   public List<JournalSummary> listJournals() {
-    return Journal.listAll().stream()
-      .map(j -> (Journal) j)
-      .map(j -> new JournalSummary(j.id, j.date, j.summary, j.messageCount, j.createdAt))
-      .toList();
+    return journals.listJournals();
   }
 
   @Override
-  @Transactional
   public long count() {
-    return Journal.count();
+    return journals.count();
   }
 
   @Override
-  @Transactional
   public long purgeAll() {
-    return Journal.deleteAll();
+    return journals.deleteAll();
   }
 }

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -105,7 +105,7 @@ graph LR
 * *Facts* - long-term facts, each tagged with a source (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`). The store backend is selectable via `qlawkus.cognition.backend`: `pgvector` (default), `markdown` (files plus an in-process embedding index, no database), or `hybrid` (files mirrored into pgvector). All three retrieve query-relevant top-K through the same RAG path.
 * *Active memory* - before each reply, relevant facts are retrieved and injected (transcripts excluded to keep it clean).
 * *Transcripts (session search)* - every message is archived and semantically searchable via the `searchTranscripts` tool, distinct from curated facts.
-* *Episodic journals* - a nightly job summarizes each day; summaries are embedded and surfaced by active memory.
+* *Episodic journals* - a nightly job summarizes each day; the summary is embedded through the fact store (so it is surfaced by active memory) and the journal record is kept by an `EpisodicStore` whose backend follows the same `qlawkus.cognition.backend` switch: `pgvector` (the `Journal` table, default), `markdown` (dated `<date>.md` files, no database), or `hybrid` (files mirrored into pgvector).
 
 === Background jobs
 

--- a/docs/modules/ROOT/pages/includes/qlawkus-client_qlawkus.agent.adoc
+++ b/docs/modules/ROOT/pages/includes/qlawkus-client_qlawkus.agent.adoc
@@ -280,5 +280,26 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++${user.home}/.qlawkus/facts+++`
 
+a| [[qlawkus-client_qlawkus-agent-episodic-root]] [.property-path]##link:#qlawkus-client_qlawkus-agent-episodic-root[`+++qlawkus.agent.episodic.root+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.episodic.root+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Directory holding the dated journal markdown files (one per day, `<date>.md`). Defaults to a qlawkus-owned folder, keeping journals editable and git-versionable.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_EPISODIC_ROOT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_EPISODIC_ROOT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++${user.home}/.qlawkus/journals+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/memory.adoc
+++ b/docs/modules/ROOT/pages/memory.adoc
@@ -56,17 +56,19 @@ The agent maintains its own memory so it does not rot:
 
 == Storage backends
 
-The fact store backend is selected at build time with `qlawkus.cognition.backend`:
+Cognition persistence is selected at build time with `qlawkus.cognition.backend`. The same setting governs both the fact store and the episodic (daily journal) store, so a deployment is uniformly database-backed, file-backed, or hybrid:
 
 [cols="1,3",options="header"]
 |===
 |Backend |Behavior
 
-|`pgvector` (default) |Embeddings in Postgres. Scales and is shared across instances.
-|`markdown` |Facts are `.md` files (editable, git-versionable) plus an in-process embedding index cached to JSON. No database; single-node.
-|`hybrid` |`.md` files are the source of truth, mirrored into pgvector for retrieval.
+|`pgvector` (default) |Facts are embeddings in Postgres; journals are rows in the `Journal` table. Scales and is shared across instances.
+|`markdown` |Facts are `.md` files (editable, git-versionable) plus an in-process embedding index cached to JSON; journals are dated `<date>.md` files, one per day. No database; single-node.
+|`hybrid` |`.md` files are the source of truth (facts and dated journals), mirrored into Postgres for retrieval and scale.
 |===
 
-Whichever backend is active, retrieval is the same query-relevant top-K RAG path described above - the choice trades off persistence and scale, never the recall model.
+Whichever backend is active, fact retrieval is the same query-relevant top-K RAG path described above - the choice trades off persistence and scale, never the recall model. Journal text is always embedded through the fact store (`source=episodic-consolidator`), so journals remain searchable regardless of where the journal record itself lives.
+
+The markdown fact and journal directories are configurable with `qlawkus.agent.facts.root` and `qlawkus.agent.episodic.root`.
 
 See xref:architecture.adoc#_memory[Architecture > Memory] for the write/read data-flow diagram, and the xref:config-reference.adoc[configuration reference] for every `qlawkus.agent.*` memory knob.

--- a/integration-tests/cognition/src/test/java/dev/omatheusmesmo/qlawkus/it/cognition/MarkdownEpisodicBackendTest.java
+++ b/integration-tests/cognition/src/test/java/dev/omatheusmesmo/qlawkus/it/cognition/MarkdownEpisodicBackendTest.java
@@ -1,0 +1,43 @@
+package dev.omatheusmesmo.qlawkus.it.cognition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import dev.omatheusmesmo.qlawkus.store.markdown.MarkdownEpisodicStore;
+import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration test for the markdown episodic backend inside the assembled application. The store is
+ * instantiated directly with a temp root (mirroring {@code MarkdownFactBackendTest}), so no separate
+ * markdown-pinned module is needed: a journal is written as a dated {@code .md} file and read back,
+ * proving the backend works end-to-end with no database. Full no-database boot is a later step (SP4).
+ */
+@QuarkusTest
+class MarkdownEpisodicBackendTest {
+
+  @TempDir
+  Path journalsRoot;
+
+  @Test
+  void storesJournalAsDatedFileAndReadsItBack() throws IOException {
+    MarkdownEpisodicStore store = new MarkdownEpisodicStore(journalsRoot.toString());
+    LocalDate date = LocalDate.of(2026, 6, 19);
+
+    store.storeEpisode(date, "User shipped the pluggable episodic backend.", 14);
+
+    assertTrue(Files.isRegularFile(journalsRoot.resolve("2026-06-19.md")),
+        "journal should be persisted as a dated .md file");
+    List<JournalSummary> journals = store.listJournals();
+    assertEquals(1, journals.size());
+    assertEquals(date, journals.get(0).date());
+    assertTrue(journals.get(0).summary().contains("pluggable episodic backend"));
+  }
+}

--- a/site/content/architecture.adoc
+++ b/site/content/architecture.adoc
@@ -105,7 +105,7 @@ graph LR
 * *Facts* - long-term facts, each tagged with a source (`remember-tool`, `semantic-extractor`, `episodic-consolidator`, `transcript`). The store backend is selectable via `qlawkus.cognition.backend`: `pgvector` (default), `markdown` (files plus an in-process embedding index, no database), or `hybrid` (files mirrored into pgvector). All three retrieve query-relevant top-K through the same RAG path.
 * *Active memory* - before each reply, relevant facts are retrieved and injected (transcripts excluded to keep it clean).
 * *Transcripts (session search)* - every message is archived and semantically searchable via the `searchTranscripts` tool, distinct from curated facts.
-* *Episodic journals* - a nightly job summarizes each day; summaries are embedded and surfaced by active memory.
+* *Episodic journals* - a nightly job summarizes each day; the summary is embedded through the fact store (so it is surfaced by active memory) and the journal record is kept by an `EpisodicStore` whose backend follows the same `qlawkus.cognition.backend` switch: `pgvector` (the `Journal` table, default), `markdown` (dated `<date>.md` files, no database), or `hybrid` (files mirrored into pgvector).
 
 === Background jobs
 

--- a/site/content/includes/qlawkus-client_qlawkus.agent.adoc
+++ b/site/content/includes/qlawkus-client_qlawkus.agent.adoc
@@ -280,5 +280,26 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++${user.home}/.qlawkus/facts+++`
 
+a| [[qlawkus-client_qlawkus-agent-episodic-root]] [.property-path]##link:#qlawkus-client_qlawkus-agent-episodic-root[`+++qlawkus.agent.episodic.root+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.agent.episodic.root+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Directory holding the dated journal markdown files (one per day, `<date>.md`). Defaults to a qlawkus-owned folder, keeping journals editable and git-versionable.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_AGENT_EPISODIC_ROOT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_AGENT_EPISODIC_ROOT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++${user.home}/.qlawkus/journals+++`
+
 |===
 

--- a/site/content/memory.adoc
+++ b/site/content/memory.adoc
@@ -56,17 +56,19 @@ The agent maintains its own memory so it does not rot:
 
 == Storage backends
 
-The fact store backend is selected at build time with `qlawkus.cognition.backend`:
+Cognition persistence is selected at build time with `qlawkus.cognition.backend`. The same setting governs both the fact store and the episodic (daily journal) store, so a deployment is uniformly database-backed, file-backed, or hybrid:
 
 [cols="1,3",options="header"]
 |===
 |Backend |Behavior
 
-|`pgvector` (default) |Embeddings in Postgres. Scales and is shared across instances.
-|`markdown` |Facts are `.md` files (editable, git-versionable) plus an in-process embedding index cached to JSON. No database; single-node.
-|`hybrid` |`.md` files are the source of truth, mirrored into pgvector for retrieval.
+|`pgvector` (default) |Facts are embeddings in Postgres; journals are rows in the `Journal` table. Scales and is shared across instances.
+|`markdown` |Facts are `.md` files (editable, git-versionable) plus an in-process embedding index cached to JSON; journals are dated `<date>.md` files, one per day. No database; single-node.
+|`hybrid` |`.md` files are the source of truth (facts and dated journals), mirrored into Postgres for retrieval and scale.
 |===
 
-Whichever backend is active, retrieval is the same query-relevant top-K RAG path described above - the choice trades off persistence and scale, never the recall model.
+Whichever backend is active, fact retrieval is the same query-relevant top-K RAG path described above - the choice trades off persistence and scale, never the recall model. Journal text is always embedded through the fact store (`source=episodic-consolidator`), so journals remain searchable regardless of where the journal record itself lives.
+
+The markdown fact and journal directories are configurable with `qlawkus.agent.facts.root` and `qlawkus.agent.episodic.root`.
 
 See xref:architecture.adoc#_memory[Architecture > Memory] for the write/read data-flow diagram, and the xref:config-reference.adoc[configuration reference] for every `qlawkus.agent.*` memory knob.


### PR DESCRIPTION
## SP3 - Episodic backends

Makes the `EpisodicStore` (daily journals) pluggable on the same build-time `qlawkus.cognition.backend` switch already used by facts (SP2) and skills (SP1), continuing the path toward a database-free, markdown-only distribution.

### Backends

| `qlawkus.cognition.backend` | Journal record |
|---|---|
| `pgvector` (default) | rows in the `Journal` table |
| `markdown` | dated `<date>.md` files, one per day, no database |
| `hybrid` | `.md` files (source of truth) + Postgres mirror |

New config: `qlawkus.agent.episodic.root` (default `~/.qlawkus/journals`).

### Why

- **Closes a latent bug.** `PgEpisodicStore` was ungated (`@ApplicationScoped`), so even in `markdown` mode it bound the Panache `Journal` entity and forced a datasource. It is now gated (`@IfBuildProperty` `pgvector`, `enableIfMissing`), exactly as SP2 did for `PgFactStore`.
- **No new retrieval path.** Journal text is still embedded through the `FactStore` (`source=episodic-consolidator`), which SP2 already made backend-aware, so recall is unchanged. SP3 only makes the durable journal *record* pluggable.

### Changes

- `MarkdownEpisodicStore` + `MarkdownEpisodicFiles` (dated `<date>.md` files, no embedding cache).
- `HybridEpisodicStore` (files source-of-truth + pg mirror), mirroring `HybridFactStore`.
- `JournalRepository`: a fakeable transactional seam shared by the pg and hybrid stores (mirrors `EmbeddingRepository`).
- `AgentConfig.Episodic` config interface.
- Docs: `AGENTS.md`, `memory.adoc`, `architecture.adoc`, and the regenerated `qlawkus.agent` config-reference include.

### Tests

- `MarkdownEpisodicStoreTest` (no DB/LLM): write/read, dedup-by-date, ordering, count, purge, same-day re-consolidation no-op.
- `HybridEpisodicStoreTest` (no Postgres): file write + pg mirror via a fake `JournalRepository`; reads carry DB ids.
- `MarkdownEpisodicBackendTest` (integration-tests/cognition): markdown journal round-trips inside the assembled app.

### Verification

- `client/deployment`: 354 tests, 0 failures (9 new + full regression after the `PgEpisodicStore`/`JournalRepository` refactor).
- `integration-tests/cognition`: 68 tests, 0 failures (1 new).
- Config reference regenerated and mirrored via the docs build (no drift).
- Native (`-Pnative`) left to CI, as in SP2; no new static non-native-safe fields introduced.
