### PR TITLE
Prepare release 0.7.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 release:
   # Current version to release (edit this to trigger a release)
-  current-version: 0.7.3-SNAPSHOT
+  current-version: 0.7.3
   # Next development version after the release
-  next-version: 0.7.3-SNAPSHOT
+  next-version: 0.8.0-SNAPSHOT


### PR DESCRIPTION
Prepares the **0.7.3** release by bumping `.github/project.yml`.

- `current-version` → `0.7.3` (the version to release)
- `next-version` → `0.8.0-SNAPSHOT` (development continues on the 0.8 line)

## What happens on merge

`pre-release` validates this PR (non-SNAPSHOT release version, not a fork). Merging it triggers `release-prepare`, which sets the POMs to `0.7.3`, tags `0.7.3` (no `v` prefix), pushes the tag, and bumps development to `0.8.0-SNAPSHOT`. The tag push then triggers `release-perform` to build the artifacts and open a draft GitHub Release with a PR-based changelog.

## Highlights since 0.7.2

**Pluggable cognition backends (markdown / pgvector / hybrid)**
- #236 - Pluggable fact store backends: markdown, pgvector, and hybrid
- #237 - Pluggable episodic journal backends: markdown, pgvector, and hybrid
- #228 - Self-managing skill system with pluggable storage backends
- #238 - Pluggable working memory and persona/profile, pgvector extracted into an optional extension (database-free markdown-only distribution), with bidirectional file <-> Postgres migration

**Remote skill registry**
- #239 - Skill Hub: search, install and publish skills from a remote registry (skills.sh + well-known hosts), native, with yolo/hitl approval modes

**LLM provider system**
- #224 - Provider-agnostic LLM configuration with a kind-based provider system

**Config & infrastructure**
- #213 - Migrate scattered config to @ConfigMapping; tidy docs, site and Docker
- #215 - Bring local Docker compose to parity with prod and persist shared data volumes
- #214 - Run passive memory extraction on every channel, not just REST

(The draft GitHub Release generated by `release-perform` will include the full PR-based changelog.)