### PR TITLE
Release 0.8.1 (M8 Sub-project 1: composable agent platform)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 release:
   # Current version to release (edit this to trigger a release)
-  current-version: 0.8.1-SNAPSHOT
+  current-version: 0.8.1
   # Next development version after the release
-  next-version: 0.8.1-SNAPSHOT
+  next-version: 0.8.2-SNAPSHOT


### PR DESCRIPTION
Cuts the **0.8.1** release: M8 Sub-project 1 (declarative composition) plus the oversized-fact chunking fix.

Sets `current-version` to `0.8.1` and bumps development to `0.8.2-SNAPSHOT`, which triggers the release pipeline on merge (tag `0.8.1`, then draft GitHub Release).

## What's in 0.8.1

**Declarative composition (M8 Group A / Sub-project 1)**
- `agent.yml` composition manifest model (build-time + runtime tiers), single parser and policy-with-exceptions in a Quarkus-free `composition-model`
- `qlawkus-maven-plugin` (`qlawkus:generate`): turns the manifest into the pom's `<dependencies>` before the build, reconciling in place (idempotent, BOM-managed versions)
- Decentralized capability catalog: each extension self-describes `metadata.qlawkus.capability`; the `ReactorCatalog` resolves it across the reactor
- Resolved capability-set build report (selected/excluded), fail-fast on an unknown `except` name (opt-out via `-Dqlawkus.composition.fail-on-unknown-capability=false`)
- Dev-mode reload: `quarkus:dev` regenerates the pom when `agent.yml` changes
- End-to-end `maven-invoker` ITs (happy path + fail-fast)

**Cognition fix: oversized facts are chunked**
- Facts over the embedding model's 512-token limit are split into overlapping segments before embedding (one fact -> N vector rows sharing a `factHash`), so a long fact no longer aborts the boot reconcile
- Per-fact resilience in `CognitionReconciler` so one bad fact never aborts the six-store union

## Validation
- Full module build green with the real LLM key (client/deployment: 316 tests, 0 failures)
- Local `prod` deploy: clean boot, idempotent reconcile, chunking live in pgvector (498 rows / 450 facts / 57 multi-chunk), authenticated recall verbatim from the vector store
- Composition feature exercised end-to-end via the invoker ITs (report + pom generation + fail-fast validation)
