### PR TITLE
First-run onboarding wizard for the console

### DIFF
--- a/console/deployment/src/main/java/dev/omatheusmesmo/qlawkus/console/deployment/ConsoleProcessor.java
+++ b/console/deployment/src/main/java/dev/omatheusmesmo/qlawkus/console/deployment/ConsoleProcessor.java
@@ -2,6 +2,8 @@ package dev.omatheusmesmo.qlawkus.console.deployment;
 
 import dev.omatheusmesmo.qlawkus.console.ConsoleResource;
 import dev.omatheusmesmo.qlawkus.console.ConsoleStatus;
+import dev.omatheusmesmo.qlawkus.console.onboarding.OnboardingResource;
+import dev.omatheusmesmo.qlawkus.console.onboarding.SetupState;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -26,7 +28,8 @@ class ConsoleProcessor {
     @BuildStep
     AdditionalBeanBuildItem consoleBeans() {
         return AdditionalBeanBuildItem.builder()
-                .addBeanClasses(ConsoleResource.class, ConsoleStatus.class)
+                .addBeanClasses(ConsoleResource.class, ConsoleStatus.class, SetupState.class,
+                        OnboardingResource.class)
                 .setUnremovable()
                 .build();
     }

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/ConsoleResource.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/ConsoleResource.java
@@ -1,5 +1,6 @@
 package dev.omatheusmesmo.qlawkus.console;
 
+import dev.omatheusmesmo.qlawkus.console.onboarding.SetupState;
 import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
@@ -24,19 +25,22 @@ public class ConsoleResource {
     private final Template index;
     private final Template status;
     private final ConsoleStatus consoleStatus;
+    private final SetupState setupState;
 
     public ConsoleResource(@Location("console/index.html") Template index,
                            @Location("console/status.html") Template status,
-                           ConsoleStatus consoleStatus) {
+                           ConsoleStatus consoleStatus,
+                           SetupState setupState) {
         this.index = index;
         this.status = status;
         this.consoleStatus = consoleStatus;
+        this.setupState = setupState;
     }
 
     @GET
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance index() {
-        return index.instance();
+        return index.data("needsSetup", setupState.needsSetup());
     }
 
     @GET

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/onboarding/ConsoleCapability.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/onboarding/ConsoleCapability.java
@@ -1,0 +1,45 @@
+package dev.omatheusmesmo.qlawkus.console.onboarding;
+
+import java.util.List;
+
+/**
+ * The curated set of capabilities the onboarding wizard can toggle. The running app has no
+ * composition catalog (that lives in the build-time Maven plugin, which reads the reactor), so the
+ * console ships this list. Adding a new composable capability means adding an entry here.
+ *
+ * @param name the composition capability name, matching {@code metadata.qlawkus.capability}
+ * @param label a short human label for the checkbox
+ * @param description one line explaining what enabling it does
+ * @param followUp the Phase B step this capability unlocks once it is compiled in
+ * @param tokenProperty for {@link FollowUp#MESSAGING_TOKEN}, the keystore alias (config property) of
+ *                      the bot token; {@code null} otherwise
+ */
+public record ConsoleCapability(String name, String label, String description, FollowUp followUp,
+                                String tokenProperty) {
+
+    /** The interactive step a capability unlocks only after it has been compiled in (Phase B). */
+    public enum FollowUp {
+        NONE,
+        GOOGLE_OAUTH,
+        MESSAGING_TOKEN
+    }
+
+    public static final List<ConsoleCapability> CATALOG = List.of(
+            new ConsoleCapability("cognition.pgvector", "Postgres memory (pgvector)",
+                    "Vector memory on Postgres. Without it the agent uses the database-free markdown stores.",
+                    FollowUp.NONE, null),
+            new ConsoleCapability("brag", "Brag documents",
+                    "Career brag-document tool.", FollowUp.NONE, null),
+            new ConsoleCapability("skill-hub", "Skill Hub",
+                    "Search, install and publish skills from a remote registry.", FollowUp.NONE, null),
+            new ConsoleCapability("google-workspace", "Google Workspace",
+                    "Gmail, Calendar, Drive, Sheets and Storage tools.", FollowUp.GOOGLE_OAUTH, null),
+            new ConsoleCapability("messaging.discord", "Discord",
+                    "Discord chat adapter.", FollowUp.MESSAGING_TOKEN, "qlawkus.messaging.discord.bot-token"),
+            new ConsoleCapability("messaging.telegram", "Telegram",
+                    "Telegram chat adapter.", FollowUp.MESSAGING_TOKEN, "qlawkus.messaging.telegram.bot-token"));
+
+    public static ConsoleCapability byName(String name) {
+        return CATALOG.stream().filter(c -> c.name().equals(name)).findFirst().orElse(null);
+    }
+}

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/onboarding/OnboardingResource.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/onboarding/OnboardingResource.java
@@ -1,0 +1,165 @@
+package dev.omatheusmesmo.qlawkus.console.onboarding;
+
+import dev.omatheusmesmo.qlawkus.compose.CompositionAdminService;
+import dev.omatheusmesmo.qlawkus.secrets.KeystoreSecretWriter;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateData;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestForm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The first-run onboarding wizard, served inside the console at {@code /console/setup}. It never
+ * writes config or secrets itself: it drives the existing admin surfaces - {@link KeystoreSecretWriter}
+ * (secrets, applied on restart) and {@link CompositionAdminService} (staged manifest, applied on
+ * rebuild) - so the wizard is only an orchestrator of UI over primitives that already exist.
+ *
+ * <p>Two phases split by the closed-world boundary. Phase A (pre-rebuild): the LLM key/settings and
+ * the capability selection. Phase B (post-rebuild): the interactive steps that only make sense once
+ * a capability has been compiled in - messaging tokens and Google authorization - shown per
+ * capability found in the baked manifest.
+ */
+@Path("/console/setup")
+@Authenticated
+@Produces(MediaType.TEXT_HTML)
+public class OnboardingResource {
+
+    private static final String LLM_API_KEY = "quarkus.langchain4j.openai.\"primary\".api-key";
+    private static final String LLM_BASE_URL = "quarkus.langchain4j.openai.\"primary\".base-url";
+    private static final String LLM_CHAT_MODEL = "quarkus.langchain4j.openai.\"primary\".chat-model.model-name";
+    private static final String CONSOLE_CAPABILITY = "console";
+
+    private final Template setup;
+    private final Template result;
+    private final SetupState state;
+    private final KeystoreSecretWriter secrets;
+    private final CompositionAdminService composition;
+
+    public OnboardingResource(@Location("console/setup.html") Template setup,
+                              @Location("console/setup-result.html") Template result,
+                              SetupState state,
+                              KeystoreSecretWriter secrets,
+                              CompositionAdminService composition) {
+        this.setup = setup;
+        this.result = result;
+        this.state = state;
+        this.secrets = secrets;
+        this.composition = composition;
+    }
+
+    @GET
+    public TemplateInstance page() {
+        List<CapView> caps = new ArrayList<>();
+        List<PhaseBView> phaseB = new ArrayList<>();
+        for (ConsoleCapability c : ConsoleCapability.CATALOG) {
+            boolean baked = state.capabilityBaked(c.name());
+            caps.add(new CapView(c.name(), c.label(), c.description(), baked));
+            if (baked && c.followUp() != ConsoleCapability.FollowUp.NONE) {
+                boolean done = c.followUp() == ConsoleCapability.FollowUp.MESSAGING_TOKEN
+                        && state.secretPresent(c.tokenProperty());
+                phaseB.add(new PhaseBView(c.name(), c.label(), c.followUp().name(), c.tokenProperty(), done));
+            }
+        }
+        return setup
+                .data("llmConfigured", state.llmConfigured())
+                .data("capabilities", caps)
+                .data("phaseB", phaseB)
+                .data("staged", isStaged());
+    }
+
+    @POST
+    @Path("/llm")
+    public TemplateInstance saveLlm(@RestForm String baseUrl, @RestForm String chatModel, @RestForm String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return err("An API key is required.");
+        }
+        try {
+            secrets.setSecret(LLM_API_KEY, apiKey.trim());
+            if (baseUrl != null && !baseUrl.isBlank()) {
+                secrets.setSecret(LLM_BASE_URL, baseUrl.trim());
+            }
+            if (chatModel != null && !chatModel.isBlank()) {
+                secrets.setSecret(LLM_CHAT_MODEL, chatModel.trim());
+            }
+            return ok("LLM settings saved to the keystore.", "Restart the app to apply them.");
+        } catch (RuntimeException e) {
+            return err("Could not save LLM settings: " + e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("/capabilities")
+    public TemplateInstance saveCapabilities(@RestForm List<String> capability) {
+        List<String> selected = new ArrayList<>();
+        if (capability != null) {
+            selected.addAll(capability);
+        }
+        if (!selected.contains(CONSOLE_CAPABILITY)) {
+            selected.add(CONSOLE_CAPABILITY);
+        }
+        try {
+            composition.stage(manifestYaml(selected));
+            return ok("Capability manifest staged.",
+                    "Rebuild and redeploy to apply it (see examples/redeploy).");
+        } catch (Exception e) {
+            return err("Could not stage the manifest: " + e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("/messaging")
+    public TemplateInstance saveMessagingToken(@RestForm String property, @RestForm String token) {
+        if (property == null || property.isBlank() || token == null || token.isBlank()) {
+            return err("A token is required.");
+        }
+        try {
+            secrets.setSecret(property.trim(), token.trim());
+            return ok("Token saved to the keystore.", "Restart the app to connect the adapter.");
+        } catch (RuntimeException e) {
+            return err("Could not save the token: " + e.getMessage());
+        }
+    }
+
+    private boolean isStaged() {
+        try {
+            return composition.currentState().staged() != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String manifestYaml(List<String> except) {
+        StringBuilder sb = new StringBuilder("version: 1\nbuild-time:\n  default: disabled\n  except:\n");
+        for (String capability : except) {
+            sb.append("    - ").append(capability).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private TemplateInstance ok(String message, String detail) {
+        return result.data("ok", true).data("message", message).data("detail", detail);
+    }
+
+    private TemplateInstance err(String message) {
+        return result.data("ok", false).data("message", message).data("detail", "");
+    }
+
+    /** A capability row in the selection form: identity plus whether it is already compiled in. */
+    @TemplateData
+    public record CapView(String name, String label, String description, boolean enabled) {
+    }
+
+    /** A Phase B follow-up unlocked by a baked capability (a messaging token form or the Google card). */
+    @TemplateData
+    public record PhaseBView(String name, String label, String kind, String tokenProperty, boolean done) {
+    }
+}

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/onboarding/SetupState.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/onboarding/SetupState.java
@@ -1,0 +1,72 @@
+package dev.omatheusmesmo.qlawkus.console.onboarding;
+
+import dev.omatheusmesmo.qlawkus.composition.CompositionManifest;
+import dev.omatheusmesmo.qlawkus.composition.CompositionManifestParser;
+import dev.omatheusmesmo.qlawkus.composition.CompositionPaths;
+import dev.omatheusmesmo.qlawkus.secrets.KeystoreSecretWriter;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Answers "is this agent configured, and which onboarding steps remain?" by inference from the live
+ * state: the LLM key in config, the capabilities in the baked manifest, and the aliases already in
+ * the keystore. So the wizard needs no separate progress file, and it never couples to the tool
+ * modules (it reads the baked manifest, it does not inject their beans). Read-only.
+ */
+@ApplicationScoped
+public class SetupState {
+
+    static final String LLM_API_KEY = "quarkus.langchain4j.openai.\"primary\".api-key";
+    private static final Set<String> PLACEHOLDERS = Set.of("", "dummy", "test-key", "changeme", "your-key");
+
+    private final KeystoreSecretWriter secrets;
+
+    public SetupState(KeystoreSecretWriter secrets) {
+        this.secrets = secrets;
+    }
+
+    /**
+     * Whether a usable LLM API key is configured: present and not one of the known placeholders that
+     * a fresh install or a test fixture leaves in place.
+     */
+    public boolean llmConfigured() {
+        String key = ConfigProvider.getConfig()
+                .getOptionalValue(LLM_API_KEY, String.class)
+                .orElse("")
+                .trim();
+        return !PLACEHOLDERS.contains(key.toLowerCase(Locale.ROOT));
+    }
+
+    /** The first-run signal that drives the console banner: the agent cannot talk to an LLM yet. */
+    public boolean needsSetup() {
+        return !llmConfigured();
+    }
+
+    /** Whether the given capability is enabled in the manifest baked into this running app. */
+    public boolean capabilityBaked(String capability) {
+        CompositionManifest manifest = bakedManifest();
+        return manifest != null && manifest.buildTime().isEnabled(capability);
+    }
+
+    /** Whether a secret is already stored under the given alias (keystore, best-effort). */
+    public boolean secretPresent(String alias) {
+        try {
+            return secrets.aliases().contains(alias);
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private static CompositionManifest bakedManifest() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try (InputStream in = loader.getResourceAsStream(CompositionPaths.DEFAULT_MANIFEST)) {
+            return in == null ? null : CompositionManifestParser.parse(in);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/console/runtime/src/main/resources/META-INF/resources/console/app.css
+++ b/console/runtime/src/main/resources/META-INF/resources/console/app.css
@@ -10,6 +10,7 @@
   --faint: #9a949e;
   --border: #ece8e3;
   --accent: #f5821f;
+  --accent-ink: #b07219;
   --accent-soft: rgba(245, 130, 31, 0.12);
   --up: #3f9a52;
   --radius: 10px;
@@ -94,6 +95,21 @@ body {
 
 .muted { color: var(--muted); }
 
+.setup-banner {
+  display: block;
+  margin-top: 24px;
+  padding: 14px 18px;
+  border-radius: var(--radius);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  color: var(--accent-ink);
+  text-decoration: none;
+  font-size: 14.5px;
+}
+
+.setup-banner strong { color: var(--accent-ink); }
+.setup-banner:hover { background: rgba(245, 130, 31, 0.18); }
+
 .status-line { display: flex; align-items: center; gap: 10px; font-weight: 600; }
 
 .dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
@@ -112,3 +128,56 @@ body {
 .status-cell { border-left: 2px solid var(--border); padding-left: 12px; }
 .status-cell dt { color: var(--faint); font-size: 12px; text-transform: uppercase; letter-spacing: 0.8px; }
 .status-cell dd { margin: 3px 0 0; font-family: var(--mono); font-size: 14px; }
+
+/* ---------- Onboarding wizard ---------- */
+.step {
+  margin-top: 26px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px 24px;
+}
+.step-title { margin: 0 0 6px; font-size: 18px; letter-spacing: -0.2px; }
+.step-note { background: transparent; border-style: dashed; }
+.step-note ul { margin: 8px 0 0; padding-left: 20px; color: var(--muted); }
+.step-note li { margin: 4px 0; }
+
+.form { display: flex; flex-direction: column; gap: 14px; margin-top: 16px; max-width: 640px; }
+.form label { display: flex; flex-direction: column; gap: 5px; font-size: 13px; color: var(--muted); }
+.form input[type="text"], .form input[type="password"], .form input:not([type]) {
+  font: inherit;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+}
+.form input:focus { outline: 2px solid var(--accent-soft); border-color: var(--accent); }
+.form button {
+  align-self: flex-start;
+  font: inherit;
+  font-weight: 600;
+  padding: 9px 18px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+}
+.form button:hover { background: var(--accent-ink); }
+
+.form label.check { display: grid; grid-template-columns: auto 1fr; column-gap: 10px; row-gap: 2px; align-items: center; padding: 10px 0; border-bottom: 1px solid var(--border); }
+.check input { grid-column: 1; grid-row: 1; }
+.check-label { grid-column: 2; grid-row: 1; font-weight: 600; color: var(--text); font-size: 15px; }
+.check-desc { grid-column: 2; grid-row: 2; color: var(--muted); font-size: 13px; }
+
+.pill { font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; padding: 2px 8px; border-radius: 999px; vertical-align: middle; }
+.pill-ok { background: rgba(63, 154, 82, 0.14); color: var(--up); }
+
+.phaseb { padding: 12px 0; border-top: 1px solid var(--border); }
+.phaseb h3 { margin: 0 0 6px; font-size: 15px; }
+
+.result { margin-top: 12px; }
+.result-msg { padding: 10px 14px; border-radius: 8px; font-size: 14px; }
+.result-ok { background: rgba(63, 154, 82, 0.12); color: var(--up); }
+.result-err { background: #fdeeec; color: #c0392b; }

--- a/console/runtime/src/main/resources/templates/console/index.html
+++ b/console/runtime/src/main/resources/templates/console/index.html
@@ -38,6 +38,11 @@
             <h1>Console</h1>
             <p class="lede">Scaffold ready. The management screens land here.</p>
         </header>
+        {#if needsSetup}
+        <a class="setup-banner" href="/console/setup">
+            <strong>Finish setting up your agent.</strong> The LLM is not configured yet - run first-time setup.
+        </a>
+        {/if}
         <section class="panel">
             <h2 class="panel-title">Status</h2>
             <div class="panel-body" hx-get="/console/status" hx-trigger="load, every 5s" hx-swap="innerHTML">

--- a/console/runtime/src/main/resources/templates/console/setup-result.html
+++ b/console/runtime/src/main/resources/templates/console/setup-result.html
@@ -1,0 +1,3 @@
+<div class="result-msg {#if ok}result-ok{#else}result-err{/if}">
+    <strong>{message}</strong> <span class="muted">{detail}</span>
+</div>

--- a/console/runtime/src/main/resources/templates/console/setup.html
+++ b/console/runtime/src/main/resources/templates/console/setup.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Qlawkus Console - Setup</title>
+    <link rel="stylesheet" href="/console/app.css">
+    <script src="/console/htmx.min.js" defer></script>
+</head>
+<body>
+<div class="layout">
+    <aside class="sidebar">
+        <div class="brand">
+            <span class="brand-mark" aria-hidden="true">
+                <svg viewBox="0 0 32 32" width="27" height="27">
+                    <circle cx="16" cy="18.5" r="11" fill="#f5821f"/>
+                    <ellipse cx="12" cy="14.5" rx="3.2" ry="2.1" fill="#ffffff" opacity="0.22"/>
+                    <path d="M15.6 8.2 l-0.3 -3.5" stroke="#6b4a2b" stroke-width="1.5" stroke-linecap="round"/>
+                    <path d="M16 7.4 c 0.5 -3 3.4 -4 5.4 -3.2 c -0.4 2.8 -2.9 3.9 -5.4 3.2 z" fill="#43a35f"/>
+                </svg>
+            </span>
+            <span class="brand-text">
+                <span class="brand-name">Qlawkus</span>
+                <span class="brand-sub">setup</span>
+            </span>
+        </div>
+        <nav class="nav">
+            <a class="nav-item" href="/console">Overview</a>
+            <a class="nav-item is-active" href="/console/setup">Setup</a>
+        </nav>
+        <div class="sidebar-foot">First-run setup</div>
+    </aside>
+    <main class="content">
+        <header class="content-head">
+            <h1>First-run setup</h1>
+            <p class="lede">Point the agent at a model, choose what to build in, then rebuild and redeploy.</p>
+        </header>
+
+        <section class="step">
+            <h2 class="step-title">1. Language model {#if llmConfigured}<span class="pill pill-ok">configured</span>{/if}</h2>
+            <p class="muted">The provider and key the agent talks to. Saved to the keystore; applies on the next restart.</p>
+            <form class="form" hx-post="/console/setup/llm" hx-target="#llm-result" hx-swap="innerHTML">
+                <label>Base URL<input name="baseUrl" placeholder="https://integrate.api.nvidia.com/v1"></label>
+                <label>Chat model<input name="chatModel" placeholder="e.g. meta/llama-3.1-70b-instruct"></label>
+                <label>API key<input name="apiKey" type="password" placeholder="paste the provider API key"></label>
+                <button type="submit">Save LLM settings</button>
+            </form>
+            <div id="llm-result" class="result"></div>
+        </section>
+
+        <section class="step">
+            <h2 class="step-title">2. Capabilities</h2>
+            <p class="muted">What gets compiled into the agent. Staged as a manifest; applies on rebuild + redeploy.</p>
+            <form class="form" hx-post="/console/setup/capabilities" hx-target="#caps-result" hx-swap="innerHTML">
+                {#for c in capabilities}
+                <label class="check">
+                    <input type="checkbox" name="capability" value="{c.name}"{#if c.enabled} checked{/if}>
+                    <span class="check-label">{c.label}</span>
+                    <span class="check-desc">{c.description}</span>
+                </label>
+                {/for}
+                <button type="submit">Stage manifest</button>
+            </form>
+            <div id="caps-result" class="result">{#if staged}<p class="muted">A manifest is currently staged, pending a rebuild.</p>{/if}</div>
+        </section>
+
+        <section class="step step-note">
+            <h2 class="step-title">Applying your choices</h2>
+            <ul>
+                <li><strong>Restart</strong> applies the LLM key and any tokens - secrets take effect on the next boot.</li>
+                <li><strong>Rebuild + redeploy</strong> applies the capability manifest - the running app cannot re-augment itself. See <code>examples/redeploy</code>.</li>
+            </ul>
+        </section>
+
+        {#if phaseB}
+        <section class="step">
+            <h2 class="step-title">3. After the rebuild</h2>
+            <p class="muted">Steps unlocked by capabilities that are now compiled in.</p>
+            {#for step in phaseB}
+                {#if step.kind == 'GOOGLE_OAUTH'}
+                <div class="phaseb">
+                    <h3>{step.label}</h3>
+                    <p class="muted">Google is built in. To authorize, open the agent chat and ask it to authorize Google - it replies with a device-flow link to approve, then confirms.</p>
+                </div>
+                {#else}
+                <div class="phaseb">
+                    <h3>{step.label} token {#if step.done}<span class="pill pill-ok">saved</span>{/if}</h3>
+                    <form class="form" hx-post="/console/setup/messaging" hx-target="#msg-{step_count}" hx-swap="innerHTML">
+                        <input type="hidden" name="property" value="{step.tokenProperty}">
+                        <label>Bot token<input name="token" type="password" placeholder="paste the bot token"></label>
+                        <button type="submit">Save token</button>
+                    </form>
+                    <div id="msg-{step_count}" class="result"></div>
+                </div>
+                {/if}
+            {/for}
+        </section>
+        {/if}
+    </main>
+</div>
+</body>
+</html>

--- a/integration-tests/console/src/main/resources/application.properties
+++ b/integration-tests/console/src/main/resources/application.properties
@@ -14,6 +14,11 @@ quarkus.http.auth.basic=true
 %test.qlawkus.agent.state.root=target/console/state
 %test.qlawkus.skills.roots=target/console/skills
 
+# Onboarding writes secrets to a throwaway keystore under target/ so the wizard's LLM-key and
+# messaging-token steps have somewhere to persist to.
+%test.qlawkus.secrets.keystore-path=target/console/secrets.p12
+%test.qlawkus.secrets.keystore-password=testpass
+
 %test.quarkus.wiremock.devservices.enabled=true
 %test.quarkus.langchain4j.openai."primary".base-url=http://localhost:${quarkus.wiremock.devservices.port}/v1
 %test.quarkus.langchain4j.openai."primary".api-key=test-key

--- a/integration-tests/console/src/main/resources/qlawkus/agent.yml
+++ b/integration-tests/console/src/main/resources/qlawkus/agent.yml
@@ -3,3 +3,5 @@ build-time:
   default: disabled
   except:
     - console
+    - messaging.discord
+    - google-workspace

--- a/integration-tests/console/src/test/java/dev/omatheusmesmo/qlawkus/it/console/OnboardingWizardTest.java
+++ b/integration-tests/console/src/test/java/dev/omatheusmesmo/qlawkus/it/console/OnboardingWizardTest.java
@@ -1,0 +1,118 @@
+package dev.omatheusmesmo.qlawkus.it.console;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the onboarding wizard end to end over HTTP, database-free. It proves the wizard is only
+ * an orchestrator of the existing admin surfaces: the LLM step lands a secret in the keystore, the
+ * capability step stages a manifest through the composition service, and the Phase B steps appear
+ * only for capabilities present in the baked manifest (this module bakes messaging.discord and
+ * google-workspace so both follow-ups render).
+ */
+@QuarkusTest
+class OnboardingWizardTest {
+
+  private static final String USER = "qlawkus";
+  private static final String PASS = "qlawkus-test";
+  private static final Path STAGED = Path.of("target/console/state/agent.staged.yml");
+  private static final Path KEYSTORE = Path.of("target/console/secrets.p12");
+
+  @BeforeEach
+  void clearStaged() throws IOException {
+    Files.deleteIfExists(STAGED);
+  }
+
+  /**
+   * The LLM/token steps write real secrets into the throwaway keystore. Remove it afterwards so the
+   * next run boots unconfigured again (the keystore outranks application.properties, so a leftover
+   * key would otherwise flip the first-run detection and hide the setup banner).
+   */
+  @AfterAll
+  static void removeTestKeystore() throws IOException {
+    Files.deleteIfExists(KEYSTORE);
+  }
+
+  @Test
+  void setupPage_requiresAuthentication() {
+    given().when().get("/console/setup").then().statusCode(401);
+    given().when().post("/console/setup/llm").then().statusCode(401);
+  }
+
+  @Test
+  void console_showsSetupBannerWhenUnconfigured() {
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/console")
+        .then().statusCode(200)
+        .body(containsString("setup-banner"))
+        .body(containsString("/console/setup"));
+  }
+
+  @Test
+  void setupPage_rendersPhaseAAndPhaseB() {
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/console/setup")
+        .then().statusCode(200)
+        .body(containsString("First-run setup"))
+        .body(containsString("/console/setup/llm"))
+        .body(containsString("name=\"capability\""))
+        .body(containsString("Google is built in"))
+        .body(containsString("/console/setup/messaging"));
+  }
+
+  @Test
+  void llmStep_writesTheApiKeySecret() {
+    given().auth().preemptive().basic(USER, PASS)
+        .contentType("application/x-www-form-urlencoded")
+        .formParam("apiKey", "real-secret-key")
+        .formParam("baseUrl", "https://example.test/v1")
+        .when().post("/console/setup/llm")
+        .then().statusCode(200)
+        .body(containsString("saved"));
+
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/api/admin/secrets")
+        .then().statusCode(200)
+        .body(containsString("langchain4j.openai"));
+  }
+
+  @Test
+  void capabilitiesStep_stagesManifestAlwaysKeepingConsole() {
+    given().auth().preemptive().basic(USER, PASS)
+        .contentType("application/x-www-form-urlencoded")
+        .formParam("capability", "brag")
+        .when().post("/console/setup/capabilities")
+        .then().statusCode(200)
+        .body(containsString("staged"));
+
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/api/admin/composition")
+        .then().statusCode(200)
+        .body(containsString("brag"))
+        .body(containsString("console"));
+  }
+
+  @Test
+  void messagingStep_writesTheBotTokenSecret() {
+    given().auth().preemptive().basic(USER, PASS)
+        .contentType("application/x-www-form-urlencoded")
+        .formParam("property", "qlawkus.messaging.discord.bot-token")
+        .formParam("token", "a-real-bot-token")
+        .when().post("/console/setup/messaging")
+        .then().statusCode(200)
+        .body(containsString("saved"));
+
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/api/admin/secrets")
+        .then().statusCode(200)
+        .body(containsString("messaging.discord.bot-token"));
+  }
+}


### PR DESCRIPTION
The first-run onboarding wizard (M8 Sub-project 3), served inside the console at `/console/setup` behind the shared `@Authenticated` gate. It never writes config or secrets itself: it orchestrates the admin surfaces that already exist, so it stays a thin UI over primitives, not a new write path.

## Two phases, split by the closed-world boundary

The running app cannot re-augment itself, so the wizard is honest about it:

- **Phase A (pre-rebuild):** the LLM provider/base-url/model/key (written to the keystore via the secrets writer, applied on the next **restart**) and the capability selection (staged as an `agent.yml` through the composition service, applied on **rebuild + redeploy**). A summary separates the two.
- **Phase B (post-rebuild):** the steps that only make sense once a capability is compiled in, shown per capability found in the baked manifest: a bot-token form per messaging adapter, and a decoupled Google authorization card.

## Notable choices

- **`SetupState`** infers the configured state (LLM key in config, capabilities in the baked manifest, aliases in the keystore) with no progress file, and drives a first-run banner on the console overview.
- **Capability catalog is curated in-console.** The running app has no build-time catalog (that lives in the Maven plugin, which reads the reactor), so the selectable list ships with the console.
- **Google is a guidance card, not one-click.** Google authorization is a device flow driven through the agent tool, with no console-reachable redirect endpoint; a one-click bridge would couple the console to the `google-auth` module. The card detects Google is built in and points the user to the chat flow.
- **The manifest step always keeps `console`,** so a user cannot compose away the UI they are standing in.

## Testing

`integration-tests/console` grows to 10 tests (database-free): the auth gate, the unconfigured banner, both phases rendering, the LLM-key and bot-token secret writes, and manifest staging.

Closes #190
