### PR TITLE
Docs site: restructure the sidebar nav and fix the composition capability list

### DIFF
--- a/docs/modules/ROOT/pages/composition.adoc
+++ b/docs/modules/ROOT/pages/composition.adoc
@@ -194,6 +194,7 @@ Names are namespaced where natural, and several modules may share one name (sele
 |`brag` |Career brag-document tool
 |`skill-hub` |Remote skill-registry client
 |`google-workspace` |The six Google modules (auth, Gmail, Calendar, Drive, Sheets, Storage)
+|`console` |The optional server-rendered admin console (first-run setup wizard and the memory, skills and cognition management pages)
 |===
 
 The core agent (`qlawkus-client`) is the skeleton, always present, so it declares no capability. A capability name in the manifest's `except` list that no module announces fails the build by default (see <<Running the generator>>).

--- a/site/content/composition.adoc
+++ b/site/content/composition.adoc
@@ -194,6 +194,7 @@ Names are namespaced where natural, and several modules may share one name (sele
 |`brag` |Career brag-document tool
 |`skill-hub` |Remote skill-registry client
 |`google-workspace` |The six Google modules (auth, Gmail, Calendar, Drive, Sheets, Storage)
+|`console` |The optional server-rendered admin console (first-run setup wizard and the memory, skills and cognition management pages)
 |===
 
 The core agent (`qlawkus-client`) is the skeleton, always present, so it declares no capability. A capability name in the manifest's `except` list that no module announces fails the build by default (see <<Running the generator>>).

--- a/site/templates/layouts/default.html
+++ b/site/templates/layouts/default.html
@@ -33,23 +33,32 @@
         </span>
       </a>
       <nav class="nav" aria-label="Documentation">
+        <span class="nav-section">Getting started</span>
         <a href="{site.url.resolve('quickstart')}"{#if page.title == 'Quick Start'} aria-current="page"{/if}>Quick Start</a>
         <a href="{site.url.resolve('architecture')}"{#if page.title == 'Architecture'} aria-current="page"{/if}>Architecture</a>
+
+        <span class="nav-section">Memory &amp; skills</span>
         <a href="{site.url.resolve('memory')}"{#if page.title == 'Memory'} aria-current="page"{/if}>Memory</a>
         <a href="{site.url.resolve('storage')}"{#if page.title == 'Storage'} aria-current="page"{/if}>Storage</a>
         <a href="{site.url.resolve('skills')}"{#if page.title == 'Skills'} aria-current="page"{/if}>Skills</a>
-        <a href="{site.url.resolve('google-workspace')}"{#if page.title == 'Google Workspace Setup'} aria-current="page"{/if}>Google Workspace</a>
-        <a href="{site.url.resolve('messaging')}"{#if page.title == 'Messaging Setup'} aria-current="page"{/if}>Messaging</a>
-        <a href="{site.url.resolve('voice')}"{#if page.title == 'Voice Setup'} aria-current="page"{/if}>Voice</a>
+
+        <span class="nav-section">Platform</span>
+        <a href="{site.url.resolve('composition')}"{#if page.title == 'Composition'} aria-current="page"{/if}>Composition</a>
         <a href="{site.url.resolve('secrets')}"{#if page.title == 'Secrets'} aria-current="page"{/if}>Secrets</a>
-        <a href="{site.url.resolve('config-reference')}"{#if page.title == 'Configuration Reference (all modules)'} aria-current="page"{/if}>Configuration</a>
-        <a class="nav-external" href="https://github.com/omatheusmesmo/Qlawkus" target="_blank" rel="noopener">
+
+        <span class="nav-section">Integrations</span>
+        <a href="{site.url.resolve('google-workspace')}"{#if page.title == 'Google Workspace Tools Setup'} aria-current="page"{/if}>Google Workspace</a>
+        <a href="{site.url.resolve('messaging')}"{#if page.title == 'Messaging Setup (Discord & Telegram)'} aria-current="page"{/if}>Messaging</a>
+        <a href="{site.url.resolve('voice')}"{#if page.title == 'Voice Setup (STT / TTS)'} aria-current="page"{/if}>Voice</a>
+
+        <span class="nav-section">Reference</span>
+        <a href="{site.url.resolve('config-reference')}"{#if page.title == 'Configuration Reference'} aria-current="page"{/if}>Configuration</a>
+      </nav>
+      <div class="sidebar-foot">
+        <a class="foot-github" href="https://github.com/omatheusmesmo/Qlawkus" target="_blank" rel="noopener">
           <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
           GitHub
         </a>
-      </nav>
-      <div class="sidebar-foot">
-        <a class="foot-link" href="https://github.com/omatheusmesmo/Qlawkus" target="_blank" rel="noopener">View source on GitHub</a>
         <p class="foot-tag">Build your own agent on Quarkus.</p>
       </div>
     </aside>

--- a/site/web/app.css
+++ b/site/web/app.css
@@ -51,7 +51,7 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 26px;
+  gap: 18px;
 }
 
 .brand {
@@ -76,7 +76,28 @@ body {
   font-weight: 600;
 }
 
-.nav { display: flex; flex-direction: column; gap: 2px; }
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--sidebar-soft) transparent;
+}
+.nav::-webkit-scrollbar { width: 6px; }
+.nav::-webkit-scrollbar-thumb { background: var(--sidebar-soft); border-radius: 3px; }
+.nav-section {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--faint);
+  font-weight: 600;
+  padding: 14px 12px 4px;
+}
+.nav-section:first-child { padding-top: 0; }
 .nav a {
   display: block;
   padding: 8px 12px;
@@ -93,29 +114,24 @@ body {
   color: #fff;
   box-shadow: inset 2px 0 0 var(--accent);
 }
-.nav a.nav-external {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  margin-top: 8px;
-  padding-top: 14px;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
-}
-.nav a.nav-external svg { flex: 0 0 auto; }
-
 .sidebar-foot {
-  margin-top: auto;
+  margin-top: 0;
   font-size: 12.5px;
   color: var(--faint);
   border-top: 1px solid rgba(255, 255, 255, 0.07);
   padding-top: 16px;
 }
-.sidebar-foot .foot-link {
+.foot-github {
+  display: flex;
+  align-items: center;
+  gap: 9px;
   color: #d8d4dd;
   text-decoration: none;
   font-weight: 600;
+  font-size: 13px;
 }
-.sidebar-foot .foot-link:hover { color: #fff; }
+.foot-github:hover { color: #fff; }
+.foot-github svg { flex: 0 0 auto; }
 .sidebar-foot .foot-tag { margin: 8px 0 0; }
 
 /* ---------- Content ---------- */


### PR DESCRIPTION
Consolidated site/docs fixes, rebased on current main.

**Sidebar nav** (`site/web/app.css` + `site/templates/layouts/default.html`):
- The nav is now its own scrollable region (brand pinned on top, footer on the bottom) with a thin scrollbar - on shorter viewports it no longer overflows the 100vh sidebar and gets cut off.
- Grouped into sections: Getting started, Memory & skills, Platform, Integrations, Reference.
- Adds the missing **Composition** page to the nav.
- Fixes several stale `aria-current` title matches (Google Workspace, Messaging, Voice, Configuration) that never matched the real page titles, so the active item highlights again.
- De-duplicates the GitHub link: keeps a single one in the nav (icon + label, inside the scroll); the footer is just the tagline.

**Composition reference** (`site/content/composition.adoc` + Antora mirror):
- Adds the missing `console` capability to the capabilities table.

No content pages beyond composition.adoc are touched. Verified visually by rendering the sidebar at tall and short viewports.