### PR TITLE
On-demand builder runner: rebuild the app from agent.yml

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -1,0 +1,83 @@
+# Builder runner
+
+On-demand rebuild of the Qlawkus app from its composition manifest. The running app
+cannot rebuild itself (a native binary is frozen, a JVM app is closed-world augmented
+at build time, and the runtime image ships no toolchain), so a builder with the
+toolchain rebuilds on its behalf when `agent.yml` changes.
+
+This is issue #248, the foundation of the M8 build-and-redeploy control loop. It stops
+at **producing a versioned artifact**; triggering it over HTTP is #250, and swapping the
+running instance to the new artifact is #251.
+
+## What it does
+
+`build.sh <jvm|native>`:
+
+1. Optionally stages a manifest (`STAGING_AGENT_YML`) into the app's `agent.yml`.
+2. Reconciles the app pom from the manifest by running the `generate-sources` phase
+   (`mvnw -pl app -am generate-sources`): the app pom binds `qlawkus:generate` there,
+   the same seam dev mode uses. A plugin-prefix goal would not resolve from the root.
+3. Builds in a **fresh** Maven session so it reads the regenerated pom:
+   `mvnw -pl app -am -DskipTests -DskipITs [-Pnative] package`.
+4. Emits the artifact into `SHARED_DIR` and repoints `latest`.
+
+The two Maven sessions are deliberate: `qlawkus:generate` rewrites `pom.xml` on disk,
+but Maven has already resolved the model for the current session, so the build must run
+in a new session to pick up the new dependency set. This is the one-shot equivalent of
+what `quarkus:dev` does across two reload passes.
+
+It is one-shot: it builds once and exits. Nothing runs until you invoke it.
+
+## Output contract
+
+```
+$SHARED_DIR/<UTC-timestamp>/        e.g. 20260706T0210Z/
+   quarkus-app/                     jvm mode: the Quarkus fast-jar tree
+   application                      native mode: the *-runner binary (executable)
+   agent.yml                        the exact manifest that was built (provenance)
+   generate.log                     the qlawkus:generate output (capability report)
+   build.json                       { mode, timestamp, sourceGitSha, artifact, status,
+                                       resolvedCapabilities: { selected, excluded } }
+$SHARED_DIR/latest -> <UTC-timestamp>   symlink, flipped only on success
+```
+
+The publish is atomic: the build lands in a temp dir and is renamed into place, then
+`latest` is repointed, so a failed build never leaves `latest` on a partial build.
+`build.json` and `latest` are the seam #250 (reads status) and #251 (reads `latest`)
+build on: e.g. `JAVA_APP_JAR=$SHARED_DIR/latest/quarkus-app/quarkus-run.jar` (jvm) or
+`exec $SHARED_DIR/latest/application` (native).
+
+## Knobs (env)
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `STAGING_AGENT_YML` | _(unset)_ | Manifest to stage before building; unset builds the app's current `agent.yml` as-is. |
+| `SHARED_DIR` | `target/qlawkus-builds` | Output root for versioned builds. |
+| `BUILD_RETENTION` | `3` | Number of builds to keep; older ones are pruned on success. |
+| `MVN_CMD` | repo `mvnw` | Maven command; overridden by the contract test. |
+
+## Usage
+
+```bash
+# Build the current composition (JVM)
+builder/build.sh jvm
+
+# Rebuild from a staged manifest (native)
+STAGING_AGENT_YML=/path/to/agent.yml builder/build.sh native
+```
+
+## Tests
+
+- `test/build-sh-test.sh` - fast contract test. Stubs Maven, so it needs no real build;
+  covers the output layout, `build.json`, the `latest` symlink, retention, and the
+  atomicity guarantee on a failed build. Run it directly: `bash builder/test/build-sh-test.sh`.
+- `test/real-build-smoke.sh` - opt-in end-to-end smoke against the real reactor, proving
+  the manifest flows into the built artifact (not just the pom). Heavy (a full build,
+  minutes) and needs a warm local repo; see the header of that script.
+
+## Later (not in #248)
+
+Packaging this into published builder images (frozen reactor source + warm `.m2`), so a
+consumer can `docker pull` and rebuild without cloning the repo, is a deferred phase.
+Until then the runner uses the toolchain of wherever it is invoked, against the reactor
+it lives in.

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# builder/build.sh <jvm|native>
+#
+# Rebuilds the Qlawkus app from its composition manifest, on demand. Reconciles the
+# app pom from agent.yml (qlawkus:generate), runs the Quarkus build, and emits a
+# versioned artifact into SHARED_DIR alongside a build.json and an atomically
+# updated 'latest' pointer. One shot: it builds once and exits.
+#
+# Phase 1 (no Docker): runs with the toolchain of wherever it is invoked, against
+# the reactor it lives in. A later phase packages this into builder images. See
+# builder/README.md for the output contract.
+#
+# Knobs (env):
+#   STAGING_AGENT_YML  optional manifest to stage before building; when unset, the
+#                      app's current agent.yml is built as-is.
+#   SHARED_DIR         output root for versioned builds (default target/qlawkus-builds).
+#   BUILD_RETENTION    number of builds to keep; older ones are pruned (default 3).
+#   MVN_CMD            Maven command (default the repo mvnw); overridden by tests.
+set -euo pipefail
+
+usage() { echo "usage: build.sh <jvm|native>" >&2; exit 2; }
+log()   { echo "[builder] $*"; }
+fail()  { echo "[builder] ERROR: $*" >&2; exit 1; }
+
+# Reads capability names on stdin (one per line) and emits a JSON array.
+json_array_from() {
+  local first=1 out="["
+  local name
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if [[ $first -eq 1 ]]; then first=0; else out+=","; fi
+    out+="\"$name\""
+  done
+  out+="]"
+  printf '%s' "$out"
+}
+
+# Writes build.json into the given dir, parsing the resolved capability set from the
+# captured generate log (best-effort; the raw generate.log is kept alongside).
+write_build_json() {
+  local dir="$1" mode="$2" ts="$3" artifact="$4" glog="$5"
+  local sha selected excluded
+  sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  selected="$(sed -nE 's/^\[INFO\][[:space:]]+\+ ([^ ]+) \(.*/\1/p' "$glog" | json_array_from)"
+  excluded="$(sed -nE 's/^\[INFO\][[:space:]]+- ([^ ]+) \(.*/\1/p' "$glog" | json_array_from)"
+  cat > "$dir/build.json" <<JSON
+{
+  "mode": "$mode",
+  "timestamp": "$ts",
+  "sourceGitSha": "$sha",
+  "artifact": "$artifact",
+  "status": "success",
+  "resolvedCapabilities": {
+    "selected": $selected,
+    "excluded": $excluded
+  }
+}
+JSON
+}
+
+# Keeps the newest $keep timestamped build dirs, removing older ones. The 'latest'
+# symlink and any .staging-* dirs are never counted.
+prune_old_builds() {
+  local dir="$1" keep="$2"
+  local builds b i=0
+  mapfile -t builds < <(find "$dir" -mindepth 1 -maxdepth 1 -type d -name '2*' | sort -r)
+  for b in "${builds[@]}"; do
+    i=$((i + 1))
+    if (( i > keep )); then
+      rm -rf "$b"
+      log "pruned old build $(basename "$b")"
+    fi
+  done
+}
+
+MODE="${1:-}"
+case "$MODE" in
+  jvm|native) ;;
+  *) usage ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+STAGING_AGENT_YML="${STAGING_AGENT_YML:-}"
+SHARED_DIR="${SHARED_DIR:-$REPO_ROOT/target/qlawkus-builds}"
+BUILD_RETENTION="${BUILD_RETENTION:-3}"
+MVN_CMD="${MVN_CMD:-$REPO_ROOT/mvnw}"
+APP_MANIFEST="$REPO_ROOT/app/src/main/resources/qlawkus/agent.yml"
+
+# 1. Stage the manifest (optional override; default builds what the app already declares).
+if [[ -n "$STAGING_AGENT_YML" ]]; then
+  [[ -f "$STAGING_AGENT_YML" ]] || fail "staged agent.yml not found: $STAGING_AGENT_YML"
+  mkdir -p "$(dirname "$APP_MANIFEST")"
+  cp "$STAGING_AGENT_YML" "$APP_MANIFEST"
+  log "staged manifest from $STAGING_AGENT_YML"
+fi
+
+cd "$REPO_ROOT"
+
+# 2. Reconcile the app pom from the manifest by running the generate-sources phase:
+#    the app pom binds qlawkus:generate there, so this is the same seam dev mode uses
+#    (a plugin-prefix goal would not resolve from the root reactor). The reactor is
+#    visible via -am so ${reactorProjects} populates the catalog. Captured for build.json.
+generate_log="$(mktemp)"
+trap 'rm -f "$generate_log"' EXIT
+log "reconciling app pom from manifest (generate-sources)"
+"$MVN_CMD" -B -e -pl app -am generate-sources | tee "$generate_log"
+
+# 3. Build. A FRESH Maven session, so it reads the pom that step 2 just rewrote.
+native_flags=()
+[[ "$MODE" == native ]] && native_flags=(-Pnative)
+log "building app ($MODE)"
+"$MVN_CMD" -B -e -pl app -am -DskipTests -DskipITs "${native_flags[@]}" package
+
+# 4. Emit the artifact atomically into a timestamped dir, then flip 'latest'.
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+staging_out="$SHARED_DIR/.staging-$ts"
+final_out="$SHARED_DIR/$ts"
+rm -rf "$staging_out"
+mkdir -p "$staging_out"
+
+if [[ "$MODE" == jvm ]]; then
+  [[ -d app/target/quarkus-app ]] || fail "jvm build output app/target/quarkus-app not found"
+  cp -r app/target/quarkus-app "$staging_out/quarkus-app"
+  artifact_rel="quarkus-app/quarkus-run.jar"
+else
+  runner="$(find app/target -maxdepth 1 -type f -name '*-runner' | head -n1)"
+  [[ -n "$runner" ]] || fail "native build output app/target/*-runner not found"
+  cp "$runner" "$staging_out/application"
+  chmod +x "$staging_out/application"
+  artifact_rel="application"
+fi
+
+# The manifest is optional (no agent.yml means the pom is built as-is); capture it
+# for provenance only when present.
+[[ -f "$APP_MANIFEST" ]] && cp "$APP_MANIFEST" "$staging_out/agent.yml"
+cp "$generate_log" "$staging_out/generate.log"
+write_build_json "$staging_out" "$MODE" "$ts" "$artifact_rel" "$generate_log"
+
+# Atomic publish: move the complete dir into place, then repoint 'latest'. A build
+# that failed above never reaches here, so 'latest' always names a complete build.
+mv "$staging_out" "$final_out"
+ln -sfn "$ts" "$SHARED_DIR/latest"
+log "published $final_out"
+log "latest -> $ts"
+
+prune_old_builds "$SHARED_DIR" "$BUILD_RETENTION"
+log "done ($MODE)"

--- a/builder/test/build-sh-test.sh
+++ b/builder/test/build-sh-test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Contract test for builder/build.sh. Exercises the runner's orchestration and
+# output contract with a stub Maven, so it is fast and needs no real build:
+#   - jvm happy path: versioned dir, quarkus-app copied, build.json, latest symlink
+#   - native happy path: the *-runner binary emitted as 'application'
+#   - retention: only BUILD_RETENTION builds kept
+#   - atomicity: a failed build leaves 'latest' untouched
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_BUILD_SH="$THIS_DIR/../build.sh"
+fails=0
+
+pass() { echo "  PASS: $*"; }
+check() { if eval "$2"; then pass "$1"; else echo "  FAIL: $1"; fails=$((fails + 1)); fi; }
+
+# Builds a throwaway fake repo: build.sh at <root>/builder/build.sh so it derives
+# REPO_ROOT=<root>, plus a stub mvnw and a seed manifest.
+setup_fake_repo() {
+  local root="$1"
+  mkdir -p "$root/builder" "$root/app/src/main/resources/qlawkus"
+  cp "$REAL_BUILD_SH" "$root/builder/build.sh"
+  echo "version: 1" > "$root/app/src/main/resources/qlawkus/agent.yml"
+  cat > "$root/mvnw" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+if [[ "$args" == *"generate-sources"* ]]; then
+  echo "[INFO] Resolved capability set from agent.yml"
+  echo "[INFO]   1 selected, 1 excluded"
+  echo "[INFO]   + messaging.discord (dev.omatheusmesmo:qlawkus-messaging-discord)"
+  echo "[INFO]   - cognition.pgvector (dev.omatheusmesmo:qlawkus-cognition-pgvector)"
+  exit 0
+fi
+if [[ "$args" == *"package"* ]]; then
+  [[ "${FAKE_PACKAGE_FAIL:-0}" == "1" ]] && { echo "[ERROR] simulated failure" >&2; exit 1; }
+  if [[ "$args" == *"-Pnative"* ]]; then
+    mkdir -p app/target; echo bin > app/target/app-runner
+  else
+    mkdir -p app/target/quarkus-app/lib; echo jar > app/target/quarkus-app/quarkus-run.jar
+  fi
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$root/mvnw"
+}
+
+echo "== jvm happy path =="
+root="$(mktemp -d)"; setup_fake_repo "$root"
+out="$root/out"
+SHARED_DIR="$out" MVN_CMD="$root/mvnw" bash "$root/builder/build.sh" jvm >/dev/null
+ts_dir="$(find "$out" -mindepth 1 -maxdepth 1 -type d -name '2*' | head -n1)"
+check "a versioned build dir is created"          "[[ -n '$ts_dir' ]]"
+check "quarkus-app tree is copied"                "[[ -f '$ts_dir/quarkus-app/quarkus-run.jar' ]]"
+check "the used manifest is captured"             "[[ -f '$ts_dir/agent.yml' ]]"
+check "the generate log is captured"              "[[ -f '$ts_dir/generate.log' ]]"
+check "build.json exists"                         "[[ -f '$ts_dir/build.json' ]]"
+check "build.json records mode jvm"               "grep -q '\"mode\": \"jvm\"' '$ts_dir/build.json'"
+check "build.json records success"                "grep -q '\"status\": \"success\"' '$ts_dir/build.json'"
+check "build.json parses selected capability"     "grep -q 'messaging.discord' '$ts_dir/build.json'"
+check "build.json parses excluded capability"     "grep -q 'cognition.pgvector' '$ts_dir/build.json'"
+check "latest symlink points at the build"        "[[ \"\$(readlink '$out/latest')\" == \"\$(basename '$ts_dir')\" ]]"
+rm -rf "$root"
+
+echo "== no manifest (optional agent.yml absent) =="
+root="$(mktemp -d)"; setup_fake_repo "$root"
+rm -f "$root/app/src/main/resources/qlawkus/agent.yml"
+out="$root/out"
+SHARED_DIR="$out" MVN_CMD="$root/mvnw" bash "$root/builder/build.sh" jvm >/dev/null
+ts_dir="$(find "$out" -mindepth 1 -maxdepth 1 -type d -name '2*' | head -n1)"
+check "build publishes even with no manifest"     "[[ -n '$ts_dir' && -f '$ts_dir/build.json' ]]"
+check "latest is set with no manifest"            "[[ -n \"\$(readlink '$out/latest')\" ]]"
+check "no agent.yml captured when absent"         "[[ ! -f '$ts_dir/agent.yml' ]]"
+rm -rf "$root"
+
+echo "== native happy path =="
+root="$(mktemp -d)"; setup_fake_repo "$root"
+out="$root/out"
+SHARED_DIR="$out" MVN_CMD="$root/mvnw" bash "$root/builder/build.sh" native >/dev/null
+ts_dir="$(find "$out" -mindepth 1 -maxdepth 1 -type d -name '2*' | head -n1)"
+check "native emits the runner as application"    "[[ -f '$ts_dir/application' ]]"
+check "the application binary is executable"      "[[ -x '$ts_dir/application' ]]"
+check "build.json records mode native"            "grep -q '\"mode\": \"native\"' '$ts_dir/build.json'"
+rm -rf "$root"
+
+echo "== retention =="
+root="$(mktemp -d)"; setup_fake_repo "$root"
+out="$root/out"; mkdir -p "$out/20200101T000000Z" "$out/20200102T000000Z"
+SHARED_DIR="$out" BUILD_RETENTION=2 MVN_CMD="$root/mvnw" bash "$root/builder/build.sh" jvm >/dev/null
+kept="$(find "$out" -mindepth 1 -maxdepth 1 -type d -name '2*' | wc -l)"
+check "retention keeps only BUILD_RETENTION dirs" "[[ '$kept' -eq 2 ]]"
+check "the oldest build is pruned"                "[[ ! -d '$out/20200101T000000Z' ]]"
+check "a kept newer build survives"               "[[ -d '$out/20200102T000000Z' ]]"
+rm -rf "$root"
+
+echo "== atomicity: failed build leaves latest untouched =="
+root="$(mktemp -d)"; setup_fake_repo "$root"
+out="$root/out"; mkdir -p "$out/20200102T000000Z"; ln -sfn "20200102T000000Z" "$out/latest"
+set +e
+SHARED_DIR="$out" MVN_CMD="$root/mvnw" FAKE_PACKAGE_FAIL=1 bash "$root/builder/build.sh" jvm >/dev/null 2>&1
+rc=$?
+set -e
+check "build.sh exits non-zero on build failure"  "[[ '$rc' -ne 0 ]]"
+check "latest still points at the prior build"    "[[ \"\$(readlink '$out/latest')\" == '20200102T000000Z' ]]"
+check "no new versioned dir was published"        "[[ \"\$(find '$out' -mindepth 1 -maxdepth 1 -type d -name '2*' | wc -l)\" -eq 1 ]]"
+rm -rf "$root"
+
+echo
+if [[ "$fails" -eq 0 ]]; then
+  echo "ALL PASSED"
+else
+  echo "$fails CHECK(S) FAILED"; exit 1
+fi

--- a/builder/test/real-build-smoke.sh
+++ b/builder/test/real-build-smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke for builder/build.sh against the REAL reactor: proves that the
+# composition manifest flows all the way into the built artifact (not just the pom).
+# A single-session `mvn package` cannot show this - the generator rewrites the pom
+# on disk after the model is resolved - which is exactly why build.sh runs generate
+# and package as two Maven sessions. This smoke exercises that path for real.
+#
+# Opt-in and heavy (a full JVM reactor build, minutes). Same tier as the native ITs.
+# Prerequisite: a warm local repo, so qlawkus:generate resolves the plugin and the
+# reactor's *-deployment modules resolve. From the repo root:
+#
+#   mvn install -DskipTests -DskipITs
+#   STAGING_AGENT_YML=path/to/agent.yml \
+#     EXPECT_PRESENT_JAR=qlawkus-client \
+#     EXPECT_ABSENT_JAR=qlawkus-cognition-pgvector \
+#     builder/test/real-build-smoke.sh
+#
+# EXPECT_PRESENT_JAR / EXPECT_ABSENT_JAR are jar name prefixes checked against the
+# emitted quarkus-app/lib, matched to whatever the staged manifest selects.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR/../.." && pwd)"
+SHARED_DIR="${SHARED_DIR:-$REPO_ROOT/target/qlawkus-builds}"
+export SHARED_DIR
+
+: "${EXPECT_PRESENT_JAR:?set EXPECT_PRESENT_JAR to a jar prefix that must be present}"
+: "${EXPECT_ABSENT_JAR:?set EXPECT_ABSENT_JAR to a jar prefix that must be absent}"
+
+echo "[smoke] running the real jvm build via build.sh (this takes minutes)"
+bash "$REPO_ROOT/builder/build.sh" jvm
+
+lib="$SHARED_DIR/latest/quarkus-app/lib"
+[[ -d "$lib" ]] || { echo "[smoke] FAIL: $lib not found"; exit 1; }
+
+fails=0
+if find "$lib" -name "${EXPECT_PRESENT_JAR}*.jar" | grep -q .; then
+  echo "[smoke] PASS: selected capability jar ${EXPECT_PRESENT_JAR}* is present"
+else
+  echo "[smoke] FAIL: expected ${EXPECT_PRESENT_JAR}* in the artifact"; fails=$((fails + 1))
+fi
+if find "$lib" -name "${EXPECT_ABSENT_JAR}*.jar" | grep -q .; then
+  echo "[smoke] FAIL: deselected capability jar ${EXPECT_ABSENT_JAR}* leaked into the artifact"; fails=$((fails + 1))
+else
+  echo "[smoke] PASS: deselected capability jar ${EXPECT_ABSENT_JAR}* is absent"
+fi
+
+[[ "$fails" -eq 0 ]] && echo "[smoke] ALL PASSED" || { echo "[smoke] $fails FAILED"; exit 1; }


### PR DESCRIPTION
Foundation of the M8 build-and-redeploy control loop (trilha E). The running app cannot rebuild itself (a native binary is frozen, a JVM app is closed-world augmented at build time, and the runtime image ships no toolchain), so a builder with the toolchain rebuilds on its behalf, on demand, from the composition manifest.

## What it does

`builder/build.sh <jvm|native>`:
1. Optionally stages a manifest (`STAGING_AGENT_YML`) into the app's `agent.yml`.
2. Reconciles the app pom by running the `generate-sources` phase (the app pom binds `qlawkus:generate` there, the same seam dev mode uses; a plugin-prefix goal would not resolve from the root reactor).
3. Runs the Quarkus build in a **fresh** Maven session so it reads the regenerated pom.
4. Emits the artifact under `SHARED_DIR/<ts>/` with `build.json`, `generate.log`, the used `agent.yml`, and an atomically flipped `latest` pointer. Retention-bounded. One-shot: builds once and exits.

The two Maven sessions are deliberate: `generate` rewrites `pom.xml` on disk after Maven resolved the session model, so the build must run in a new session to pick up the new dependency set. The atomic publish (build in a temp dir, rename, then flip `latest`) guarantees `latest` never points at a partial build.

## Tests

- `builder/test/build-sh-test.sh` — fast contract test with a stubbed Maven: output layout, `build.json` (incl. capability-report parsing), `latest`, retention, atomicity on a failed build, and the no-manifest case. 22/22.
- `builder/test/real-build-smoke.sh` — opt-in heavy E2E proving the manifest flows into the built artifact (two real Maven sessions).
- Validated with a real `build.sh jvm` against the reactor: exit 0, a complete `quarkus-app` emitted, and tracked files left untouched.

## Out of scope (follow-ups)

- #250 — authenticated trigger endpoint + status (reads `build.json`).
- #251 — restart contract; the runtime running from the mounted `latest` artifact.
- Docker packaging + published builder images (frozen source + warm `.m2`) for clone-free consumers: a deferred phase.

Closes #248.