### PR TITLE
Management console pages (memory, skills, cognition)

### DIFF
--- a/console/deployment/src/main/java/dev/omatheusmesmo/qlawkus/console/deployment/ConsoleProcessor.java
+++ b/console/deployment/src/main/java/dev/omatheusmesmo/qlawkus/console/deployment/ConsoleProcessor.java
@@ -2,11 +2,16 @@ package dev.omatheusmesmo.qlawkus.console.deployment;
 
 import dev.omatheusmesmo.qlawkus.console.ConsoleResource;
 import dev.omatheusmesmo.qlawkus.console.ConsoleStatus;
+import dev.omatheusmesmo.qlawkus.console.management.CognitionConsoleResource;
+import dev.omatheusmesmo.qlawkus.console.management.MemoryConsoleResource;
+import dev.omatheusmesmo.qlawkus.console.management.SkillsConsoleResource;
 import dev.omatheusmesmo.qlawkus.console.onboarding.OnboardingResource;
 import dev.omatheusmesmo.qlawkus.console.onboarding.SetupState;
+import dev.omatheusmesmo.qlawkus.skill.SkillSummary;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 /**
  * Build steps for the optional {@code qlawkus-console} extension: the server-rendered admin UI.
@@ -29,8 +34,16 @@ class ConsoleProcessor {
     AdditionalBeanBuildItem consoleBeans() {
         return AdditionalBeanBuildItem.builder()
                 .addBeanClasses(ConsoleResource.class, ConsoleStatus.class, SetupState.class,
-                        OnboardingResource.class)
+                        OnboardingResource.class, MemoryConsoleResource.class, SkillsConsoleResource.class,
+                        CognitionConsoleResource.class)
                 .setUnremovable()
+                .build();
+    }
+
+    @BuildStep
+    ReflectiveClassBuildItem skillSummaryForReflection() {
+        return ReflectiveClassBuildItem.builder(SkillSummary.class.getName())
+                .methods()
                 .build();
     }
 }

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/management/CognitionConsoleResource.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/management/CognitionConsoleResource.java
@@ -1,0 +1,41 @@
+package dev.omatheusmesmo.qlawkus.console.management;
+
+import dev.omatheusmesmo.qlawkus.console.onboarding.SetupState;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * The cognition management page. This is the decoupled case: reconcile and migrate live in the
+ * optional {@code cognition-pgvector} extension, which the console must not depend on. So the page
+ * only drives the {@code /api/admin/cognition} endpoints over HTTP, and it decides whether to show
+ * them by reading the baked composition manifest (via {@link SetupState}), not by importing anything
+ * from that module - {@code cognition.pgvector} in the manifest means the endpoints are compiled in.
+ */
+@Path("/console/cognition")
+@Authenticated
+@Produces(MediaType.TEXT_HTML)
+public class CognitionConsoleResource {
+
+    private static final String CAPABILITY = "cognition.pgvector";
+
+    private final Template cognition;
+    private final SetupState setupState;
+
+    public CognitionConsoleResource(@Location("console/cognition.html") Template cognition, SetupState setupState) {
+        this.cognition = cognition;
+        this.setupState = setupState;
+    }
+
+    @GET
+    public TemplateInstance page() {
+        return cognition
+                .data("active", "cognition")
+                .data("available", setupState.capabilityBaked(CAPABILITY));
+    }
+}

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/management/MemoryConsoleResource.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/management/MemoryConsoleResource.java
@@ -1,0 +1,53 @@
+package dev.omatheusmesmo.qlawkus.console.management;
+
+import dev.omatheusmesmo.qlawkus.dto.JournalSummary;
+import dev.omatheusmesmo.qlawkus.store.EpisodicStore;
+import dev.omatheusmesmo.qlawkus.store.FactStore;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.List;
+
+/**
+ * The memory management page. Reads directly from the client-side stores ({@link FactStore},
+ * {@link EpisodicStore}) to render a rich view; the mutating actions (review, curate, purge) are
+ * driven from the page by HTMX against the existing {@code /api/admin/memory} endpoints, so this
+ * resource only renders and never re-implements the admin logic.
+ */
+@Path("/console/memory")
+@Authenticated
+@Produces(MediaType.TEXT_HTML)
+public class MemoryConsoleResource {
+
+    private static final int RECENT_FACTS = 20;
+
+    private final Template memory;
+    private final FactStore factStore;
+    private final EpisodicStore episodicStore;
+
+    public MemoryConsoleResource(@Location("console/memory.html") Template memory,
+                                 FactStore factStore,
+                                 EpisodicStore episodicStore) {
+        this.memory = memory;
+        this.factStore = factStore;
+        this.episodicStore = episodicStore;
+    }
+
+    @GET
+    public TemplateInstance page() {
+        List<String> facts = factStore.listFactTexts(RECENT_FACTS);
+        List<JournalSummary> journals = episodicStore.listJournals();
+        return memory
+                .data("active", "memory")
+                .data("facts", facts)
+                .data("sources", factStore.listSources())
+                .data("journals", journals)
+                .data("journalCount", episodicStore.count());
+    }
+}

--- a/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/management/SkillsConsoleResource.java
+++ b/console/runtime/src/main/java/dev/omatheusmesmo/qlawkus/console/management/SkillsConsoleResource.java
@@ -1,0 +1,42 @@
+package dev.omatheusmesmo.qlawkus.console.management;
+
+import dev.omatheusmesmo.qlawkus.skill.SkillStore;
+import dev.omatheusmesmo.qlawkus.skill.SkillSummary;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.List;
+
+/**
+ * The skills management page. Lists the agent's skills from the client-side {@link SkillStore}; the
+ * per-skill (pin, delete) and maintenance (curate, lifecycle) actions are driven from the page by
+ * HTMX against the existing {@code /api/admin/skills} endpoints.
+ */
+@Path("/console/skills")
+@Authenticated
+@Produces(MediaType.TEXT_HTML)
+public class SkillsConsoleResource {
+
+    private final Template skills;
+    private final SkillStore skillStore;
+
+    public SkillsConsoleResource(@Location("console/skills.html") Template skills, SkillStore skillStore) {
+        this.skills = skills;
+        this.skillStore = skillStore;
+    }
+
+    @GET
+    public TemplateInstance page() {
+        List<SkillSummary> index = skillStore.index();
+        return skills
+                .data("active", "skills")
+                .data("skills", index)
+                .data("skillCount", index.size());
+    }
+}

--- a/console/runtime/src/main/resources/META-INF/resources/console/app.css
+++ b/console/runtime/src/main/resources/META-INF/resources/console/app.css
@@ -181,3 +181,29 @@ body {
 .result-msg { padding: 10px 14px; border-radius: 8px; font-size: 14px; }
 .result-ok { background: rgba(63, 154, 82, 0.12); color: var(--up); }
 .result-err { background: #fdeeec; color: #c0392b; }
+
+/* ---------- Management pages ---------- */
+.mono { font-family: var(--mono); font-size: 13px; }
+.mem-list { margin: 10px 0 0; padding-left: 18px; }
+.mem-list li { margin: 4px 0; font-size: 14px; }
+
+.tbl { width: 100%; border-collapse: collapse; font-size: 14px; }
+.tbl th { text-align: left; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); border-bottom: 1px solid var(--border); padding: 8px 10px; }
+.tbl td { border-bottom: 1px solid var(--border); padding: 10px; vertical-align: top; }
+
+.actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }
+.row-actions { display: flex; gap: 8px; }
+.actions button, .row-actions button {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+.row-actions button { padding: 5px 10px; font-size: 13px; }
+.actions button:hover, .row-actions button:hover { border-color: var(--accent); color: var(--accent-ink); }
+button.danger { border-color: #e3b7b2; color: #c0392b; }
+button.danger:hover { background: #fdeeec; border-color: #c0392b; color: #c0392b; }

--- a/console/runtime/src/main/resources/templates/console/base.html
+++ b/console/runtime/src/main/resources/templates/console/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Qlawkus Console</title>
+    <title>{#insert title}Qlawkus Console{/insert}</title>
     <link rel="stylesheet" href="/console/app.css">
     <script src="/console/htmx.min.js" defer></script>
 </head>
@@ -25,31 +25,17 @@
             </span>
         </div>
         <nav class="nav">
-            <a class="nav-item is-active" href="/console">Overview</a>
-            <a class="nav-item" href="/console/memory">Memory</a>
-            <a class="nav-item" href="/console/skills">Skills</a>
-            <a class="nav-item" href="/console/cognition">Cognition</a>
+            <a class="nav-item{#if active == 'overview'} is-active{/if}" href="/console">Overview</a>
+            <a class="nav-item{#if active == 'memory'} is-active{/if}" href="/console/memory">Memory</a>
+            <a class="nav-item{#if active == 'skills'} is-active{/if}" href="/console/skills">Skills</a>
+            <a class="nav-item{#if active == 'cognition'} is-active{/if}" href="/console/cognition">Cognition</a>
             <span class="nav-item is-disabled">Config</span>
             <span class="nav-item is-disabled">Schedule</span>
         </nav>
         <div class="sidebar-foot">Control plane</div>
     </aside>
     <main class="content">
-        <header class="content-head">
-            <h1>Console</h1>
-            <p class="lede">Scaffold ready. The management screens land here.</p>
-        </header>
-        {#if needsSetup}
-        <a class="setup-banner" href="/console/setup">
-            <strong>Finish setting up your agent.</strong> The LLM is not configured yet - run first-time setup.
-        </a>
-        {/if}
-        <section class="panel">
-            <h2 class="panel-title">Status</h2>
-            <div class="panel-body" hx-get="/console/status" hx-trigger="load, every 5s" hx-swap="innerHTML">
-                <p class="muted">Loading status...</p>
-            </div>
-        </section>
+{#insert /}
     </main>
 </div>
 </body>

--- a/console/runtime/src/main/resources/templates/console/cognition.html
+++ b/console/runtime/src/main/resources/templates/console/cognition.html
@@ -1,0 +1,21 @@
+{#include console/base}
+{#title}Qlawkus Console - Cognition{/title}
+<header class="content-head">
+    <h1>Cognition</h1>
+    <p class="lede">Reconcile and migrate the file and pgvector representations.</p>
+</header>
+
+<section class="panel">
+    {#if available}
+    <p class="muted">The pgvector backend is composed in. Reconcile is a safe idempotent union; migrate overwrites one side.</p>
+    <div class="actions">
+        <button hx-post="/api/admin/cognition/reconcile" hx-target="#cog-result" hx-swap="innerHTML">Reconcile (union)</button>
+        <button hx-post="/api/admin/cognition/migrate?direction=files-to-pg" hx-confirm="Overwrite pgvector from files?" hx-target="#cog-result" hx-swap="innerHTML">Migrate files to pg</button>
+        <button hx-post="/api/admin/cognition/migrate?direction=pg-to-files" hx-confirm="Overwrite files from pgvector?" hx-target="#cog-result" hx-swap="innerHTML">Migrate pg to files</button>
+    </div>
+    <div id="cog-result" class="result"></div>
+    {#else}
+    <p class="result-msg result-err">Not available: the cognition-pgvector extension is not composed into this build, so there is nothing to reconcile or migrate. Compose in <span class="mono">cognition.pgvector</span> and rebuild to enable it.</p>
+    {/if}
+</section>
+{/include}

--- a/console/runtime/src/main/resources/templates/console/memory.html
+++ b/console/runtime/src/main/resources/templates/console/memory.html
@@ -1,0 +1,32 @@
+{#include console/base}
+{#title}Qlawkus Console - Memory{/title}
+<header class="content-head">
+    <h1>Memory</h1>
+    <p class="lede">Facts, journals, and the curation jobs.</p>
+</header>
+
+<section class="panel">
+    <h2 class="panel-title">Facts (recent, up to 20)</h2>
+    {#if sources}<p class="muted">Sources: {#for s in sources}{s}{#if s_hasNext}, {/if}{/for}</p>{/if}
+    <ul class="mem-list">
+        {#for f in facts}<li>{f}</li>{#else}<li class="muted">No facts stored yet.</li>{/for}
+    </ul>
+</section>
+
+<section class="panel">
+    <h2 class="panel-title">Journals ({journalCount})</h2>
+    <ul class="mem-list">
+        {#for j in journals}<li><strong>{j.date}</strong> ({j.messageCount} msgs) {j.summary}</li>{#else}<li class="muted">No journals yet.</li>{/for}
+    </ul>
+</section>
+
+<section class="step">
+    <h2 class="step-title">Actions</h2>
+    <div class="actions">
+        <button hx-post="/api/admin/memory/review" hx-target="#mem-result" hx-swap="innerHTML" hx-indicator="#mem-result">Review (dedup facts)</button>
+        <button hx-post="/api/admin/memory/curate" hx-target="#mem-result" hx-swap="innerHTML" hx-indicator="#mem-result">Curate into profile</button>
+        <button class="danger" hx-delete="/api/admin/memory?all=true" hx-confirm="Purge ALL memory? This cannot be undone." hx-target="#mem-result" hx-swap="innerHTML">Purge all</button>
+    </div>
+    <div id="mem-result" class="result"></div>
+</section>
+{/include}

--- a/console/runtime/src/main/resources/templates/console/skills.html
+++ b/console/runtime/src/main/resources/templates/console/skills.html
@@ -1,0 +1,38 @@
+{#include console/base}
+{#title}Qlawkus Console - Skills{/title}
+<header class="content-head">
+    <h1>Skills</h1>
+    <p class="lede">The agent's procedural memory. {skillCount} skills.</p>
+</header>
+
+<section class="panel">
+    <table class="tbl">
+        <thead><tr><th>Name</th><th>Description</th><th>Actions</th></tr></thead>
+        <tbody>
+        {#for s in skills}
+            <tr>
+                <td class="mono">{s.name}</td>
+                <td>{s.description}</td>
+                <td>
+                    <div class="row-actions">
+                        <button hx-post="/api/admin/skills/{s.name}/pin?pinned=true" hx-target="#skill-result" hx-swap="innerHTML">Pin</button>
+                        <button class="danger" hx-delete="/api/admin/skills/{s.name}" hx-confirm="Delete skill {s.name}?" hx-target="#skill-result" hx-swap="innerHTML">Delete</button>
+                    </div>
+                </td>
+            </tr>
+        {#else}
+            <tr><td colspan="3" class="muted">No skills yet.</td></tr>
+        {/for}
+        </tbody>
+    </table>
+</section>
+
+<section class="step">
+    <h2 class="step-title">Maintenance</h2>
+    <div class="actions">
+        <button hx-post="/api/admin/skills/curate" hx-target="#skill-result" hx-swap="innerHTML">Curate (remove redundant)</button>
+        <button hx-post="/api/admin/skills/lifecycle" hx-target="#skill-result" hx-swap="innerHTML">Run lifecycle aging</button>
+    </div>
+    <div id="skill-result" class="result"></div>
+</section>
+{/include}

--- a/integration-tests/console/src/test/java/dev/omatheusmesmo/qlawkus/it/console/ManagementConsoleTest.java
+++ b/integration-tests/console/src/test/java/dev/omatheusmesmo/qlawkus/it/console/ManagementConsoleTest.java
@@ -1,0 +1,66 @@
+package dev.omatheusmesmo.qlawkus.it.console;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the management pages (memory, skills, cognition) over HTTP, database-free. Proves the
+ * hybrid design: the pages render rich read views from the client-side stores and wire the mutating
+ * actions to the existing admin endpoints, and the cognition page is gated by the baked manifest
+ * (this markdown-only module does not compose cognition.pgvector, so it shows "not available").
+ */
+@QuarkusTest
+class ManagementConsoleTest {
+
+  private static final String USER = "qlawkus";
+  private static final String PASS = "qlawkus-test";
+
+  @Test
+  void pages_requireAuthentication() {
+    given().when().get("/console/memory").then().statusCode(401);
+    given().when().get("/console/skills").then().statusCode(401);
+    given().when().get("/console/cognition").then().statusCode(401);
+  }
+
+  @Test
+  void memoryPage_rendersReadViewAndActions() {
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/console/memory")
+        .then().statusCode(200)
+        .body(containsString("<h1>Memory</h1>"))
+        .body(containsString("hx-post=\"/api/admin/memory/review\""))
+        .body(containsString("hx-post=\"/api/admin/memory/curate\""))
+        .body(containsString("hx-delete=\"/api/admin/memory?all=true\""));
+  }
+
+  @Test
+  void skillsPage_rendersTableAndActions() {
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/console/skills")
+        .then().statusCode(200)
+        .body(containsString("<h1>Skills</h1>"))
+        .body(containsString("hx-post=\"/api/admin/skills/curate\""))
+        .body(containsString("hx-post=\"/api/admin/skills/lifecycle\""));
+  }
+
+  @Test
+  void cognitionPage_showsUnavailableInMarkdownBuild() {
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/console/cognition")
+        .then().statusCode(200)
+        .body(containsString("<h1>Cognition</h1>"))
+        .body(containsString("Not available"));
+  }
+
+  @Test
+  void sharedNav_linksTheManagementPages() {
+    given().auth().preemptive().basic(USER, PASS)
+        .when().get("/console/memory")
+        .then().statusCode(200)
+        .body(containsString("href=\"/console/skills\""))
+        .body(containsString("href=\"/console/cognition\""));
+  }
+}


### PR DESCRIPTION
The management console (M8 Sub-project 3): pages inside the console that drive the existing admin REST surface, so the operator can run the agent's maintenance from the browser instead of curl.

## Hybrid design

- **Memory** and **Skills** render rich read views from the client-side stores (`FactStore`, `EpisodicStore`, `SkillStore`) - the console depends on `client`, so it reads them directly. The **mutating actions** (memory review/curate/purge, skill pin/delete/curate/lifecycle) are driven from the page by HTMX against the existing `/api/admin/*` endpoints, so the console never re-implements the admin logic. The browser is already authenticated to the console (same Basic realm), so the HTMX calls carry the credential automatically.
- **Cognition** (reconcile/migrate) is the decoupled case: it lives in the optional `cognition-pgvector` extension, which the console must not depend on. The page only drives `/api/admin/cognition` over HTTP, and it is gated by the baked composition manifest (`cognition.pgvector`): shown as unavailable in a markdown-only build. This is more accurate than reading `qlawkus.cognition.backend`, whose value can be `pgvector` even when the module was not composed in.

## Shared layout

Introduces a `base.html` Qute layout for the console frame (sidebar + nav), used by the new pages; the sidebar now links Memory, Skills and Cognition (Config and Schedule remain placeholders for #242 and #241).

## Testing

`integration-tests/console` grows to 15 tests (database-free): the three pages render behind auth with the correct action URLs wired, and the cognition page shows "not available" because this markdown-only module does not compose `cognition.pgvector`.

Closes #192
