### PR TITLE
Reject conventional-commit prefixes in PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,41 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+    - opened
+    - edited
+    - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-title:
+    name: Check Title
+    runs-on: ubuntu-latest
+    steps:
+    - name: Reject conventional-commit prefixes
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        echo "PR title: ${PR_TITLE}"
+        if grep -qiE '^[[:space:]]*(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([^)]*\))?!?:' <<< "${PR_TITLE}"; then
+          {
+            echo "::error::PR titles must read as a release-notes line, not a conventional commit."
+            echo "The changelog is generated from PR titles (see release-perform.yml), so drop the 'type:' prefix."
+            echo "Use an imperative, capitalized phrase:"
+            echo "  Bad:  feat: add database-free secrets"
+            echo "  Good: Add database-free secrets backed by an encrypted keystore"
+          } >&2
+          exit 1
+        fi
+        echo "Title OK."


### PR DESCRIPTION
## What

A GitHub Actions check that fails when a PR title starts with a conventional-commit prefix (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, ...).

## Why

The release changelog is generated from **PR titles** (`release-perform.yml`), so a `feat:`/`fix:` prefix leaks straight into the release notes. The 0.8.0 notes show the intended style: imperative, capitalized, no prefix ("Add database-free secrets backed by an encrypted keystore").

This mirrors what the **quarkus-github-bot** enforces upstream, implemented as a plain Actions check since this repo has no custom bot.

## Scope

- Validates the **PR title only**. Commit messages are unaffected: they keep the conventional prefix the rebase-based history uses (`feat:`, `docs:`, `ci:` on `main`).
- Runs on `opened`, `edited`, `reopened`. Reads the title from the event payload (no checkout), so it is safe and instant.
- Make it a required check in branch protection to actually block merge.

## Behavior

```
Bad:  feat: add database-free secrets   -> fails with guidance
Good: Add database-free secrets backed by an encrypted keystore
```