### PR TITLE
Add the agent.yml composition manifest model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Changing `client/` requires re-running `mvn install -pl client -am` then restart
 
 Multi-module Maven monorepo with a Quarkus extension pattern (`client/deployment` + `client/runtime`):
 
+- **`composition-model/`** - Thin, **Quarkus-free** module (plain records + Jackson YAML) holding the `agent.yml` composition manifest model: `CompositionManifest`/`BuildTime`/`Posture`, the single `CompositionManifestParser`, the policy+exceptions `isEnabled` logic, and the path conventions (`CompositionPaths`). Shared by the (future) pom generator that reads `build-time` before the build and the running app that reads `runtime` each boot, so the schema and policy never drift (same single-source-of-truth discipline as `KeystoreSecrets`). The `qlawkus.composition.*` location config (`CompositionConfig`, BUILD_TIME) lives in `client`.
 - **`client/`** - Quarkus extension (core agent, cognition, REST, tools). Not a runnable app. **Database-free**: depends on no datasource/JDBC/Flyway/pgvector - the markdown stores are its `@DefaultBean` backend.
 - **`cognition-pgvector/`** - Optional Quarkus extension (`deployment/` + `runtime/`) holding the entire Postgres/pgvector backend for the cognition stores (the `store.pg` package, the 7 Flyway migrations, and the datasource/pgvector config as `META-INF/microprofile-config.properties`). Present in `app/`; absent in a markdown-only distribution. `requires` the `dev.omatheusmesmo.qlawkus.agent` capability.
 - **`app/`** - Deployable Quarkus app (`packaging=quarkus`). Wires all extensions together. Only module you run.

--- a/client/runtime/pom.xml
+++ b/client/runtime/pom.xml
@@ -14,6 +14,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>dev.omatheusmesmo</groupId>
+      <artifactId>qlawkus-composition-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>

--- a/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/CompositionConfig.java
+++ b/client/runtime/src/main/java/dev/omatheusmesmo/qlawkus/config/CompositionConfig.java
@@ -1,0 +1,24 @@
+package dev.omatheusmesmo.qlawkus.config;
+
+import dev.omatheusmesmo.qlawkus.composition.CompositionPaths;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Where the composition manifest ({@code agent.yml}) lives. Build-time only: the manifest decides
+ * which capabilities are composed into the pom, so it is read before and during augmentation, never
+ * re-read at runtime. The runtime override is a separate file owned by the runtime toggle tier.
+ */
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "qlawkus.composition")
+public interface CompositionConfig {
+
+    /**
+     * Location of the build-time manifest, relative to the application module's resources. Defaults
+     * to {@code qlawkus/agent.yml}. The pom generator and the build report both resolve it here.
+     */
+    @WithDefault(CompositionPaths.DEFAULT_MANIFEST)
+    String manifest();
+}

--- a/composition-model/README.adoc
+++ b/composition-model/README.adoc
@@ -1,0 +1,90 @@
+= Qlawkus Composition Model
+
+The shared, Quarkus-free model for the `agent.yml` composition manifest. Two very different
+processes read this manifest at two different times, and if each had its own parser they would
+drift. This module is the single parser and the single home of the policy logic, so they cannot.
+
+[cols="1,1,1,1"]
+|===
+| Section | Who reads it | When | How
+
+| `build-time`
+| the pom generator
+| before the build (outside Quarkus)
+| plain `CompositionManifestParser`
+
+| `runtime`
+| the running app
+| each boot
+| a Quarkus `ConfigSource`
+|===
+
+== Schema
+
+[source,yaml]
+----
+version: 1
+
+build-time:
+  # Posture of EVERY capability:
+  #   enabled  -> all on,  list the ones to turn OFF
+  #   disabled -> all off, list the ones to turn ON
+  default: enabled
+  # Capabilities with the OPPOSITE effect of the default. One list.
+  except:
+    - brag
+    - skill-hub
+
+runtime:
+  skill-hub.approval-mode: hitl
+  semantic-extractor.enabled: true
+----
+
+`version`:: Schema version. Only `1` is accepted today; it exists so the schema can evolve without
+breaking older files.
+
+`build-time.default`:: `enabled` or `disabled`. Sets the posture for all capabilities. Pick the
+default that makes the `except` list shortest.
+
+`build-time.except`:: The capabilities that get the *opposite* effect of `default`. A single list
+whose meaning inverts with the posture. This is the classic policy + exceptions model (firewall
+default-DENY/ALLOW, `.gitignore` + `!`, RBAC).
+
+`runtime`:: Free-form, dot-namespaced toggles applied at boot. The keys are ordinary Qlawkus config
+property suffixes (`skill-hub.approval-mode` -> `qlawkus.skill-hub.approval-mode`).
+
+== Policy semantics
+
+`BuildTime.isEnabled(capability)` resolves intent from the posture and the exception list:
+
+[cols="1,1,1"]
+|===
+| `default` | capability in `except`? | result
+
+| `enabled`  | no  | enabled
+| `enabled`  | yes | disabled
+| `disabled` | no  | disabled
+| `disabled` | yes | enabled
+|===
+
+This answers intent only. A capability whose module is absent from the classpath is never wired
+regardless of the answer here: you cannot enable what is not a dependency. The generator simply
+emits no dependency for it, and a `disabled` build-time entry keeps the dependency out of the pom
+entirely (lean by construction, not by runtime elimination).
+
+== What is deliberately not here
+
+`cognition.backend` (markdown / pgvector / hybrid):: A *valued* choice, not a boolean. It stays the
+build property `qlawkus.cognition.backend` (`@IfBuildProperty`), out of the manifest.
+
+Per-tool refinement (`only: [...]`):: YAGNI for now. Reserved for later without a schema break,
+thanks to `version`.
+
+== Paths
+
+`CompositionPaths.DEFAULT_MANIFEST`:: `qlawkus/agent.yml`, relative to the application module
+resources. The build-time input. Its location is configurable via `qlawkus.composition.manifest`
+(build-time).
+
+`CompositionPaths.DEFAULT_RUNTIME_OVERRIDE`:: `~/.qlawkus/agent.runtime.yml`. Where live runtime
+changes persist, never back into the baked artifact. Behavior owned by the runtime toggle tier.

--- a/composition-model/pom.xml
+++ b/composition-model/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.omatheusmesmo</groupId>
+        <artifactId>qlawkus</artifactId>
+        <version>0.8.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>qlawkus-composition-model</artifactId>
+    <name>Qlawkus Composition Model</name>
+    <description>Shared, Quarkus-free model for the agent.yml composition manifest. Read by both the
+        pom generator (build-time) and the running app (runtime) so the schema and policy logic
+        never diverge.</description>
+
+    <properties>
+        <!-- The shared parent surefire config uses @{argLine} (late replacement, normally filled by
+             the Quarkus plugin in extension modules). This plain module has no Quarkus plugin, so
+             define an empty default to keep @{argLine} from resolving to a literal JVM arg. -->
+        <argLine></argLine>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/BuildTime.java
+++ b/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/BuildTime.java
@@ -1,0 +1,38 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * The {@code build-time} section of {@code agent.yml}: which capabilities the pom generator should
+ * include. Expressed as policy + exceptions - a single {@link Posture} default plus the list of
+ * capabilities that get the opposite effect.
+ *
+ * @param defaultPosture the posture applied to every capability not listed in {@code except}
+ * @param except the capabilities whose effect is the opposite of {@code defaultPosture}
+ */
+public record BuildTime(
+        @JsonProperty("default") Posture defaultPosture,
+        List<String> except) {
+
+    public BuildTime {
+        if (defaultPosture == null) {
+            throw new IllegalArgumentException("build-time.default is required ('enabled' or 'disabled')");
+        }
+        except = except == null ? List.of() : List.copyOf(except);
+    }
+
+    /**
+     * Whether the manifest asks for {@code capability} to be composed in. This answers intent only;
+     * a capability whose module is absent from the classpath is never wired regardless of the
+     * answer here (you cannot enable what is not a dependency).
+     *
+     * @param capability the dot-namespaced capability name (e.g. {@code messaging.discord})
+     * @return true when the policy resolves to enabled for this capability
+     */
+    public boolean isEnabled(String capability) {
+        boolean listed = except.contains(capability);
+        return defaultPosture == Posture.ENABLED ? !listed : listed;
+    }
+}

--- a/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/CompositionManifest.java
+++ b/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/CompositionManifest.java
@@ -1,0 +1,34 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * The whole {@code agent.yml} composition manifest. The single source of truth shared by the pom
+ * generator (which reads {@link #buildTime()} before the build) and the running app (which reads
+ * {@link #runtime()} each boot), so the schema and policy logic never diverge between them.
+ *
+ * @param version schema version; only {@link #SUPPORTED_VERSION} is currently accepted
+ * @param buildTime which capabilities to compose into the pom
+ * @param runtime free-form, dot-namespaced runtime toggles (e.g. {@code skill-hub.approval-mode})
+ */
+public record CompositionManifest(
+        int version,
+        @JsonProperty("build-time") BuildTime buildTime,
+        Map<String, Object> runtime) {
+
+    public static final int SUPPORTED_VERSION = 1;
+
+    public CompositionManifest {
+        if (version != SUPPORTED_VERSION) {
+            throw new IllegalArgumentException(
+                    "Unsupported manifest version: " + version + " (supported: " + SUPPORTED_VERSION
+                            + "). Add 'version: " + SUPPORTED_VERSION + "' at the top of agent.yml.");
+        }
+        if (buildTime == null) {
+            throw new IllegalArgumentException("agent.yml is missing the 'build-time' section");
+        }
+        runtime = runtime == null ? Map.of() : Map.copyOf(runtime);
+    }
+}

--- a/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/CompositionManifestParser.java
+++ b/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/CompositionManifestParser.java
@@ -1,0 +1,91 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Reads and writes {@code agent.yml}. The only parser in the codebase for the composition manifest,
+ * by design: the pom generator and the running app both call it, so the schema is enforced in one
+ * place. Stateless and thread-safe.
+ */
+public final class CompositionManifestParser {
+
+    private static final ObjectMapper YAML = new ObjectMapper(
+            new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER))
+            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+
+    private CompositionManifestParser() {
+    }
+
+    /**
+     * Parses a manifest from YAML text.
+     *
+     * @throws InvalidManifestException if the YAML is malformed or violates the schema
+     */
+    public static CompositionManifest parse(String yaml) {
+        try {
+            return require(YAML.readValue(yaml, CompositionManifest.class));
+        } catch (IOException e) {
+            throw wrap(e);
+        }
+    }
+
+    /**
+     * Parses a manifest from an open stream. The caller owns the stream.
+     *
+     * @throws InvalidManifestException if the YAML is malformed or violates the schema
+     */
+    public static CompositionManifest parse(InputStream in) {
+        try {
+            return require(YAML.readValue(in, CompositionManifest.class));
+        } catch (IOException e) {
+            throw wrap(e);
+        }
+    }
+
+    /**
+     * Reads and parses a manifest from a file.
+     *
+     * @throws InvalidManifestException if the file is unreadable, malformed, or violates the schema
+     */
+    public static CompositionManifest parse(Path path) {
+        try {
+            return parse(Files.readString(path));
+        } catch (IOException e) {
+            throw new InvalidManifestException("Cannot read manifest at " + path + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Renders a manifest back to YAML. Round-trips with {@link #parse(String)}.
+     */
+    public static String render(CompositionManifest manifest) {
+        try {
+            return YAML.writeValueAsString(manifest);
+        } catch (IOException e) {
+            throw new InvalidManifestException("Cannot render manifest: " + e.getMessage(), e);
+        }
+    }
+
+    private static CompositionManifest require(CompositionManifest manifest) {
+        if (manifest == null) {
+            throw new InvalidManifestException("agent.yml is empty");
+        }
+        return manifest;
+    }
+
+    private static InvalidManifestException wrap(IOException e) {
+        Throwable cause = e instanceof ValueInstantiationException vie && vie.getCause() != null
+                ? vie.getCause()
+                : e;
+        return new InvalidManifestException("Invalid agent.yml: " + cause.getMessage(), e);
+    }
+}

--- a/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/CompositionPaths.java
+++ b/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/CompositionPaths.java
@@ -1,0 +1,23 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+/**
+ * Filesystem and classpath conventions for the composition manifest. Constants only, so the
+ * generator and the runtime agree on where the files live.
+ */
+public final class CompositionPaths {
+
+    /**
+     * Default location of the build-time manifest, relative to the application module. Read by the
+     * pom generator and bundled as a classpath resource so the running app can locate it.
+     */
+    public static final String DEFAULT_MANIFEST = "qlawkus/agent.yml";
+
+    /**
+     * Default location of the runtime override, relative to the user home. Live runtime-tier
+     * changes persist here, never back into the baked artifact (behavior owned by the runtime tier).
+     */
+    public static final String DEFAULT_RUNTIME_OVERRIDE = ".qlawkus/agent.runtime.yml";
+
+    private CompositionPaths() {
+    }
+}

--- a/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/InvalidManifestException.java
+++ b/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/InvalidManifestException.java
@@ -1,0 +1,16 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+/**
+ * Thrown when {@code agent.yml} cannot be parsed or violates the schema. Carries a message that is
+ * safe to surface to the operator (it never echoes secret values - the manifest holds none).
+ */
+public class InvalidManifestException extends RuntimeException {
+
+    public InvalidManifestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidManifestException(String message) {
+        super(message);
+    }
+}

--- a/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/Posture.java
+++ b/composition-model/src/main/java/dev/omatheusmesmo/qlawkus/composition/Posture.java
@@ -1,0 +1,42 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+/**
+ * The default posture of every capability in the {@code build-time} section of {@code agent.yml}.
+ *
+ * <p>{@link #ENABLED} means "all capabilities on, list the ones to turn off"; {@link #DISABLED}
+ * means "all off, list the ones to turn on". The {@code except} list always carries the opposite
+ * effect of the posture (policy + exceptions).
+ */
+public enum Posture {
+
+    ENABLED,
+    DISABLED;
+
+    /**
+     * Parses the wire form ({@code enabled} / {@code disabled}, case-insensitive).
+     *
+     * @throws IllegalArgumentException if {@code raw} is null or not a known posture
+     */
+    @JsonCreator
+    public static Posture from(String raw) {
+        if (raw == null) {
+            throw new IllegalArgumentException("build-time.default must be 'enabled' or 'disabled'");
+        }
+        return switch (raw.trim().toLowerCase(Locale.ROOT)) {
+            case "enabled" -> ENABLED;
+            case "disabled" -> DISABLED;
+            default -> throw new IllegalArgumentException(
+                    "build-time.default must be 'enabled' or 'disabled', got: " + raw);
+        };
+    }
+
+    @JsonValue
+    public String wireName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/composition-model/src/test/java/dev/omatheusmesmo/qlawkus/composition/CompositionManifestParserTest.java
+++ b/composition-model/src/test/java/dev/omatheusmesmo/qlawkus/composition/CompositionManifestParserTest.java
@@ -1,0 +1,114 @@
+package dev.omatheusmesmo.qlawkus.composition;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompositionManifestParserTest {
+
+    private static final String FULL = """
+            version: 1
+            build-time:
+              default: enabled
+              except:
+                - brag
+                - skill-hub
+            runtime:
+              skill-hub.approval-mode: hitl
+              semantic-extractor.enabled: true
+            """;
+
+    @Test
+    void parsesEveryField() {
+        CompositionManifest m = CompositionManifestParser.parse(FULL);
+
+        assertEquals(1, m.version());
+        assertEquals(Posture.ENABLED, m.buildTime().defaultPosture());
+        assertEquals(java.util.List.of("brag", "skill-hub"), m.buildTime().except());
+        assertEquals("hitl", m.runtime().get("skill-hub.approval-mode"));
+        assertEquals(Boolean.TRUE, m.runtime().get("semantic-extractor.enabled"));
+    }
+
+    @Test
+    void policyEnabledDefault_exceptListIsDisabled() {
+        BuildTime bt = CompositionManifestParser.parse(FULL).buildTime();
+
+        assertFalse(bt.isEnabled("brag"));
+        assertFalse(bt.isEnabled("skill-hub"));
+        assertTrue(bt.isEnabled("messaging.discord"));
+    }
+
+    @Test
+    void policyDisabledDefault_exceptListIsEnabled() {
+        BuildTime bt = CompositionManifestParser.parse("""
+                version: 1
+                build-time:
+                  default: disabled
+                  except:
+                    - messaging.discord
+                """).buildTime();
+
+        assertTrue(bt.isEnabled("messaging.discord"));
+        assertFalse(bt.isEnabled("brag"));
+        assertFalse(bt.isEnabled("skill-hub"));
+    }
+
+    @Test
+    void roundTripsThroughRender() {
+        CompositionManifest original = CompositionManifestParser.parse(FULL);
+
+        CompositionManifest reparsed = CompositionManifestParser.parse(
+                CompositionManifestParser.render(original));
+
+        assertEquals(original, reparsed);
+    }
+
+    @Test
+    void emptyExceptDefaultsToEmptyList() {
+        BuildTime bt = CompositionManifestParser.parse("""
+                version: 1
+                build-time:
+                  default: enabled
+                """).buildTime();
+
+        assertTrue(bt.except().isEmpty());
+        assertTrue(bt.isEnabled("brag"));
+    }
+
+    @Test
+    void rejectsUnsupportedVersion() {
+        InvalidManifestException e = assertThrows(InvalidManifestException.class,
+                () -> CompositionManifestParser.parse("""
+                        version: 2
+                        build-time:
+                          default: enabled
+                        """));
+        assertTrue(e.getMessage().contains("version"));
+    }
+
+    @Test
+    void rejectsMissingBuildTime() {
+        assertThrows(InvalidManifestException.class,
+                () -> CompositionManifestParser.parse("version: 1\n"));
+    }
+
+    @Test
+    void rejectsUnknownPosture() {
+        InvalidManifestException e = assertThrows(InvalidManifestException.class,
+                () -> CompositionManifestParser.parse("""
+                        version: 1
+                        build-time:
+                          default: sometimes
+                        """));
+        assertTrue(e.getMessage().contains("enabled"));
+    }
+
+    @Test
+    void rejectsEmptyDocument() {
+        assertThrows(InvalidManifestException.class,
+                () -> CompositionManifestParser.parse(""));
+    }
+}

--- a/docs/modules/ROOT/pages/config-reference.adoc
+++ b/docs/modules/ROOT/pages/config-reference.adoc
@@ -43,6 +43,9 @@ include::includes/qlawkus-client_qlawkus.shell.adoc[]
 === Secrets
 include::includes/qlawkus-client_qlawkus.secrets.adoc[]
 
+=== Composition
+include::includes/qlawkus-client_qlawkus.composition.adoc[]
+
 == Messaging
 
 === Core

--- a/docs/modules/ROOT/pages/includes/qlawkus-client_qlawkus.composition.adoc
+++ b/docs/modules/ROOT/pages/includes/qlawkus-client_qlawkus.composition.adoc
@@ -1,0 +1,32 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[qlawkus-client_qlawkus-composition-manifest]] [.property-path]##link:#qlawkus-client_qlawkus-composition-manifest[`+++qlawkus.composition.manifest+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.composition.manifest+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Location of the build-time manifest, relative to the application module's resources. Defaults to `qlawkus/agent.yml`. The pom generator and the build report both resolve it here.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_COMPOSITION_MANIFEST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_COMPOSITION_MANIFEST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++qlawkus/agent.yml+++`
+
+|===
+

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
   <packaging>pom</packaging>
 
     <modules>
+        <module>composition-model</module>
         <module>client</module>
         <module>cognition-pgvector</module>
         <module>tools</module>

--- a/site/content/config-reference.adoc
+++ b/site/content/config-reference.adoc
@@ -43,6 +43,9 @@ include::includes/qlawkus-client_qlawkus.shell.adoc[]
 === Secrets
 include::includes/qlawkus-client_qlawkus.secrets.adoc[]
 
+=== Composition
+include::includes/qlawkus-client_qlawkus.composition.adoc[]
+
 == Messaging
 
 === Core

--- a/site/content/includes/qlawkus-client_qlawkus.composition.adoc
+++ b/site/content/includes/qlawkus-client_qlawkus.composition.adoc
@@ -1,0 +1,32 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[qlawkus-client_qlawkus-composition-manifest]] [.property-path]##link:#qlawkus-client_qlawkus-composition-manifest[`+++qlawkus.composition.manifest+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++qlawkus.composition.manifest+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Location of the build-time manifest, relative to the application module's resources. Defaults to `qlawkus/agent.yml`. The pom generator and the build report both resolve it here.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QLAWKUS_COMPOSITION_MANIFEST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QLAWKUS_COMPOSITION_MANIFEST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++qlawkus/agent.yml+++`
+
+|===
+


### PR DESCRIPTION
## What

First slice of **M8 Sub-project 1 (Manifest + Composition)**: the `agent.yml` composition manifest **model**. This issue defines the format only - the generator is #69, the capability catalog is #74.

## Why this shape

Three hard Quarkus/Maven truths force the design (full rationale in #7):

1. Quarkus resolves dependencies **before** augmentation, so a `@BuildStep` cannot inject deps into its own build. "Manifest decides the deps" can only live in a **generator** that runs before the build.
2. Maven does **no** tree-shaking. A declared dep is always on the classpath.
3. So the generator wins: a capability not listed never enters the classpath at all (lean by construction, not by native elimination).

## Changes

- **New module `qlawkus-composition-model`** (Quarkus-free, plain records + Jackson YAML):
  - `CompositionManifest` / `BuildTime` / `Posture` records; `version` schema field.
  - `CompositionManifestParser` - the **single** parser (read + round-trip render).
  - `BuildTime.isEnabled(capability)` - the policy+exceptions logic, shared by the future generator and runtime so they cannot drift (same discipline as `KeystoreSecrets`).
  - `CompositionPaths` - path conventions (`qlawkus/agent.yml`, `~/.qlawkus/agent.runtime.yml`).
  - 9 unit tests (parse, both policy directions, round-trip, validation).
- **`qlawkus.composition.*` BUILD_TIME config root** (`CompositionConfig`) in `client` for the manifest location; default bound to the shared `CompositionPaths.DEFAULT_MANIFEST` constant.
- Config reference wired in both doc trees; schema documented in the module README and AGENTS.md.

## Selection model

Policy + exceptions: a single `default: enabled|disabled` posture plus an `except` list that carries the opposite effect. One list, meaning inverts with the default.

```yaml
version: 1
build-time:
  default: enabled      # or: disabled
  except: [brag, skill-hub]
runtime:
  skill-hub.approval-mode: hitl
```

A capability absent from the classpath is never wired regardless of posture.

## Out of scope (follow-ups)

- #69 generator (manifest -> pom)
- #74 capability catalog (module self-describes Maven coordinates)
- #73 runtime toggle tier + external override
- #77 dev-mode hot reload + validation + build report

## Test

```
mvn -pl composition-model test     # 9/9 green
mvn -pl client -am install -DskipTests   # client builds with the new config root
```

Closes #68
