### PR TITLE
Restart contract and reference implementations for the redeploy loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,10 @@ QLAWKUS_VAULT_PASSPHRASE=
 
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_ALLOWED_USER_IDS=
+
+# Admin credential (Argon2id PHC hash) for the @Authenticated admin endpoints.
+# Replaces the removed API_USER_PASSWORD. Username defaults to "qlawkus"
+# (override with QLAWKUS_ADMIN_USERNAME). Generate a hash for your password:
+#   printf '%s' 'your-password' | argon2 "$(openssl rand -hex 8)" -id -e -t 2 -m 16 -p 1
+# Or store it in the keystore alias qlawkus.admin.password-hash.
+QLAWKUS_ADMIN_PASSWORD_HASH=

--- a/docs/modules/ROOT/pages/composition.adoc
+++ b/docs/modules/ROOT/pages/composition.adoc
@@ -138,6 +138,36 @@ The running app cannot rebuild itself: a native binary is frozen, a JVM app is c
 
 All three require authentication. The staged manifest lives in the app's own state (`qlawkus.agent.state.root`), not a shared volume: the seam to whatever rebuilds and rolls out the new image is this API, read over HTTP, rather than a filesystem both containers mount.
 
+== The restart contract
+
+Staging a manifest records intent; it never rebuilds. Closing the loop - turning a staged manifest into a running instance with the new capability set - is a rebuild and a restart driven from *outside* the app, because the app cannot rebuild or restart itself (a native binary is frozen, a JVM app is closed-world augmented at build time, and the runtime image ships no toolchain).
+
+Qlawkus defines that as a five-phase contract and ships reference implementations under `examples/redeploy/`. It is never a hard dependency: the consuming environment wires the actual mechanism.
+
+[cols="1,4"]
+|===
+|Phase |What happens
+
+|1. fetch |Read the staged manifest over `GET /api/admin/composition`.
+|2. promote |Write it into the source tree the builder reads (`app/src/main/resources/qlawkus/agent.yml`).
+|3. build |Regenerate the pom from the manifest (`qlawkus:generate`) and build the artifact.
+|4. restart |Swap the running instance onto the new artifact.
+|5. verify |Wait for health, then discard the consumed staged manifest (`DELETE`).
+|===
+
+The app stays passive: it only fetches (`GET`) and discards (`DELETE`); everything that executes a build or a restart lives in the redeploy tooling, never in the app. Phases 1, 2 and 5 are the environment-independent hook (`examples/redeploy/redeploy.sh`); phases 3 and 4 are the parts each reference implementation fills in:
+
+[cols="1,4"]
+|===
+|Environment |Build + restart step
+
+|docker-compose |`docker compose up -d --build --force-recreate --no-deps qlawkus` - build and recreate in one step (mirrors `run.sh restart`, standalone).
+|Kubernetes |Build and push an image, then `kubectl set image` + `kubectl rollout status` (the readiness probe gates the swap).
+|systemd |Package on the host, then `systemctl restart qlawkus`.
+|===
+
+Because the staged manifest lives inside the app's own state and is read back over the API, the redeploy tooling - not the app - is what promotes it into the source before a build. If nothing is staged, a redeploy simply rebuilds the currently committed manifest, so it is safe to run in CI on every deploy.
+
 == Capabilities and where they come from
 
 The catalog of capability names is not a central list. Each extension module *self-describes*: it declares its capability name in its own `quarkus-extension.yaml` under `metadata.qlawkus.capability`. The generator reads that key from every module in the build, so adding a new capability is just a matter of shipping a module that announces one - no central vocabulary to edit.

--- a/examples/redeploy/README.md
+++ b/examples/redeploy/README.md
@@ -1,0 +1,65 @@
+# Redeploy contract - reference implementations
+
+The running agent cannot rebuild or restart itself (a native binary is frozen, a JVM app
+is closed-world augmented at build time, and the runtime image ships no toolchain).
+Swapping a capability set in or out is therefore a **rebuild-and-redeploy** driven from
+outside the app. These files are the reference implementations of that flow; the app only
+stages a validated manifest and exposes it (see the composition admin endpoint), never
+building or restarting anything itself.
+
+## The 5-phase contract
+
+1. **fetch** - read the staged manifest over the authenticated composition API (`GET`).
+2. **promote** - write it into the source tree the builder reads (`app/src/main/resources/qlawkus/agent.yml`).
+3. **build** - regenerate the pom from the manifest and build the artifact.
+4. **restart** - swap the running instance onto the new artifact.
+5. **verify** - wait for health, then discard the consumed staged manifest (`DELETE`).
+
+`redeploy.sh` is the environment-independent driver (phases 1, 2, 5). Each implementation
+supplies phases 3 and 4 by defining `build` and `restart`, then sourcing it.
+
+## Prerequisites
+
+- `curl` and `jq` on the machine running the redeploy (it talks to the composition API).
+- The **builder** side needs the toolchain (JDK + Maven, or GraalVM/Mandrel for native).
+  With compose/k8s the toolchain lives in the multi-stage Docker build; with systemd it is
+  the host itself.
+- Admin credentials for the composition API, as `QLAWKUS_ADMIN_USER` / `QLAWKUS_ADMIN_PASSWORD`.
+
+## Running (from the repository root)
+
+```bash
+export QLAWKUS_ADMIN_USER=... QLAWKUS_ADMIN_PASSWORD=...
+
+# docker-compose: build + recreate the app container in one step
+examples/redeploy/compose/redeploy.sh
+
+# kubernetes: build+push an image, then roll the Deployment onto it
+IMAGE=ghcr.io/you/qlawkus:$(git rev-parse --short HEAD) \
+  QLAWKUS_HEALTH_URL=https://qlawkus.example/q/health/ready \
+  examples/redeploy/k8s/rollout.sh
+
+# systemd: package on the host, then restart the unit
+examples/redeploy/systemd/restart.sh
+```
+
+Nothing here depends on `run.sh`; the compose recipe mirrors its restart step standalone.
+
+## Configuration (environment variables)
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `QLAWKUS_BASE_URL` | `http://localhost:8742` | Base URL of the running agent |
+| `QLAWKUS_ADMIN_USER` / `QLAWKUS_ADMIN_PASSWORD` | (required) | Composition API credentials |
+| `QLAWKUS_SOURCE_MANIFEST` | `app/src/main/resources/qlawkus/agent.yml` | Where promotion writes the manifest |
+| `QLAWKUS_HEALTH_URL` | `${BASE_URL}/q/health/ready` | Readiness endpoint polled in phase 5 |
+| `QLAWKUS_HEALTH_TIMEOUT` | `180` | Seconds to wait for health |
+| `QLAWKUS_DRY_RUN` | `0` | `1` stops after promotion (no build/restart/discard) |
+
+Per-implementation knobs are documented in each script's header (`QLAWKUS_COMPOSE_SERVICE`,
+`IMAGE` / `QLAWKUS_K8S_DEPLOYMENT`, `QLAWKUS_SYSTEMD_UNIT`).
+
+## When there is no staged manifest
+
+If `GET` shows no staged manifest, the redeploy rebuilds the currently committed one (a
+plain no-op promotion). This is safe to run in CI on every deploy.

--- a/examples/redeploy/compose/redeploy.sh
+++ b/examples/redeploy/compose/redeploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Reference implementation: docker-compose.
+#
+# Compose rebuilds and recreates the app container in one step, so `build` is a no-op
+# and `restart` does both via `up -d --build`. The multi-stage Dockerfile.jvm-build
+# runs `qlawkus:generate` inside the build stage, so the promoted agent.yml decides the
+# new capability set. Native: point SERVICE at qlawkus-native and add `--profile native`.
+#
+# Run from the repository root (compose needs docker-compose.yml; promotion writes the
+# source agent.yml):
+#   QLAWKUS_ADMIN_USER=... QLAWKUS_ADMIN_PASSWORD=... examples/redeploy/compose/redeploy.sh
+#
+set -euo pipefail
+
+SERVICE="${QLAWKUS_COMPOSE_SERVICE:-qlawkus}"
+COMPOSE_FILE="${QLAWKUS_COMPOSE_FILE:-docker-compose.yml}"
+
+build() { :; }
+
+restart() {
+  docker compose -f "${COMPOSE_FILE}" up -d --build --force-recreate --no-deps "${SERVICE}"
+}
+
+# shellcheck source=../redeploy.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../redeploy.sh"
+redeploy_run

--- a/examples/redeploy/k8s/deployment.yaml
+++ b/examples/redeploy/k8s/deployment.yaml
@@ -1,0 +1,61 @@
+# Reference Deployment for the Qlawkus redeploy contract.
+#
+# A redeploy rolls this Deployment onto a freshly built image (built from the promoted
+# agent.yml). The readiness probe is what lets the rollout swap pods safely - it gates
+# phase 5 (verify) without the redeploy script needing to reach the pod directly.
+#
+# The probe below uses tcpSocket so it works with no extra extension. If the app bundles
+# quarkus-smallrye-health, prefer the httpGet form (commented) for a real readiness signal.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qlawkus
+  labels:
+    app: qlawkus
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: qlawkus
+  template:
+    metadata:
+      labels:
+        app: qlawkus
+    spec:
+      containers:
+        - name: qlawkus
+          # Replaced per redeploy by `kubectl set image` (see rollout.sh).
+          image: ghcr.io/omatheusmesmo/qlawkus:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: QLAWKUS_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: qlawkus-admin
+                  key: user
+            - name: QLAWKUS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: qlawkus-admin
+                  key: password
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            # httpGet:               # with quarkus-smallrye-health on the classpath
+            #   path: /q/health/ready
+            #   port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          volumeMounts:
+            - name: state
+              mountPath: /home/jboss/.qlawkus
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: qlawkus-state

--- a/examples/redeploy/k8s/rollout.sh
+++ b/examples/redeploy/k8s/rollout.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Reference implementation: Kubernetes.
+#
+# build   - build and push a new image from the promoted agent.yml
+# restart - point the Deployment at that image and wait for the rollout
+#
+# The Deployment's readiness probe gates the rollout, so `kubectl rollout status` is the
+# authoritative health gate here; set QLAWKUS_HEALTH_URL to an in-cluster or ingress URL
+# only if you also want the generic health poll.
+#
+# Run from the repository root:
+#   IMAGE=ghcr.io/you/qlawkus:$(git rev-parse --short HEAD) \
+#   QLAWKUS_ADMIN_USER=... QLAWKUS_ADMIN_PASSWORD=... QLAWKUS_HEALTH_URL=https://qlawkus.example/q/health/ready \
+#   examples/redeploy/k8s/rollout.sh
+#
+set -euo pipefail
+
+IMAGE="${IMAGE:?set IMAGE to the new tag to build and roll out}"
+DEPLOYMENT="${QLAWKUS_K8S_DEPLOYMENT:-qlawkus}"
+DOCKERFILE="${QLAWKUS_DOCKERFILE:-app/src/main/docker/Dockerfile.jvm-build}"
+
+build() {
+  docker build -f "${DOCKERFILE}" -t "${IMAGE}" .
+  docker push "${IMAGE}"
+}
+
+restart() {
+  kubectl set image "deployment/${DEPLOYMENT}" "${DEPLOYMENT}=${IMAGE}"
+  kubectl rollout status "deployment/${DEPLOYMENT}"
+}
+
+# shellcheck source=../redeploy.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../redeploy.sh"
+redeploy_run

--- a/examples/redeploy/redeploy.sh
+++ b/examples/redeploy/redeploy.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Qlawkus redeploy contract - the generic hook.
+#
+# The running agent cannot rebuild or restart itself: a native binary is frozen,
+# a JVM app is closed-world augmented at build time, and the runtime image ships
+# no toolchain. So composing a new capability set in or out is a rebuild-and-redeploy
+# driven from OUTSIDE the app. This script is the environment-independent part of
+# that flow; each reference implementation (compose/, k8s/, systemd/) supplies the
+# two environment-specific steps by defining `build` and `restart` before sourcing it.
+#
+# The 5-phase contract:
+#   1. fetch    - read the staged manifest over the authenticated composition API
+#   2. promote  - write it into the source tree the builder reads (agent.yml)
+#   3. build    - regenerate the pom from the manifest and build (caller-provided)
+#   4. restart  - swap the running instance onto the new artifact (caller-provided)
+#   5. verify   - wait for health, confirm the new active manifest, discard the staged one
+#
+# The app is passive: it only fetches (GET), and discards (DELETE). Everything that
+# executes a build or a restart lives here or in the caller, never in the app - so a
+# leaked admin credential can at most stage a validated manifest, never run a command.
+#
+# Usage (standalone, rebuilds the currently committed manifest, no promotion):
+#   QLAWKUS_ADMIN_USER=... QLAWKUS_ADMIN_PASSWORD=... ./redeploy.sh
+# Usage (from a reference implementation):
+#   define build() and restart(), then `source redeploy.sh` and call `redeploy_run`.
+#
+set -euo pipefail
+
+BASE_URL="${QLAWKUS_BASE_URL:-http://localhost:8742}"
+API="${BASE_URL}/api/admin/composition"
+AUTH_USER="${QLAWKUS_ADMIN_USER:?set QLAWKUS_ADMIN_USER}"
+AUTH_PASS="${QLAWKUS_ADMIN_PASSWORD:?set QLAWKUS_ADMIN_PASSWORD}"
+SOURCE_MANIFEST="${QLAWKUS_SOURCE_MANIFEST:-app/src/main/resources/qlawkus/agent.yml}"
+HEALTH_URL="${QLAWKUS_HEALTH_URL:-${BASE_URL}/q/health/ready}"
+HEALTH_TIMEOUT="${QLAWKUS_HEALTH_TIMEOUT:-180}"
+DRY_RUN="${QLAWKUS_DRY_RUN:-0}"
+
+log() { printf '[redeploy] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+curl_api() {
+  curl -fsS --user "${AUTH_USER}:${AUTH_PASS}" "$@"
+}
+
+# Phase 1: fetch the staged manifest. Prints it on stdout, or nothing if none is staged.
+fetch_staged() {
+  local body
+  body="$(curl_api "${API}")" || die "cannot reach the composition API at ${API}"
+  jq -er '.staged // empty' <<<"${body}"
+}
+
+# Phase 2: promote the staged manifest into the source tree the builder reads.
+promote() {
+  local staged="$1"
+  [ -f "${SOURCE_MANIFEST}" ] || die "source manifest not found: ${SOURCE_MANIFEST} (run from the repo root)"
+  printf '%s\n' "${staged}" >"${SOURCE_MANIFEST}"
+  log "promoted staged manifest into ${SOURCE_MANIFEST}"
+}
+
+# Default build/restart hooks. A reference implementation defines its own BEFORE sourcing
+# this file; the `declare -F` guards mean sourcing never clobbers a caller's definition
+# (otherwise these no-ops would silently win and the redeploy would skip build and restart).
+# So these apply only to a standalone run, which supplies neither.
+declare -F build >/dev/null 2>&1 || build() { log "no build step defined; skipping (define build() in a reference implementation)"; }
+declare -F restart >/dev/null 2>&1 || restart() { log "no restart step defined; skipping (define restart() in a reference implementation)"; }
+
+# Phase 5a: wait for the new instance to report ready.
+wait_for_health() {
+  log "waiting for ${HEALTH_URL} (timeout ${HEALTH_TIMEOUT}s)"
+  local waited=0
+  until curl -fsS -o /dev/null "${HEALTH_URL}"; do
+    waited=$((waited + 3))
+    [ "${waited}" -lt "${HEALTH_TIMEOUT}" ] || die "instance did not become healthy within ${HEALTH_TIMEOUT}s"
+    sleep 3
+  done
+  log "instance is healthy"
+}
+
+# Phase 5b: discard the staged manifest once the new instance is live.
+discard_staged() {
+  curl_api -X DELETE "${API}/manifest" -o /dev/null -w '%{http_code}' \
+    | grep -qE '^(204|404)$' && log "discarded the consumed staged manifest" \
+    || log "WARN: could not discard the staged manifest (leave it for a retry)"
+}
+
+redeploy_run() {
+  local staged
+  staged="$(fetch_staged)"
+
+  if [ -z "${staged}" ]; then
+    log "no staged manifest; rebuilding the currently committed one"
+  else
+    promote "${staged}"
+  fi
+
+  if [ "${DRY_RUN}" = "1" ]; then
+    log "dry run: stopping after promotion (no build, restart, or discard)"
+    return 0
+  fi
+
+  log "phase 3: build"
+  build
+  log "phase 4: restart"
+  restart
+  wait_for_health
+  [ -n "${staged}" ] && discard_staged
+  log "redeploy complete"
+}
+
+# Run directly only when executed, not when sourced by a reference implementation.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  redeploy_run
+fi

--- a/examples/redeploy/systemd/qlawkus.service
+++ b/examples/redeploy/systemd/qlawkus.service
@@ -1,0 +1,23 @@
+# Reference systemd unit for the Qlawkus redeploy contract.
+#
+# Runs the fast-jar produced by the JVM build. For a native build, set ExecStart to the
+# binary (app/target/*-runner) and drop the `java -jar` wrapper. Admin credentials and
+# LLM keys come from the EnvironmentFile, never the unit itself.
+#
+# Install: copy to /etc/systemd/system/qlawkus.service, then `systemctl daemon-reload`.
+[Unit]
+Description=Qlawkus agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=qlawkus
+WorkingDirectory=/opt/qlawkus
+EnvironmentFile=/etc/qlawkus/qlawkus.env
+ExecStart=/usr/bin/java -jar /opt/qlawkus/app/target/quarkus-app/quarkus-run.jar
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/redeploy/systemd/restart.sh
+++ b/examples/redeploy/systemd/restart.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Reference implementation: systemd (host toolchain).
+#
+# build   - regenerate the pom from the promoted agent.yml and package the app on the host
+# restart - restart the unit onto the freshly built artifact
+#
+# Unlike compose/k8s, the build runs on the host that also runs the service, so the toolchain
+# (JDK + Maven, or GraalVM for native) must be present. Deploy the built artifact to the unit's
+# WorkingDirectory if it differs from the build checkout.
+#
+# Run from the repository root:
+#   QLAWKUS_ADMIN_USER=... QLAWKUS_ADMIN_PASSWORD=... examples/redeploy/systemd/restart.sh
+#
+set -euo pipefail
+
+UNIT="${QLAWKUS_SYSTEMD_UNIT:-qlawkus}"
+MVN="${QLAWKUS_MVN:-./mvnw}"
+
+build() {
+  "${MVN}" -q -pl app -am clean package -DskipTests
+}
+
+restart() {
+  sudo systemctl restart "${UNIT}"
+}
+
+# shellcheck source=../redeploy.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../redeploy.sh"
+redeploy_run

--- a/site/content/composition.adoc
+++ b/site/content/composition.adoc
@@ -138,6 +138,36 @@ The running app cannot rebuild itself: a native binary is frozen, a JVM app is c
 
 All three require authentication. The staged manifest lives in the app's own state (`qlawkus.agent.state.root`), not a shared volume: the seam to whatever rebuilds and rolls out the new image is this API, read over HTTP, rather than a filesystem both containers mount.
 
+== The restart contract
+
+Staging a manifest records intent; it never rebuilds. Closing the loop - turning a staged manifest into a running instance with the new capability set - is a rebuild and a restart driven from *outside* the app, because the app cannot rebuild or restart itself (a native binary is frozen, a JVM app is closed-world augmented at build time, and the runtime image ships no toolchain).
+
+Qlawkus defines that as a five-phase contract and ships reference implementations under `examples/redeploy/`. It is never a hard dependency: the consuming environment wires the actual mechanism.
+
+[cols="1,4"]
+|===
+|Phase |What happens
+
+|1. fetch |Read the staged manifest over `GET /api/admin/composition`.
+|2. promote |Write it into the source tree the builder reads (`app/src/main/resources/qlawkus/agent.yml`).
+|3. build |Regenerate the pom from the manifest (`qlawkus:generate`) and build the artifact.
+|4. restart |Swap the running instance onto the new artifact.
+|5. verify |Wait for health, then discard the consumed staged manifest (`DELETE`).
+|===
+
+The app stays passive: it only fetches (`GET`) and discards (`DELETE`); everything that executes a build or a restart lives in the redeploy tooling, never in the app. Phases 1, 2 and 5 are the environment-independent hook (`examples/redeploy/redeploy.sh`); phases 3 and 4 are the parts each reference implementation fills in:
+
+[cols="1,4"]
+|===
+|Environment |Build + restart step
+
+|docker-compose |`docker compose up -d --build --force-recreate --no-deps qlawkus` - build and recreate in one step (mirrors `run.sh restart`, standalone).
+|Kubernetes |Build and push an image, then `kubectl set image` + `kubectl rollout status` (the readiness probe gates the swap).
+|systemd |Package on the host, then `systemctl restart qlawkus`.
+|===
+
+Because the staged manifest lives inside the app's own state and is read back over the API, the redeploy tooling - not the app - is what promotes it into the source before a build. If nothing is staged, a redeploy simply rebuilds the currently committed manifest, so it is safe to run in CI on every deploy.
+
 == Capabilities and where they come from
 
 The catalog of capability names is not a central list. Each extension module *self-describes*: it declares its capability name in its own `quarkus-extension.yaml` under `metadata.qlawkus.capability`. The generator reads that key from every module in the build, so adding a new capability is just a matter of shipping a module that announces one - no central vocabulary to edit.


### PR DESCRIPTION
Closes the build-and-redeploy control loop (Sub-project 2). The builder and the stage/status endpoint already exist; this adds the final link - how an external orchestrator swaps the running instance onto a freshly built artifact.

The app cannot rebuild or restart itself (native binary frozen, JVM closed-world, runtime image toolchain-free), so this link is external by construction: a documented contract plus reference implementations, never a hard dependency (honors "nothing depends on `run.sh`"). No app/client/extension code changes.

## The five-phase contract

The app stays passive, providing only fetch (`GET`) and discard (`DELETE`):

1. **fetch** - read the staged manifest over `GET /api/admin/composition`
2. **promote** - write it into the source tree the builder reads (`app/src/main/resources/qlawkus/agent.yml`)
3. **build** - regenerate the pom from the manifest and build
4. **restart** - swap the running instance onto the new artifact
5. **verify** - wait for health, then discard the consumed staged manifest

The promotion phase is the crux: the endpoint only records intent (a staged `agent.yml` in the app's state), while the builder reads the committed source, so the redeploy tooling - not the app - bridges the two before a build.

## Deliverable

- `examples/redeploy/redeploy.sh` - the environment-independent hook (fetch/promote/verify). Default build/restart hooks are guarded with `declare -F` so sourcing never clobbers a caller's definitions.
- `examples/redeploy/compose/` - `docker compose up -d --build --force-recreate` (mirrors `run.sh restart`, standalone)
- `examples/redeploy/k8s/` - Deployment + `kubectl set image` + `rollout status` (readiness probe gates the swap)
- `examples/redeploy/systemd/` - host package + `systemctl restart`
- `examples/redeploy/README.md` + a "restart contract" section in the composition docs (and mirror)

Also documents `QLAWKUS_ADMIN_PASSWORD_HASH` in `.env.example` (an orphan from the earlier auth-hardening: the Argon2id credential replaced `API_USER_PASSWORD` but the example never gained the new variable).

## Verification

Verified end to end against a running docker-compose stack: staged a variant manifest over the API, ran the compose redeploy, and the rebuilt instance's active manifest reflected the new capability set while the staged one was discarded. The E2E run caught a real bug - a sourcing-order issue where the no-op default build/restart clobbered the caller's, so the redeploy silently skipped build and restart; fixed with the `declare -F` guard and re-verified. Plus a dry-run of the promotion phase and `bash -n` on all scripts.

Closes #251.