### PR TITLE
List the console capability in the composition reference

### DIFF
--- a/docs/modules/ROOT/pages/composition.adoc
+++ b/docs/modules/ROOT/pages/composition.adoc
@@ -194,6 +194,7 @@ Names are namespaced where natural, and several modules may share one name (sele
 |`brag` |Career brag-document tool
 |`skill-hub` |Remote skill-registry client
 |`google-workspace` |The six Google modules (auth, Gmail, Calendar, Drive, Sheets, Storage)
+|`console` |The optional server-rendered admin console (first-run setup wizard and the memory, skills and cognition management pages)
 |===
 
 The core agent (`qlawkus-client`) is the skeleton, always present, so it declares no capability. A capability name in the manifest's `except` list that no module announces fails the build by default (see <<Running the generator>>).

--- a/site/content/composition.adoc
+++ b/site/content/composition.adoc
@@ -194,6 +194,7 @@ Names are namespaced where natural, and several modules may share one name (sele
 |`brag` |Career brag-document tool
 |`skill-hub` |Remote skill-registry client
 |`google-workspace` |The six Google modules (auth, Gmail, Calendar, Drive, Sheets, Storage)
+|`console` |The optional server-rendered admin console (first-run setup wizard and the memory, skills and cognition management pages)
 |===
 
 The core agent (`qlawkus-client`) is the skeleton, always present, so it declares no capability. A capability name in the manifest's `except` list that no module announces fails the build by default (see <<Running the generator>>).


### PR DESCRIPTION
The composition capabilities table was missing the `console` capability (added with the qlawkus-console extension this cycle), so `agent.yml` could compose the admin console in or out but the reference never mentioned it.

Adds the row in both the site source (`site/content/composition.adoc`) and the Antora mirror. Verified the rest of the page against the code (manifest schema, generator, fail-on-unknown, dev reload, runtime-toggle ordinals, the staging API and the restart contract all match).