### PR TITLE
Release 0.8.2 (M8 Sub-project 2: build-and-redeploy control loop)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 release:
   # Current version to release (edit this to trigger a release)
-  current-version: 0.8.2-SNAPSHOT
+  current-version: 0.8.2
   # Next development version after the release
-  next-version: 0.8.2-SNAPSHOT
+  next-version: 0.8.3-SNAPSHOT


### PR DESCRIPTION
Flips `current-version` to `0.8.2` to cut the release. Wraps up M8 Sub-project 2: the composition control plane (staging endpoint) and the outside-the-app restart contract, on the Argon2id database-free admin auth.

Merging this triggers `release-prepare` (tag `0.8.2`, bump to `0.8.3-SNAPSHOT`); the tag then fires `release-perform` to draft the GitHub release. Changelog is auto-generated from merged PR titles.