### PR TITLE
Release 0.8.0 (M8 Group B: secrets & config without a DB)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 release:
   # Current version to release (edit this to trigger a release)
-  current-version: 0.8.0-SNAPSHOT
+  current-version: 0.8.0
   # Next development version after the release
-  next-version: 0.8.0-SNAPSHOT
+  next-version: 0.8.1-SNAPSHOT


### PR DESCRIPTION
## Release 0.8.0 - M8 Group B (Secrets & Config without a database)

First release on the 0.8.x line, closing **Group B** of M8 (#7): a database-free secret store backed by a PKCS12 keystore, authoritative over environment variables, with no custom crypto.

### What ships (Group B issues, all merged since 0.7.3)

- **#71** - `CredentialsProvider` SPI adopted as the secret seam.
- **#70** - File-backed encrypted secret store auto-wired in `client` (keystore config source, no DB).
- **#76** - Keystore secrets made authoritative over env (config ordinal 350).
- **#72** - Secret consumers migrated to handles + secret catalog, LLM-key keystore path proven end to end.
- **#191** - Admin endpoint to write a secret into the encrypted store (no `keytool`), basic-auth gated, never logs the value; fail-closed auth in `app/`.

### Mechanics of this PR

Edits `.github/project.yml` only:

- `current-version` -> `0.8.0` (the tag)
- `next-version` -> `0.8.1-SNAPSHOT` (next dev cycle)

Merging triggers `release-prepare.yml` (sets POMs, tags `0.8.0`, pushes the tag, bumps to the next SNAPSHOT) which in turn fires `release-perform.yml` to build artifacts and draft the GitHub Release.
